### PR TITLE
Fix: make results df creation agnostic to keys of FI computation method

### DIFF
--- a/octopus/modules/octo/bag.py
+++ b/octopus/modules/octo/bag.py
@@ -616,11 +616,7 @@ class BagBase(BaseEstimator):
                 by="importance", ascending=False
             ).reset_index(drop=True)
 
-        # Return only training-level feature importances (keys like "0_0_0")
-        training_fi = {}
-        for training in self.trainings:
-            training_fi[training.training_id] = training.feature_importances
-        return training_fi
+        return self.feature_importances
 
     def predict(self, x):
         """Predict with sklearn compatibility."""

--- a/octopus/results.py
+++ b/octopus/results.py
@@ -86,14 +86,13 @@ class ModuleResults:
         df_feature_importance = pd.DataFrame()
 
         for key, value in self.feature_importances.items():
-            _, _, split_id = key.split("_")
             for fi_type, df in value.items():
                 if fi_type in ["internal", "permutation_dev"]:
                     temp_df = df.copy()
                     temp_df["fi_type"] = fi_type
                     temp_df["experiment_id"] = self.experiment_id
                     temp_df["task_id"] = self.task_id
-                    temp_df["split_id"] = split_id
+                    temp_df["training_id"] = key
 
                     df_feature_importance = pd.concat([df_feature_importance, temp_df], ignore_index=True)
         return df_feature_importance


### PR DESCRIPTION
Fixes #199.

**Problem**: TabFN example crashed with
```
Traceback (most recent call last):
  File "/Users/m342104/projects/octopus/examples/basic_classification_tabpfn.py", line 48, in <module>
    study.fit(data=df)
  File "/Users/m342104/projects/octopus/octopus/study/core.py", line 354, in fit
    manager.run_outer_experiments()
  File "/Users/m342104/projects/octopus/octopus/manager/core.py", line 65, in run_outer_experiments
    self._run_single_experiment(single_exp)
  File "/Users/m342104/projects/octopus/octopus/manager/core.py", line 106, in _run_single_experiment
    self.create_execute_mlmodules(self.base_experiments[exp_num])
  File "/Users/m342104/projects/octopus/octopus/manager/core.py", line 164, in create_execute_mlmodules
    self._run_and_save_experiment(experiment, path_study_workflow, path_save)
  File "/Users/m342104/projects/octopus/octopus/manager/core.py", line 242, in _run_and_save_experiment
    experiment.results[key].create_feature_importance_df().to_parquet(
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/m342104/projects/octopus/octopus/results.py", line 89, in create_feature_importance_df
    _, _, split_id = key.split("_")
    ^^^^^^^^^^^^^^
ValueError: not enough values to unpack (expected 3, got 2)
```
The error occurred in `results.py:89` when trying to create feature importance dataframes. The issue was caused by `calculate_fi_*` functions in `octopus/modules/octo/training.py` returning dictionaries with keys with varying number of underscores and the `create_feature_importance_df()` method in `results.py` expected all keys to have precisely two underscores.

**Solution**
Modified `results.py` to be agnostic to the keys in the dictionary. Now, keys are not splitted anymore before being added to the dataframe, but the entire key is added.

**Note**
Unit tests that test the different `calculate_fi_*` functions in `octopus/modules/octo/training.py` will follow in a separate PR.