### PR TITLE
test/predict and analysispipeline, closes #102

### DIFF
--- a/octopus/models/config.py
+++ b/octopus/models/config.py
@@ -44,19 +44,19 @@ type PredType = Literal["predict", "predict_proba"]
 class BaseModel(BaseEstimator):
     """Base model class."""
 
-    def fit(self, X: OctoMatrixLike | OctoArrayLike, y: OctoArrayLike, *args, **kwarfs):
+    def fit(self, X: OctoMatrixLike | OctoArrayLike, y: OctoArrayLike, *args, **kwargs):
         """Fit model."""
         ...
 
-    def predict(self, X: OctoMatrixLike | OctoArrayLike, **kwargs) -> pd.DataFrame:
+    def predict(self, X: OctoMatrixLike | OctoArrayLike, **kwargs) -> np.ndarray:
         """Predict."""
         raise NotImplementedError("predict not implemented for this model.")
 
-    def predict_proba(self, X: OctoMatrixLike | OctoArrayLike, **kwargs) -> pd.DataFrame:
+    def predict_proba(self, X: OctoMatrixLike | OctoArrayLike, **kwargs) -> np.ndarray:
         """Predict probabilities."""
         raise NotImplementedError("predict_proba not implemented for this model.")
 
-    def predict_log_proba(self, X: OctoMatrixLike | OctoArrayLike) -> pd.DataFrame:
+    def predict_log_proba(self, X: OctoMatrixLike | OctoArrayLike) -> np.ndarray:
         """Predict log probabilities."""
         raise NotImplementedError("predict_log_proba not implemented for this model.")
 

--- a/octopus/models/wrapper_models/GaussianProcessClassifier.py
+++ b/octopus/models/wrapper_models/GaussianProcessClassifier.py
@@ -60,7 +60,7 @@ class GPClassifierWrapper(ClassifierMixin, BaseEstimator):
         self.model_.fit(X, y)
         return self
 
-    def predict(self, X: Any) -> Any:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict using the Gaussian Process model."""
         check_is_fitted(self, "model_")
         X = check_array(X)

--- a/octopus/models/wrapper_models/GaussianProcessRegressor.py
+++ b/octopus/models/wrapper_models/GaussianProcessRegressor.py
@@ -5,6 +5,7 @@
 from collections.abc import Callable
 from typing import Any, Literal
 
+import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import RBF, Kernel, Matern, RationalQuadratic
@@ -50,7 +51,7 @@ class GPRegressorWrapper(RegressorMixin, BaseEstimator):
         self.model_.fit(X, y)
         return self
 
-    def predict(self, X: Any) -> Any:
+    def predict(self, X: Any) -> np.ndarray:
         """Predict using the Gaussian Process model."""
         check_is_fitted(self, "model_")
         X = check_array(X)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,356 @@
+"""Tests for octopus/predict.py."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from octopus.config.core import ConfigManager, ConfigStudy, ConfigWorkflow, OctoConfig
+from octopus.experiment import OctoExperiment
+from octopus.modules import Octo
+from octopus.predict import OctoPredict
+from octopus.results import ModuleResults
+
+
+@pytest.fixture
+def sample_data():
+    """Fixture to provide sample data for testing."""
+    np.random.seed(42)
+    data = {
+        "row_id": [f"row_{i}" for i in range(100)],
+        "feature1": np.random.randn(100),
+        "feature2": np.random.randn(100),
+        "feature3": np.random.randn(100),
+        "target": np.random.choice([0, 1], 100),
+    }
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def mock_model():
+    """Fixture to create a mock model that returns predictions based on input size."""
+    model = Mock()
+
+    # Create side_effect functions that return arrays matching input size
+    def predict_side_effect(X):
+        n_samples = len(X)
+        np.random.seed(42)
+        return np.random.choice([0, 1], n_samples)
+
+    def predict_proba_side_effect(X):
+        n_samples = len(X)
+        np.random.seed(42)
+        # Generate random probabilities that sum to 1
+        probs = np.random.rand(n_samples, 2)
+        probs = probs / probs.sum(axis=1, keepdims=True)
+        return probs
+
+    model.predict = Mock(side_effect=predict_side_effect)
+    model.predict_proba = Mock(side_effect=predict_proba_side_effect)
+    return model
+
+
+@pytest.fixture
+def mock_config():
+    """Fixture to create a mock OctoConfig."""
+    config_study = ConfigStudy(
+        name="test_study",
+        ml_type="classification",
+        target_metric="AUCROC",
+        n_folds_outer=3,
+        path="test_path",
+    )
+    config_workflow = ConfigWorkflow(
+        tasks=[
+            Octo(
+                task_id=0,
+                depends_on_task=-1,
+                description="step_1_octo",
+                models=["RandomForestClassifier"],
+                n_trials=1,
+            )
+        ]
+    )
+    return OctoConfig(study=config_study, manager=ConfigManager(), workflow=config_workflow)
+
+
+@pytest.fixture
+def mock_experiment(sample_data, mock_model, mock_config):
+    """Fixture to create a mock OctoExperiment."""
+    experiment = Mock(spec=OctoExperiment)
+    experiment.id = "experiment_0"
+    experiment.experiment_id = 0
+    experiment.task_id = 0
+    experiment.depends_on_task = -1
+    experiment._task_path = Path("experiment0/workflowtask0")
+    experiment.configs = mock_config
+    experiment.datasplit_column = "target"
+    experiment.row_column = "row_id"
+    experiment.feature_columns = ["feature1", "feature2", "feature3"]
+    experiment.target_assignments = {"target": [0, 1]}
+    experiment.data_traindev = sample_data.iloc[:80]
+    experiment.data_test = sample_data.iloc[80:]
+    experiment.feature_groups = {"group0": ["feature1", "feature2"]}
+
+    # Create mock results
+    mock_result = Mock(spec=ModuleResults)
+    mock_result.model = mock_model
+    experiment.results = {"best": mock_result}
+
+    return experiment
+
+
+@pytest.fixture
+def mock_study_path(tmp_path):
+    """Fixture to create a mock study directory structure."""
+    study_path = tmp_path / "test_study"
+    study_path.mkdir()
+
+    # Create config directory
+    config_dir = study_path / "config"
+    config_dir.mkdir()
+
+    # Create experiment directories with pickle files
+    for exp_id in range(3):
+        exp_dir = study_path / f"experiment{exp_id}" / "workflowtask0"
+        exp_dir.mkdir(parents=True)
+
+        # Create a dummy pickle file
+        pkl_file = exp_dir / f"exp{exp_id}_0.pkl"
+        pkl_file.touch()
+
+        # Create results directory
+        results_dir = exp_dir / "results"
+        results_dir.mkdir()
+
+    return study_path
+
+
+@pytest.fixture
+def mock_octo_data(mock_config):
+    """Fixture to create a mock OctoData."""
+    # Return the actual config instead of a mock
+    return mock_config
+
+
+@pytest.fixture
+def predictor_with_experiments(mock_study_path, mock_experiment, mock_octo_data, sample_data, mock_model):
+    """Fixture to create an OctoPredict instance with loaded experiments."""
+    with (
+        patch("octopus.config.core.OctoConfig.from_pickle", return_value=mock_octo_data),
+        patch("octopus.predict.OctoExperiment.from_pickle", return_value=mock_experiment),
+    ):
+        predictor = OctoPredict(study_path=mock_study_path)
+
+        # Manually populate experiments since mocking file system is complex
+        # Using SimpleNamespace for attribute access instead of custom dict class
+        for exp_id in range(3):
+            predictor.experiments[exp_id] = SimpleNamespace(
+                id=exp_id,
+                model=mock_model,
+                data_traindev=sample_data.iloc[:80],
+                data_test=sample_data.iloc[80:],
+                feature_columns=["feature1", "feature2", "feature3"],
+                row_column="row_id",
+                target_assignments={"target": [0, 1]},
+                target_metric="AUCROC",
+                ml_type="classification",
+                feature_group_dict={"group0": ["feature1", "feature2"]},
+                positive_class=1,
+            )
+
+        return predictor
+
+
+class TestOctoPredictInitialization:
+    """Tests for OctoPredict initialization."""
+
+    def test_initialization_with_default_task_id(self, mock_study_path, mock_experiment, mock_octo_data):
+        """Test initialization with default task_id."""
+        with (
+            patch("octopus.config.core.OctoConfig.from_pickle", return_value=mock_octo_data),
+            patch("octopus.predict.OctoExperiment.from_pickle", return_value=mock_experiment),
+        ):
+            predictor = OctoPredict(study_path=mock_study_path)
+
+            assert predictor.study_path == mock_study_path
+            assert predictor.task_id == 0  # Should use last workflow task
+            assert predictor.results_key == "best"
+            assert isinstance(predictor.experiments, dict)
+
+    def test_initialization_with_custom_task_id(self, mock_study_path, mock_experiment, mock_octo_data):
+        """Test initialization with custom task_id."""
+        with (
+            patch("octopus.config.core.OctoConfig.from_pickle", return_value=mock_octo_data),
+            patch("octopus.predict.OctoExperiment.from_pickle", return_value=mock_experiment),
+        ):
+            predictor = OctoPredict(study_path=mock_study_path, task_id=0)
+
+            assert predictor.task_id == 0
+
+    def test_config_property(self, mock_study_path, mock_experiment, mock_octo_data):
+        """Test config property."""
+        with (
+            patch("octopus.config.core.OctoConfig.from_pickle", return_value=mock_octo_data),
+            patch("octopus.predict.OctoExperiment.from_pickle", return_value=mock_experiment),
+        ):
+            predictor = OctoPredict(study_path=mock_study_path)
+
+            assert predictor.config == mock_octo_data
+
+    def test_n_experiments_property(self, mock_study_path, mock_experiment, mock_octo_data):
+        """Test n_experiments property."""
+        with (
+            patch("octopus.config.core.OctoConfig.from_pickle", return_value=mock_octo_data),
+            patch("octopus.predict.OctoExperiment.from_pickle", return_value=mock_experiment),
+        ):
+            predictor = OctoPredict(study_path=mock_study_path)
+
+            assert predictor.n_experiments == 3
+
+
+class TestOctoPredictPredictionMethods:
+    """Tests for OctoPredict prediction methods."""
+
+    def test_predict_return_array(self, predictor_with_experiments, sample_data):
+        """Test predict method returning numpy array."""
+        result = predictor_with_experiments.predict(sample_data.iloc[:5], return_df=False)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape[0] == 5
+
+    def test_predict_return_dataframe(self, predictor_with_experiments, sample_data):
+        """Test predict method returning DataFrame."""
+        result = predictor_with_experiments.predict(sample_data.iloc[:5], return_df=True)
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 5
+        assert "prediction" in result.columns
+
+    def test_predict_missing_features(self, predictor_with_experiments):
+        """Test predict method with missing features."""
+        data = pd.DataFrame({"feature1": [1, 2, 3]})
+
+        with pytest.raises(ValueError, match="Features missing in provided dataset"):
+            predictor_with_experiments.predict(data)
+
+    def test_predict_proba_return_array(self, predictor_with_experiments, sample_data):
+        """Test predict_proba method returning numpy array."""
+        result = predictor_with_experiments.predict_proba(sample_data.iloc[:5], return_df=False)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape[0] == 5
+
+    def test_predict_proba_return_dataframe(self, predictor_with_experiments, sample_data):
+        """Test predict_proba method returning DataFrame."""
+        result = predictor_with_experiments.predict_proba(sample_data.iloc[:5], return_df=True)
+
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) == 5
+
+    def test_predict_test(self, predictor_with_experiments):
+        """Test predict_test method."""
+        result = predictor_with_experiments.predict_test()
+
+        assert isinstance(result, pd.DataFrame)
+        assert "prediction" in result.columns
+        assert "prediction_std" in result.columns
+        assert "n" in result.columns
+        assert len(result) > 0
+
+    def test_predict_proba_test(self, predictor_with_experiments):
+        """Test predict_proba_test method."""
+        result = predictor_with_experiments.predict_proba_test()
+
+        assert isinstance(result, pd.DataFrame)
+        assert "probability" in result.columns
+        assert "probability_std" in result.columns
+        assert "n" in result.columns
+        assert len(result) > 0
+
+
+class TestOctoPredictFeatureImportance:
+    """Tests for OctoPredict feature importance methods."""
+
+    @pytest.fixture
+    def mock_fi_results(self):
+        """Fixture to create mock feature importance results."""
+        return pd.DataFrame(
+            {
+                "feature": ["feature1", "feature2", "feature3"],
+                "importance": [0.5, 0.3, 0.2],
+                "stddev": [0.1, 0.05, 0.03],
+                "p-value": [0.01, 0.05, 0.1],
+                "n": [10, 10, 10],
+                "ci_low_95": [0.4, 0.25, 0.17],
+                "ci_high_95": [0.6, 0.35, 0.23],
+            }
+        )
+
+    def test_calculate_fi_permutation(self, predictor_with_experiments, sample_data, mock_fi_results):
+        """Test calculate_fi with permutation method."""
+        with (
+            patch("octopus.predict.get_fi_permutation", return_value=mock_fi_results),
+            patch("octopus.predict.OctoPredict._plot_permutation_fi"),
+        ):
+            predictor_with_experiments.calculate_fi(sample_data, n_repeat=10, fi_type="permutation")
+
+            assert "fi_table_permutation_ensemble" in predictor_with_experiments.results
+            assert isinstance(predictor_with_experiments.results["fi_table_permutation_ensemble"], pd.DataFrame)
+
+    def test_calculate_fi_invalid_shap_type(self, predictor_with_experiments, sample_data):
+        """Test calculate_fi with invalid shap_type."""
+        with pytest.raises(ValueError, match="Specified shap_type not supported"):
+            predictor_with_experiments.calculate_fi(sample_data, fi_type="shap", shap_type="invalid_shap")
+
+    def test_calculate_fi_test_invalid_shap_type(self, predictor_with_experiments):
+        """Test calculate_fi_test with invalid shap_type."""
+        with pytest.raises(ValueError, match="Specified shap_type not supported"):
+            predictor_with_experiments.calculate_fi_test(fi_type="shap", shap_type="invalid_shap")
+
+
+class TestOctoPredictPlotting:
+    """Tests for OctoPredict plotting methods."""
+
+    def test_plot_permutation_fi(self, predictor_with_experiments, mock_study_path):
+        """Test _plot_permutation_fi method."""
+        df = pd.DataFrame(
+            {
+                "feature": ["feature1", "feature2", "feature3"],
+                "importance": [0.5, 0.3, 0.2],
+                "ci_low_95": [0.4, 0.25, 0.17],
+                "ci_high_95": [0.6, 0.35, 0.23],
+            }
+        )
+
+        with patch("octopus.predict.PdfPages"), patch("octopus.predict.plt"):
+            predictor_with_experiments._plot_permutation_fi(0, df)
+
+            # Check that the results directory would be created
+            expected_path = mock_study_path / "experiment0" / "workflowtask0" / "results"
+            assert expected_path.exists()
+
+    def test_plot_shap_fi(self, predictor_with_experiments, mock_study_path):
+        """Test _plot_shap_fi method."""
+        df = pd.DataFrame(
+            {
+                "feature": ["feature1", "feature2", "feature3"],
+                "importance": [0.5, 0.3, 0.2],
+            }
+        )
+        shap_values = np.random.randn(100, 3)
+        data = pd.DataFrame(np.random.randn(100, 3), columns=["feature1", "feature2", "feature3"])
+
+        with (
+            patch("octopus.predict.PdfPages"),
+            patch("octopus.predict.shap.summary_plot"),
+            patch("octopus.predict.plt"),
+        ):
+            predictor_with_experiments._plot_shap_fi(0, df, shap_values, data)
+
+            # Check that the results directory would be created
+            expected_path = mock_study_path / "experiment0" / "workflowtask0" / "results"
+            assert expected_path.exists()

--- a/tests/workflows/test_analysispipeline.py
+++ b/tests/workflows/test_analysispipeline.py
@@ -1,0 +1,570 @@
+"""Test analysis pipeline for OctoPredict functionality."""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.metrics import auc, roc_curve
+
+from octopus import OctoData, OctoML
+from octopus.config import ConfigManager, ConfigStudy, ConfigWorkflow
+from octopus.metrics.utils import get_performance_from_model
+from octopus.modules import Octo
+from octopus.predict import OctoPredict
+
+
+@pytest.fixture(scope="session")
+def classification_dataset():
+    """Create synthetic binary classification dataset for testing."""
+    # Create a highly separable dataset with 100 samples
+    X, y = make_classification(
+        n_samples=100,
+        n_features=4,
+        n_informative=4,
+        n_redundant=0,
+        n_repeated=0,
+        n_classes=2,
+        n_clusters_per_class=1,  # Single cluster per class for maximum separation
+        weights=[0.5, 0.5],
+        flip_y=0.0,  # No label noise
+        class_sep=10.0,  # Maximum class separation
+        random_state=42,
+        shuffle=True,
+    )
+
+    feature_names = [f"feature_{i}" for i in range(4)]
+    df = pd.DataFrame(X, columns=feature_names)
+    df["target"] = y
+    df = df.reset_index()
+
+    return df, feature_names
+
+
+@pytest.fixture(scope="session")
+def trained_study(classification_dataset, tmp_path_factory):
+    """Create and train a minimal study for testing analysis pipeline."""
+    df, features = classification_dataset
+
+    temp_dir = tmp_path_factory.mktemp("test_data")
+
+    # Create OctoData
+    octo_data = OctoData(
+        data=df,
+        target_columns=["target"],
+        feature_columns=features,
+        sample_id="index",
+        datasplit_type="sample",
+        stratification_column="target",
+    )
+
+    # Create minimal study configuration
+    config_study = ConfigStudy(
+        name="test_analysis_pipeline",
+        ml_type="classification",
+        target_metric="ACCBAL",
+        metrics=["AUCROC", "ACCBAL", "ACC", "F1", "AUCPR"],
+        datasplit_seed_outer=1234,
+        n_folds_outer=5,
+        start_with_empty_study=True,
+        path=temp_dir,
+        silently_overwrite_study=True,
+        ignore_data_health_warning=True,
+        positive_class=1,
+    )
+
+    config_manager = ConfigManager(
+        outer_parallelization=False,
+        run_single_experiment_num=0,  # Run only experiment 0
+    )
+
+    # Create minimal workflow
+    config_workflow = ConfigWorkflow(
+        [
+            Octo(
+                description="step_1_octo",
+                task_id=0,
+                depends_on_task=-1,
+                n_folds_inner=5,
+                models=["ExtraTreesClassifier"],
+                model_seed=0,
+                n_jobs=1,
+                n_trials=20,
+                fi_methods_bestbag=["permutation"],
+                max_features=4,
+            )
+        ]
+    )
+
+    # Run the study
+    octo_ml = OctoML(
+        octo_data,
+        config_study=config_study,
+        config_manager=config_manager,
+        config_workflow=config_workflow,
+    )
+    octo_ml.run_study()
+
+    study_path = Path(temp_dir) / "test_analysis_pipeline"
+    yield study_path
+
+
+class TestAnalysisPipeline:
+    """Test suite for analysis pipeline using OctoPredict."""
+
+    @pytest.mark.slow
+    def test_octopredict_initialization(self, trained_study):
+        """Test OctoPredict initialization with trained study."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Verify initialization
+        assert task_item.study_path == trained_study
+        assert task_item.task_id == 0
+        assert task_item.results_key == "best"
+        assert len(task_item.experiments) > 0
+
+        # Verify experiments structure
+        for _exp_id, experiment in task_item.experiments.items():
+            assert hasattr(experiment, "model")
+            assert hasattr(experiment, "data_test")
+            assert hasattr(experiment, "feature_columns")
+            assert hasattr(experiment, "target_assignments")
+
+    @pytest.mark.slow
+    def test_predict_on_test_data(self, trained_study):
+        """Test prediction on test data."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Test predict_test method
+        predictions = task_item.predict_test()
+
+        assert isinstance(predictions, pd.DataFrame)
+        assert "prediction" in predictions.columns
+        assert "prediction_std" in predictions.columns
+        assert "n" in predictions.columns
+        assert len(predictions) > 0
+
+    @pytest.mark.slow
+    def test_predict_proba_on_test_data(self, trained_study):
+        """Test probability prediction on test data."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Test predict_proba_test method
+        probabilities = task_item.predict_proba_test()
+
+        assert isinstance(probabilities, pd.DataFrame)
+        assert "probability" in probabilities.columns
+        assert "probability_std" in probabilities.columns
+        assert "n" in probabilities.columns
+        assert len(probabilities) > 0
+
+        # Verify probabilities are in valid range [0, 1]
+        assert (probabilities["probability"] >= 0).all()
+        assert (probabilities["probability"] <= 1).all()
+
+    @pytest.mark.slow
+    def test_performance_metrics_calculation(self, trained_study):
+        """Test calculation of performance metrics on test data."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        metrics = ["AUCROC", "ACCBAL", "ACC", "F1", "AUCPR"]
+
+        for _exp_id, experiment in task_item.experiments.items():
+            for metric in metrics:
+                performance = get_performance_from_model(
+                    experiment.model,
+                    experiment.data_test,
+                    experiment.feature_columns,
+                    metric,
+                    experiment.target_assignments,
+                    positive_class=1,
+                )
+
+                # Verify performance is a valid number
+                assert isinstance(performance, (int, float))
+                assert not np.isnan(performance)
+
+                # Verify performance is in reasonable range
+                if metric in ["AUCROC", "ACCBAL", "ACC", "F1", "AUCPR"]:
+                    assert 0 <= performance <= 1
+
+    @pytest.mark.slow
+    def test_roc_curve_calculation(self, trained_study):
+        """Test ROC curve calculation for classification."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Collect predictions from all experiments
+        res_lst = []
+        for _key, experiment in task_item.experiments.items():
+            data_test = experiment.data_test
+            feature_columns = experiment.feature_columns
+            row_column = experiment.row_column
+            target_col = list(experiment.target_assignments.values())[0]
+
+            df = pd.DataFrame()
+            df["row_id"] = data_test[row_column]
+            df["prediction"] = experiment.model.predict(data_test[feature_columns])
+
+            pred = experiment.model.predict_proba(data_test[feature_columns])
+            if isinstance(pred, pd.DataFrame):
+                df["probabilities"] = pred[1]
+            elif isinstance(pred, np.ndarray):
+                df["probabilities"] = pred[:, 1]
+
+            df["target"] = data_test[target_col]
+            res_lst.append(df)
+
+        res_df = pd.concat(res_lst, axis=0)
+
+        # Compute ROC curve and AUC
+        fpr, tpr, _thresholds = roc_curve(res_df["target"], res_df["probabilities"], drop_intermediate=True)
+        auc_roc = auc(fpr, tpr)
+
+        # Verify ROC metrics
+        assert isinstance(fpr, np.ndarray)
+        assert isinstance(tpr, np.ndarray)
+        assert 0 <= auc_roc <= 1
+        assert len(fpr) == len(tpr)
+
+    @pytest.mark.slow
+    def test_feature_importance_permutation(self, trained_study):
+        """Test permutation feature importance calculation."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Calculate permutation feature importance with reduced repeats for speed
+        task_item.calculate_fi_test(
+            fi_type="group_permutation",
+            n_repeat=2,
+            experiment_id=0,
+        )
+
+        # Verify results are stored
+        assert len(task_item.results) > 0
+
+        # Check for permutation FI results
+        pfi_keys = [key for key in task_item.results if "permutation" in key]
+        assert len(pfi_keys) > 0
+
+        # Verify FI dataframe structure
+        for key in pfi_keys:
+            fi_df = task_item.results[key]
+            assert isinstance(fi_df, pd.DataFrame)
+            assert "feature" in fi_df.columns
+            assert "importance" in fi_df.columns
+            assert len(fi_df) > 0
+
+    @pytest.mark.slow
+    @pytest.mark.expensive
+    def test_feature_importance_shap(self, trained_study):
+        """Test SHAP feature importance calculation."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Calculate SHAP feature importance with kernel explainer
+        task_item.calculate_fi_test(
+            fi_type="shap",
+            shap_type="kernel",
+            experiment_id=0,
+        )
+
+        # Verify results are stored
+        shap_keys = [key for key in task_item.results if "shap" in key]
+        assert len(shap_keys) > 0
+
+        # Verify SHAP FI dataframe structure
+        for key in shap_keys:
+            fi_df = task_item.results[key]
+            assert isinstance(fi_df, pd.DataFrame)
+            assert "feature" in fi_df.columns
+            assert "importance" in fi_df.columns
+            assert len(fi_df) > 0
+
+    @pytest.mark.slow
+    def test_experiment_info_attributes(self, trained_study):
+        """Test that ExperimentInfo objects have correct attributes."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        for _exp_id, experiment in task_item.experiments.items():
+            # Verify all required attributes exist
+            assert hasattr(experiment, "id")
+            assert hasattr(experiment, "model")
+            assert hasattr(experiment, "data_traindev")
+            assert hasattr(experiment, "data_test")
+            assert hasattr(experiment, "feature_columns")
+            assert hasattr(experiment, "row_column")
+            assert hasattr(experiment, "target_assignments")
+            assert hasattr(experiment, "target_metric")
+            assert hasattr(experiment, "ml_type")
+            assert hasattr(experiment, "feature_group_dict")
+            assert hasattr(experiment, "positive_class")
+
+            # Verify attribute types
+            assert isinstance(experiment.id, int)
+            assert isinstance(experiment.data_test, pd.DataFrame)
+            assert isinstance(experiment.feature_columns, list)
+            assert isinstance(experiment.target_assignments, dict)
+            assert experiment.ml_type == "classification"
+
+    @pytest.mark.slow
+    def test_config_property(self, trained_study):
+        """Test config property of OctoPredict."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        config = task_item.config
+
+        # Verify config structure
+        assert hasattr(config, "study")
+        assert hasattr(config, "workflow")
+        assert config.study.ml_type == "classification"
+        assert config.study.target_metric == "ACCBAL"
+
+    @pytest.mark.slow
+    def test_n_experiments_property(self, trained_study):
+        """Test n_experiments property."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        n_experiments = task_item.n_experiments
+
+        assert isinstance(n_experiments, int)
+        assert n_experiments > 0
+        # n_experiments returns the configured n_folds_outer (5 in this case)
+        assert n_experiments == 5
+        # With run_single_experiment_num=0, only 1 experiment is actually run
+        assert len(task_item.experiments) == 1
+
+    @pytest.mark.slow
+    def test_predict_on_new_data(self, trained_study, classification_dataset):
+        """Test prediction on new data."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        df, features = classification_dataset
+
+        # Create new data (subset of original)
+        new_data = df[features].head(10)
+
+        # Test predict with return_df=False (returns numpy array)
+        predictions_array = task_item.predict(new_data, return_df=False)
+        assert isinstance(predictions_array, np.ndarray)
+        assert len(predictions_array) == 10
+
+        # Test predict with return_df=True (returns DataFrame)
+        predictions_df = task_item.predict(new_data, return_df=True)
+        assert isinstance(predictions_df, pd.DataFrame)
+        assert len(predictions_df) == 10
+
+    @pytest.mark.slow
+    def test_predict_proba_on_new_data(self, trained_study, classification_dataset):
+        """Test probability prediction on new data."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        df, features = classification_dataset
+        new_data = df[features].head(10)
+
+        # Test predict_proba with return_df=False
+        proba_array = task_item.predict_proba(new_data, return_df=False)
+        assert isinstance(proba_array, np.ndarray)
+        assert len(proba_array) == 10
+
+        # Test predict_proba with return_df=True
+        proba_df = task_item.predict_proba(new_data, return_df=True)
+        assert isinstance(proba_df, pd.DataFrame)
+        assert len(proba_df) == 10
+
+    @pytest.mark.slow
+    def test_invalid_results_key(self, trained_study):
+        """Test that invalid results_key raises appropriate error."""
+        with pytest.raises(ValueError, match="Specified results key not found"):
+            OctoPredict(
+                study_path=trained_study,
+                task_id=0,
+                results_key="invalid_key",
+            )
+
+    @pytest.mark.slow
+    def test_feature_importance_results_structure(self, trained_study):
+        """Test that feature importance results have correct structure."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        # Calculate FI
+        task_item.calculate_fi_test(
+            fi_type="group_permutation",
+            n_repeat=5,
+            experiment_id=0,
+        )
+
+        # Get FI results
+        fi_key = "fi_table_group_permutation_exp0"
+        assert fi_key in task_item.results
+
+        fi_df = task_item.results[fi_key]
+
+        # Verify required columns
+        required_columns = ["feature", "importance", "ci_low_95", "ci_high_95"]
+        for col in required_columns:
+            assert col in fi_df.columns
+
+        # Verify data types
+        assert fi_df["importance"].dtype in [np.float64, np.float32]
+        assert all(fi_df["importance"] >= 0)
+
+    @pytest.mark.slow
+    def test_predict_return_formats(self, trained_study, classification_dataset):
+        """Test predict and predict_proba with different return formats."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        df, features = classification_dataset
+        new_data = df[features].head(10)
+
+        # Test predict with return_df=True
+        result_df = task_item.predict(new_data, return_df=True)
+        assert isinstance(result_df, pd.DataFrame)
+        assert len(result_df) == 10
+        assert "prediction" in result_df.columns
+
+        # Test predict with return_df=False
+        result_array = task_item.predict(new_data, return_df=False)
+        assert isinstance(result_array, np.ndarray)
+        assert len(result_array) == 10
+
+        # Test predict_proba with return_df=True
+        proba_df = task_item.predict_proba(new_data, return_df=True)
+        assert isinstance(proba_df, pd.DataFrame)
+        assert len(proba_df) == 10
+        assert proba_df.columns.nlevels == 2
+
+        # Test predict_proba with return_df=False
+        proba_array = task_item.predict_proba(new_data, return_df=False)
+        assert isinstance(proba_array, np.ndarray)
+        assert len(proba_array) == 10
+        assert proba_array.shape[1] >= 1
+
+    @pytest.mark.slow
+    def test_calculate_fi_permutation(self, trained_study, classification_dataset):
+        """Test calculate_fi with fi_type='permutation'."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        df, features = classification_dataset
+        # Include target column for calculate_fi
+        new_data = df[[*features, "target"]].head(50)
+
+        # Calculate permutation feature importance on new data with reduced repeats
+        task_item.calculate_fi(
+            data=new_data,
+            n_repeat=2,
+            fi_type="permutation",
+        )
+
+        # Verify results are stored for each experiment
+        perm_keys = [key for key in task_item.results if "permutation" in key and "exp" in key]
+        assert len(perm_keys) > 0
+
+        # Verify structure of results
+        for key in perm_keys:
+            fi_df = task_item.results[key]
+            assert isinstance(fi_df, pd.DataFrame)
+            assert "feature" in fi_df.columns
+            assert "importance" in fi_df.columns
+            assert "ci_low_95" in fi_df.columns
+            assert "ci_high_95" in fi_df.columns
+            assert len(fi_df) == len(features)
+
+        # Verify ensemble results also exist
+        assert "fi_table_permutation_ensemble" in task_item.results
+
+    @pytest.mark.slow
+    @pytest.mark.expensive
+    def test_calculate_fi_shap_kernel(self, trained_study, classification_dataset):
+        """Test calculate_fi with fi_type='shap' and shap_type='kernel'."""
+        task_item = OctoPredict(
+            study_path=trained_study,
+            task_id=0,
+            results_key="best",
+        )
+
+        df, features = classification_dataset
+        # Include target column for calculate_fi
+        new_data = df[[*features, "target"]].head(20)  # Use smaller sample for SHAP
+
+        # Calculate SHAP feature importance on new data
+        task_item.calculate_fi(
+            data=new_data,
+            fi_type="shap",
+            shap_type="kernel",
+        )
+
+        # Verify results are stored for each experiment
+        shap_keys = [key for key in task_item.results if "shap" in key and "exp" in key]
+        assert len(shap_keys) > 0
+
+        # Verify structure of results
+        for key in shap_keys:
+            fi_df = task_item.results[key]
+            assert isinstance(fi_df, pd.DataFrame)
+            assert "feature" in fi_df.columns
+            assert "importance" in fi_df.columns
+            assert len(fi_df) == len(features)
+            # SHAP importances should be non-negative after abs()
+            assert all(fi_df["importance"] >= 0)
+
+        # Verify ensemble results also exist
+        assert "fi_table_shap_ensemble" in task_item.results

--- a/typos.toml
+++ b/typos.toml
@@ -2,3 +2,5 @@
 strat = "strat"
 TPE = "TPE"
 TPESampler = "TPESampler"
+fpr = "fpr"
+tpr = "tpr"


### PR DESCRIPTION
Added tests for the predict class and the current analysis pipeline. The purpose of those tests is make sure that all on-going refactoring efforts don't break the analysis pipeline and to highlight secondary effects.