### PR TITLE
Store `octopus_manager.log` inside the study directory, fixes #201

### DIFF
--- a/octopus/manager/core.py
+++ b/octopus/manager/core.py
@@ -27,6 +27,9 @@ class OctoManager:
     workflow: list[Task] = field(
         validator=[validators.instance_of(list)],
     )
+    log_dir: UPath = field(
+        validator=[validators.instance_of(UPath)],
+    )
     outer_parallelization: bool = field(
         default=True,
         validator=[validators.instance_of(bool)],
@@ -133,6 +136,7 @@ class OctoManager:
             base_experiments=self.base_experiments,
             create_execute_mlmodules=create_execute_mlmodules_fn,
             num_workers=self.num_outer_workers,
+            log_dir=self.log_dir,
         )
         return results
 
@@ -254,7 +258,7 @@ class OctoManager:
 
     def _get_ml_module(self, experiment):
         if experiment.ml_module in modules_inventory:
-            return modules_inventory[experiment.ml_module](experiment)
+            return modules_inventory[experiment.ml_module](experiment, log_dir=self.log_dir)
         else:
             raise ValueError(f"ml_module {experiment.ml_module} not supported")
 

--- a/octopus/modules/autogluon/core.py
+++ b/octopus/modules/autogluon/core.py
@@ -109,6 +109,7 @@ class AGCore:
     """Autogluon."""
 
     experiment: "OctoExperiment[AutoGluon]" = field(validator=[validators.instance_of(OctoExperiment)])
+    log_dir: UPath = field(validator=[validators.instance_of(UPath)])
     model = field(init=False)
     num_cpus = field(init=False)  # TODO: this is also in the AutoGluon class
 

--- a/octopus/modules/octo/bag.py
+++ b/octopus/modules/octo/bag.py
@@ -121,6 +121,7 @@ class BagBase(BaseEstimator):
     target_assignments: dict = field(validator=[validators.instance_of(dict)])
     row_column: str = field(validator=[validators.instance_of(str)])
     ml_type: str = field(validator=[validators.instance_of(str)])
+    log_dir: UPath = field(validator=[validators.instance_of(UPath)])
     train_status: bool = field(default=False)
 
     # bag training outputs, initialized in post_init
@@ -265,7 +266,7 @@ class BagBase(BaseEstimator):
             TrainingWithLogging(t, idx, logger, LogGroup, log_prefix="EXP") for idx, t in enumerate(self.trainings)
         ]
         # Orchestrate with Ray; exceptions propagate only if your wrapper re-raises.
-        results = run_parallel_inner(wrapped)
+        results = run_parallel_inner(wrapped, log_dir=self.log_dir)
         self.trainings = results
 
     def _train_sequential(self):
@@ -426,7 +427,7 @@ class BagBase(BaseEstimator):
 
         # Execute feature importance calculations in parallel
         # Use the same pattern as training execution
-        results = run_parallel_inner(wrapped, num_cpus=1)
+        results = run_parallel_inner(wrapped, log_dir=self.log_dir, num_cpus=1)
 
         # Update trainings with results (should be the same objects with FI calculated)
         self.trainings = results

--- a/octopus/modules/octo/core.py
+++ b/octopus/modules/octo/core.py
@@ -43,6 +43,7 @@ class OctoCoreGeneric[TaskConfigType: Octo]:
     Attributes:
         experiment (OctoExperiment): Configuration and data container
             for the experiment.
+        log_dir (UPath): Directory for individual worker logs
         data_splits (dict): Stores training and validation data splits.
         paths_optuna_db (dict): Stores file paths to Optuna databases
             for each experiment.
@@ -62,6 +63,8 @@ class OctoCoreGeneric[TaskConfigType: Octo]:
     """
 
     experiment: OctoExperiment[TaskConfigType] = field(validator=[validators.instance_of(OctoExperiment)])
+
+    log_dir: UPath = field(validator=[validators.instance_of(UPath)])
     # model = field(default=None)
     data_splits: dict = field(default=Factory(dict), validator=[validators.instance_of(dict)])
 
@@ -221,6 +224,7 @@ class OctoCoreGeneric[TaskConfigType: Octo]:
             target_metric=self.experiment.target_metric,
             row_column=self.experiment.row_column,
             ml_type=self.experiment.ml_type,
+            log_dir=self.log_dir,
         )
         # save ensel bag
         ensel_bag.to_pickle(self.path_results / "ensel_bag.pkl")
@@ -277,6 +281,7 @@ class OctoCoreGeneric[TaskConfigType: Octo]:
             study_name=study_name,
             top_trials=self.top_trials,
             mrmr_features=self.mrmr_features,
+            log_dir=self.log_dir,
         )
 
         # multivariate sampler with group option
@@ -391,6 +396,7 @@ class OctoCoreGeneric[TaskConfigType: Octo]:
             target_metric=self.experiment.target_metric,
             row_column=self.experiment.row_column,
             ml_type=self.experiment.ml_type,
+            log_dir=self.log_dir,
             # path?
         )
 

--- a/octopus/modules/octo/objective_optuna.py
+++ b/octopus/modules/octo/objective_optuna.py
@@ -2,6 +2,8 @@
 
 import heapq
 
+from upath import UPath
+
 from octopus.experiment import OctoExperiment
 from octopus.logger import LogGroup, get_logger
 from octopus.metrics import metrics_inventory
@@ -25,6 +27,7 @@ class ObjectiveOptuna:
         study_name,
         top_trials,
         mrmr_features,
+        log_dir: UPath,
     ):
         self.experiment = experiment
         self.data_splits = data_splits
@@ -46,6 +49,7 @@ class ObjectiveOptuna:
         # training parameters
         self.parallel_execution = self.experiment.ml_config.inner_parallelization
         self.num_workers = self.experiment.ml_config.n_workers
+        self.log_dir = log_dir
 
     def __call__(self, trial):
         """Call.
@@ -131,6 +135,7 @@ class ObjectiveOptuna:
             target_metric=self.experiment.target_metric,
             row_column=self.experiment.row_column,
             ml_type=self.experiment.ml_type,
+            log_dir=self.log_dir,
             # path?
         )
 

--- a/octopus/modules/roc/core.py
+++ b/octopus/modules/roc/core.py
@@ -51,7 +51,7 @@ class RocCore:
     """Roc Module."""
 
     experiment: OctoExperiment[Roc] = field(validator=[validators.instance_of(OctoExperiment)])
-
+    log_dir: UPath = field(validator=[validators.instance_of(UPath)])
     feature_groups: list = field(init=False, validator=[validators.instance_of(list)])
 
     @property

--- a/tests/infrastructure/test_fsspec.py
+++ b/tests/infrastructure/test_fsspec.py
@@ -1,4 +1,6 @@
 import os
+import stat
+import tempfile
 
 import pandas as pd
 import pytest
@@ -128,65 +130,81 @@ class TestFSSpecIntegration:
         """
         df, features = breast_cancer_dataset
 
-        study = OctoStudy(
-            name="test_octo_intro_execution",
-            ml_type="classification",
-            target_metric="ACCBAL",
-            feature_columns=features,
-            target_columns=["target"],
-            sample_id="index",
-            stratification_column="target",
-            metrics=["AUCROC", "ACCBAL", "ACC", "LOGLOSS"],
-            datasplit_seed_outer=1234,
-            n_folds_outer=2,
-            path=root_dir,
-            ignore_data_health_warning=True,
-            outer_parallelization=False,
-            run_single_experiment_num=0,
-            workflow=[
-                Octo(
-                    description="step_1_octo",
-                    task_id=0,
-                    depends_on_task=-1,
-                    load_task=False,
-                    n_folds_inner=3,
-                    models=["ExtraTreesClassifier"],
-                    model_seed=0,
-                    n_jobs=1,
-                    max_outl=0,
-                    fi_methods_bestbag=["permutation"],
-                    inner_parallelization=True,
-                    n_workers=2,
-                    optuna_seed=0,
-                    n_optuna_startup_trials=3,
-                    resume_optimization=False,
-                    n_trials=5,
-                    max_features=5,
-                    penalty_factor=1.0,
-                    ensemble_selection=True,
-                    ensel_n_save_trials=5,
+        with tempfile.TemporaryDirectory(delete=True) as tmpdir:
+            old_dir = os.getcwd()
+            os.chdir(tmpdir)
+            # Disable all read/write access to the temp dir to ensure that
+            # all file IO goes through fsspec and the specified root_dir.
+            # Execute permission is needed to enter the dir.
+            os.chmod(tmpdir, mode=stat.S_IXUSR | stat.S_IRUSR)
+
+            try:
+                study = OctoStudy(
+                    name="test_octo_intro_execution",
+                    ml_type="classification",
+                    target_metric="ACCBAL",
+                    feature_columns=features,
+                    target_columns=["target"],
+                    sample_id="index",
+                    stratification_column="target",
+                    metrics=["AUCROC", "ACCBAL", "ACC", "LOGLOSS"],
+                    datasplit_seed_outer=1234,
+                    n_folds_outer=2,
+                    path=root_dir,
+                    ignore_data_health_warning=True,
+                    outer_parallelization=False,
+                    run_single_experiment_num=0,
+                    workflow=[
+                        Octo(
+                            description="step_1_octo",
+                            task_id=0,
+                            depends_on_task=-1,
+                            load_task=False,
+                            n_folds_inner=3,
+                            models=["ExtraTreesClassifier"],
+                            model_seed=0,
+                            n_jobs=1,
+                            max_outl=0,
+                            fi_methods_bestbag=["permutation"],
+                            inner_parallelization=True,
+                            n_workers=2,
+                            optuna_seed=0,
+                            n_optuna_startup_trials=3,
+                            resume_optimization=False,
+                            n_trials=5,
+                            max_features=5,
+                            penalty_factor=1.0,
+                            ensemble_selection=True,
+                            ensel_n_save_trials=5,
+                        )
+                    ],
                 )
-            ],
-        )
 
-        study.fit(data=df)
+                study.fit(data=df)
 
-        study_path = root_dir / study.name
+                study_path = root_dir / study.name
 
-        # Verify that the study was created and files exist
-        assert study_path.exists(), "Study directory should be created"
+                # Verify that the study was created and files exist
+                assert study_path.exists(), "Study directory should be created"
 
-        # Check for expected files (new architecture uses files, not directories)
-        assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
-        assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"
+                assert (study_path / "octo_manager.log").exists(), "Octo Manager log file should exist"
 
-        assert (study_path / "config.json").exists(), "Config JSON file should exist"
-        assert (study_path / "outersplit0").exists(), "Experiment directory should exist"
+                # Check for expected files (new architecture uses files, not directories)
+                assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
+                assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"
 
-        # Verify that the Octo step was executed by checking for workflow directories
-        experiment_path = study_path / "outersplit0"
-        workflow_dirs = [d for d in experiment_path.iterdir() if d.is_dir() and d.name.startswith("workflowtask")]
+                assert (study_path / "config.json").exists(), "Config JSON file should exist"
+                assert (study_path / "outersplit0").exists(), "Experiment directory should exist"
 
-        assert len(workflow_dirs) >= 1, (
-            f"Should have at least 1 workflow directory, found: {[d.name for d in workflow_dirs]}"
-        )
+                # Verify that the Octo step was executed by checking for workflow directories
+                experiment_path = study_path / "outersplit0"
+                workflow_dirs = [
+                    d for d in experiment_path.iterdir() if d.is_dir() and d.name.startswith("workflowtask")
+                ]
+
+                assert len(workflow_dirs) >= 1, (
+                    f"Should have at least 1 workflow directory, found: {[d.name for d in workflow_dirs]}"
+                )
+
+            finally:
+                os.chdir(old_dir)

--- a/tests/manager/test_manager.py
+++ b/tests/manager/test_manager.py
@@ -51,6 +51,7 @@ def octo_manager(mock_workflow, mock_experiment):
         workflow=mock_workflow,
         outer_parallelization=False,
         run_single_experiment_num=-1,
+        log_dir=mock_experiment.path_study,
     )
 
 

--- a/tests/modules/octo/test_ensemble_selection_unit.py
+++ b/tests/modules/octo/test_ensemble_selection_unit.py
@@ -1,5 +1,7 @@
 """Unit tests for EnSel (Ensemble Selection) individual methods."""
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import LinearRegression
@@ -76,7 +78,7 @@ def create_mock_training(training_id, performance_dev, performance_test, n_sampl
     return training
 
 
-def create_mock_bag(bag_id, target_dev_mae, target_test_mae, n_trainings=3, exact_performance=False):
+def create_mock_bag(log_dir, bag_id, target_dev_mae, target_test_mae, n_trainings=3, exact_performance=False):
     """Create a mock Bag with controlled performance."""
     trainings = []
     for i in range(n_trainings):
@@ -101,6 +103,7 @@ def create_mock_bag(bag_id, target_dev_mae, target_test_mae, n_trainings=3, exac
         ml_type="regression",
         parallel_execution=False,
         num_workers=1,
+        log_dir=log_dir,
     )
 
     bag.train_status = True
@@ -108,7 +111,7 @@ def create_mock_bag(bag_id, target_dev_mae, target_test_mae, n_trainings=3, exac
 
 
 def create_mock_trial_directory(
-    tmp_path: UPath, bag_performances: list[tuple[str, float, float]], exact_performance: bool = False
+    tmp_path: Path, bag_performances: list[tuple[str, float, float]], exact_performance: bool = False
 ) -> UPath:
     """Create directory with mock trial bags.
 
@@ -120,11 +123,11 @@ def create_mock_trial_directory(
     Returns:
         Path to trials directory
     """
-    trials_path = tmp_path / "trials"
+    trials_path = UPath(tmp_path / "trials")
     trials_path.mkdir()
 
     for i, (bag_id, dev_mae, test_mae) in enumerate(bag_performances):
-        bag = create_mock_bag(bag_id, dev_mae, test_mae, exact_performance=exact_performance)
+        bag = create_mock_bag(trials_path, bag_id, dev_mae, test_mae, exact_performance=exact_performance)
         bag_file = trials_path / f"trial{i}_bag.pkl"
         bag.to_pickle(bag_file)
 

--- a/tests/workflows/test_octo_classification.py
+++ b/tests/workflows/test_octo_classification.py
@@ -236,6 +236,8 @@ class TestOctoIntroClassification:
             study_path = Path(temp_dir) / "test_octo_intro_execution"
             assert study_path.exists(), "Study directory should be created"
 
+            assert (study_path / "octo_manager.log").exists(), "Octo Manager log file should exist"
+
             # Check for expected files (new architecture uses files, not directories)
             assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"

--- a/tests/workflows/test_octo_multiclass.py
+++ b/tests/workflows/test_octo_multiclass.py
@@ -246,6 +246,8 @@ class TestOctoMulticlass:
             study_path = Path(temp_dir) / "test_multiclass_execution"
             assert study_path.exists(), "Study directory should be created"
 
+            assert (study_path / "octo_manager.log").exists(), "Octo Manager log file should exist"
+
             # Check for expected files (new architecture uses files, not directories)
             assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"

--- a/tests/workflows/test_octo_regression.py
+++ b/tests/workflows/test_octo_regression.py
@@ -241,6 +241,8 @@ class TestOctoRegression:
             study_path = Path(temp_dir) / "test_octo_regression_execution"
             assert study_path.exists(), "Study directory should be created"
 
+            assert (study_path / "octo_manager.log").exists(), "Octo Manager log file should exist"
+
             # Check for expected files (new architecture uses files, not directories)
             assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"

--- a/tests/workflows/test_octo_t2e.py
+++ b/tests/workflows/test_octo_t2e.py
@@ -221,6 +221,8 @@ class TestOctoTimeToEvent:
             study_path = Path(temp_dir) / "test_octo_t2e_execution"
             assert study_path.exists(), "Study directory should be created"
 
+            assert (study_path / "octo_manager.log").exists(), "Octo Manager log file should exist"
+
             # Check for expected files (new architecture uses files, not directories)
             assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"

--- a/tests/workflows/test_roc_octo_roc_workflow.py
+++ b/tests/workflows/test_roc_octo_roc_workflow.py
@@ -330,6 +330,8 @@ class TestRocOctoRocWorkflow:
             study_path = Path(temp_dir) / "test_roc_octo_roc_execution"
             assert study_path.exists(), "Study directory should be created"
 
+            assert (study_path / "octo_manager.log").exists(), "Octo Manager log file should exist"
+
             # Check for expected files (new architecture uses files, not directories)
             assert (study_path / "data.parquet").exists(), "Data parquet file should exist"
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"


### PR DESCRIPTION
While definitely containing study-specific data/information, the `octo_manager.log` file was stored inside the current working directory. This is problematic in two ways:
* It is not being saved with the study, i.e. warnings / error messages might get lost when archiving the study
* If the current working directory is not writeable, Octopus just crashes (see #201).

This PR builds upon #177 and should not be merged before that one.

It ensures that `octo_manager.log` goes through `fsspec` (see #177 for details) and moves the file into the study directory. To this end, all relevant classes / functions are getting a `log_dir` parameter. This will allow for moving the log to a different place if needed (e.g. in case we want to create one log file per ray worker, etc.).

Also, the fsspec test has been extended to run from a write-protected directory to immediately fail in case we accidentally introduce writing more files to local storage.