### PR TITLE
chore: add mypy as dev dependency to allow running mypy also outside the pre-commit hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,10 @@ tabpfn = [
 ]
 dev = [
     "octopus[test]",
+    "octopus[mypy]",
     "nbformat>=5.10", # analysis notebook
     "seaborn>=0.13", # analysis notebook
-    "ipywidgets>=8", # anlysis notebook
+    "ipywidgets>=8", # analysis notebook
 ]
 docs = [
 ]
@@ -86,6 +87,17 @@ lint = [
     "pydoclint==0.7.3", # see DEV TOOLS NOTE
     "pyupgrade==3.21.0", # see DEV TOOLS NOTE
     "ruff==0.14.1", # see DEV TOOLS NOTE
+]
+mypy = [
+    "mypy==1.18.2", # see DEV TOOLS NOTE
+    "joblib-stubs>=1.5.2.0.20250831",
+    "pandas-stubs>=2.3,<3",
+    "plotly-stubs==0.0.6",
+    "scikit-learn-stubs>=0.0.3",
+    "scipy-stubs>=1.16.3.0",
+    "types-networkx>=3.5",
+    "types-pytz>=2025.2.0",
+    "types-jmespath>=1.0.2"
 ]
 test = [
     "pytest>=8.4.2",


### PR DESCRIPTION
Currently, it is impossible to run `mypy` outside the pre-commit hook because it is not being installed as dev-dependency. This also prevents e.g. vscode from using mypy for code checking during development.

This change adds an additional dependency group `octopus[mypy]` (to keep things confined) which is added to `octopus[dev]` as additional dependency.