### PR TITLE
Test ensemble selection

### DIFF
--- a/tests/modules/octo/test_ensemble_selection.py
+++ b/tests/modules/octo/test_ensemble_selection.py
@@ -216,7 +216,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
 
     # Get individual model performance
     individual_performances = []
-    for model_name, bag in bags.items():
+    for _model_name, bag in bags.items():
         scores = bag.get_performance()
         individual_performances.append(scores["dev_pool"])
 

--- a/tests/modules/octo/test_ensemble_selection_unit.py
+++ b/tests/modules/octo/test_ensemble_selection_unit.py
@@ -242,8 +242,8 @@ def test_ensemble_models_single_bag(tmp_path):
     assert isinstance(scores, dict)
     expected_keys = {"dev_pool", "test_pool"}
     assert expected_keys.issubset(set(scores.keys()))
-    assert isinstance(scores["dev_pool"], (int, float))
-    assert isinstance(scores["test_pool"], (int, float))
+    assert isinstance(scores["dev_pool"], (int | float))
+    assert isinstance(scores["test_pool"], (int | float))
 
 
 # Tests for EnSel._ensemble_scan() method


### PR DESCRIPTION
Simple unit tests for ensemble selection. Integration test for ensemble selection: 
- Creates a controlled synthetic dataset where 3 models use orthogonal feature subsets (features 0-3, 4-7, 8-11)
- Each model captures only 1/3 of the total signal, with target = signal1 + signal2 + signal3 + noise
- Tests that the EnSel ensemble selection algorithm can:
        - Identify that all 3 models contribute complementary information
        - Combine them to achieve significantly better performance than any individual model
        - Find near-optimal ensemble weights through its optimization process
