### PR TITLE
Refactor: Simplify Models Module Architecture, closes #191, #182

### DIFF
--- a/tests/models/test_hyperparameter.py
+++ b/tests/models/test_hyperparameter.py
@@ -12,7 +12,7 @@ from octopus.models.hyperparameter import (
     FloatHyperparameter,
     IntHyperparameter,
 )
-from octopus.models.inventory import ModelInventory
+from octopus.models import Models
 
 
 @pytest.mark.parametrize(
@@ -132,7 +132,7 @@ def test_step_takes_priority_over_log():
 def test_create_trial_parameters():
     """Test create_trial_parameters uses suggest methods."""
     mock_trial = create_mock_trial()
-    inventory = ModelInventory()
+    # Models uses classmethods, no instantiation needed
 
     hyperparameters = [
         IntHyperparameter(name="int_param", low=1, high=10),
@@ -149,7 +149,7 @@ def test_create_trial_parameters():
         model_seed="random_state",
     )
 
-    result = inventory.create_trial_parameters(
+    result = Models.create_trial_parameters(
         trial=mock_trial, model_item=model_config, hyperparameters=hyperparameters, n_jobs=2, model_seed=123
     )
 

--- a/tests/modules/octo/test_classes_attribute.py
+++ b/tests/modules/octo/test_classes_attribute.py
@@ -10,22 +10,21 @@ from octopus.models.hyperparameter import (
     FloatHyperparameter,
     IntHyperparameter,
 )
-from octopus.models.inventory import ModelInventory
+from octopus.models import Models
 from octopus.modules.octo.training import Training
 
 
 def get_classification_models():
-    """Get all classification models dynamically from ModelInventory."""
-    inventory = ModelInventory()
+    """Get all classification models dynamically from Models registry."""
     models = []
 
     # Models to exclude (TabPFN models require downloading which can fail in CI)
     excluded_models = {"TabPFNClassifier"}
 
-    # Get all models from the inventory
-    for model_name in inventory.models:
+    # Get all models from the registry
+    for model_name in Models._config_factories.keys():
         try:
-            config = inventory.get_model_config(model_name)
+            config = Models.get_model_config(model_name)
             if config.ml_type == "classification" and model_name not in excluded_models:
                 models.append(model_name)
         except Exception:
@@ -37,8 +36,8 @@ def get_classification_models():
 
 def get_default_params(model_name):
     """Get default parameters for a model."""
-    inventory = ModelInventory()
-    config = inventory.get_model_config(model_name)
+    # Models uses classmethods, no instantiation needed
+    config = Models.get_model_config(model_name)
     params = {}
 
     for hp in config.hyperparameters:

--- a/tests/modules/test_training_feature_importances.py
+++ b/tests/modules/test_training_feature_importances.py
@@ -33,7 +33,7 @@ from octopus.models.hyperparameter import (
     FloatHyperparameter,
     IntHyperparameter,
 )
-from octopus.models.inventory import ModelInventory
+from octopus.models import Models
 from octopus.modules.octo.training import Training
 
 # ============================================================================
@@ -67,15 +67,15 @@ class ModelCache:
         self._tabpfn_skip_logged = False
 
     def get_available_models_by_type(self):
-        """Get all available models dynamically from ModelInventory, grouped by ML type.
+        """Get all available models dynamically from Models registry, grouped by ML type.
 
         Excludes TabPFN models as they may have dependency issues.
         """
         if self._cached_models_by_type is not None:
             return self._cached_models_by_type
 
-        inventory = ModelInventory()
-        all_models = inventory.models
+        # Get all models from the registry
+        all_models = Models._config_factories.keys()
 
         models_by_type = {"classification": [], "regression": [], "timetoevent": [], "multiclass": []}
         skipped_tabpfn_models = []
@@ -87,7 +87,7 @@ class ModelCache:
                 continue
 
             try:
-                model_config = inventory.get_model_config(model_name)
+                model_config = Models.get_model_config(model_name)
                 ml_type = model_config.ml_type
                 if ml_type in models_by_type:
                     models_by_type[ml_type].append(model_name)
@@ -143,8 +143,8 @@ def get_model_configs():
 
 def get_default_model_params(model_name: str) -> dict:
     """Get default parameters for a model from its hyperparameter configuration."""
-    inventory = ModelInventory()
-    model_config = inventory.get_model_config(model_name)
+    # Models uses classmethods, no instantiation needed
+    model_config = Models.get_model_config(model_name)
 
     params = {}
 


### PR DESCRIPTION
## Overview

This PR simplifies the `octopus.models` module by replacing the two-class design (`ModelRegistry` + `ModelInventory`) with a single `Models` class that uses function-based model definitions. 

## Architectural Changes

### Before: Two-Class Design

```python
# Registry handles registration
class ModelRegistry:
    _models: dict[str, type] = {}

    @classmethod
    def register(cls, name):
        # Registers wrapper classes
        ...

    @classmethod
    def get_all_models(cls):
        return cls._models

# Inventory handles configuration and instantiation
class ModelInventory:
    def __init__(self):
        self.models = ModelRegistry.get_all_models()

    def get_model_config(self, name):
        # Builds ModelConfig from wrapper class
        ...

    def get_model_instance(self, name, params):
        ...

    def create_trial_parameters(self, trial, model_item, ...):
        ...

# Model definitions as wrapper classes
@ModelRegistry.register("ExtraTreesClassifier")
class ExtraTreesClassifierModel:
    @staticmethod
    def get_model_config():
        return ModelConfig(
            name="ExtraTreesClassifier",  # Redundant
            model_class=ExtraTreesClassifier,
            ...
        )
```

### After: Single-Class Design

```python
# Single Models class combines registry + inventory
class Models:
    _config_factories: ClassVar[dict[str, Callable[[], ModelConfig]]] = {}
    _model_configs: ClassVar[dict[str, ModelConfig]] = {}

    @classmethod
    def register(cls, name):
        # Registers factory functions
        ...

    @classmethod
    def get_model_config(cls, name):
        # Lazy-loads from factory
        ...

    @classmethod
    def get_model_instance(cls, name, params):
        ...

    @classmethod
    def create_trial_parameters(cls, trial, model_item, ...):
        ...

# Model definitions as simple functions
@Models.register("ExtraTreesClassifier")
def extra_trees_classifier() -> ModelConfig:
    """ExtraTrees classification model config."""
    return ModelConfig(
        model_class=ExtraTreesClassifier,  # Name set by decorator
        ml_type="classification",
        ...
    )
```

### Old API
```python
from octopus.models.inventory import ModelInventory

# Instantiate inventory
inventory = ModelInventory()

# Get model configuration
config = inventory.get_model_config("ExtraTreesClassifier")

# Create Optuna parameters
params = inventory.create_trial_parameters(
    trial, model_item, hyperparameters, n_jobs, seed
)

# Instantiate model
model = inventory.get_model_instance("ExtraTreesClassifier", params)

# Get feature method
method = inventory.get_feature_method("ExtraTreesClassifier")
```

### New API
```python
from octopus.models import Models

# No instantiation needed - all classmethods

# Get model configuration
config = Models.get_model_config("ExtraTreesClassifier")

# Create Optuna parameters
params = Models.create_trial_parameters(
    trial, model_item, hyperparameters, n_jobs, seed
)

# Instantiate model
model = Models.get_model_instance("ExtraTreesClassifier", params)

# Get feature method
method = Models.get_feature_method("ExtraTreesClassifier")
```

## Files Changed

### Core Changes

#### New Files
- **`octopus/models/core.py`** (new, 183 lines)
  - Contains the unified `Models` class
  - Replaces both `registry.py` and `inventory.py`

#### Deleted Files
- **`octopus/models/registry.py`** (deleted)
- **`octopus/models/inventory.py`** (deleted)

#### Modified Model Definition Files
- **`octopus/models/*_models.py`**
  - Converted 10 wrapper classes to functions
  - Removed: `ModelRegistry` import, `__all__` export
  - Added: `Models` import, function-based definitions

## Preliminary Cleanups

As part of this refactoring, two preliminary cleanups were performed:

- Removed `get_model_by_name()` (alias to `get_model_config()`)
- Removed Redundant `name` Parameter

## TODO:
- remove `name` parameter
- fix string based `MLType` definition to enum
- rename some functions