### PR TITLE
feat: add octopus CLI command for interactive examples

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,1 +1,0 @@
-"""Initialize."""

--- a/octopus/cli.py
+++ b/octopus/cli.py
@@ -1,0 +1,104 @@
+"""CLI entry point for Octopus."""
+
+import argparse
+import os
+import subprocess
+import sys
+from itertools import chain
+from pathlib import Path
+
+
+def _get_example_files(path: Path):
+    try:
+        return [file.relative_to(path) for file in chain.from_iterable([path.glob("*.py"), path.glob("*.ipynb")])]
+    except FileNotFoundError as e:
+        raise RuntimeError("Examples directory not found.") from e
+
+
+EXAMPLES_DIR = Path(__file__).parent.parent.absolute() / "examples"
+EXAMPLES_FILES = _get_example_files(EXAMPLES_DIR)
+
+
+def run_jupyter_notebook(target: Path):
+    """Run a Jupyter notebook server for the specified target path."""
+    # Jupyter has no proper notion of the current working directory.
+    # Thus we inject a proper default location for the studies directory.
+    env = os.environ | {"STUDIES_PATH": str(Path.cwd() / "studies")}
+
+    try:
+        subprocess.run([sys.executable, "-m", "jupyter", "notebook", str(target)], env=env, check=True)
+    except subprocess.CalledProcessError as e:
+        print(
+            "Failed to open Jupyter notebook. "
+            "Please ensure Jupyter is installed (e.g. 'pip install jupyter') and "
+            "that the 'jupyter' command is available on your PATH.\n"
+            f"Underlying error: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(e.returncode or 1)
+
+
+def open_all_examples_in_jupyter():
+    """Open the examples directory in a Jupyter notebook server."""
+    run_jupyter_notebook(EXAMPLES_DIR)
+
+
+def open_example_in_jupyter(which: str):
+    """Open a specific example in a Jupyter notebook server."""
+    try:
+        example_number = int(which)
+    except ValueError:
+        example_path = EXAMPLES_DIR / which
+    else:
+        if 0 <= example_number < len(EXAMPLES_FILES):
+            example_path = EXAMPLES_DIR / EXAMPLES_FILES[example_number]
+        else:
+            print(f"Example number {example_number} is out of range.")
+            return
+
+    if example_path.is_file():
+        run_jupyter_notebook(example_path)
+    else:
+        print(f"Example file {example_path} does not exist.")
+
+
+def list_examples():
+    """List all example files in the examples directory."""
+    print("Available example scripts/notebooks:")
+    for ifile, file in enumerate(EXAMPLES_FILES):
+        print(f"\t({ifile:2d}) - {file}")
+
+
+def cli_main(argv=None):
+    """Main cli function."""
+    parser = argparse.ArgumentParser(prog="octopus", description="Octopus CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    examples_parser = subparsers.add_parser("examples", help="Interact with example notebooks/scripts")
+    examples_parser.add_argument(
+        "target",
+        nargs="?",
+        default=None,
+        help="Example index or filename. Omit to open the examples directory.",
+    )
+    examples_parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available examples",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "examples":
+        if args.list:
+            list_examples()
+        elif args.target:
+            open_example_in_jupyter(args.target)
+        else:
+            open_all_examples_in_jupyter()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ Documentation = "https://emdgroup.github.io/octopus/"
 Changelog = "https://github.com/emdgroup/octopus/releases"
 GitHub = "https://github.com/emdgroup/octopus/"
 Issues = "https://github.com/emdgroup/octopus/issues/"
+
 # DEV TOOLS NOTE: The versions of all dev tools should be consistent everywhere
 # (pre-commit, environment.yml, requirements.txt, pyproject.toml, ...)
 # AUDIT NOTE: The marked packages are secondary dependencies but their versions are
@@ -130,6 +131,9 @@ test = [
     "fastparquet>=2024.11.0",
 ]
 
+[project.scripts]
+octopus = "octopus.cli:cli_main"
+
 [build-system]
 requires = [
     "setuptools>=80.9",
@@ -139,8 +143,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 version_scheme = 'post-release'
 local_scheme = "dirty-tag"
-[tool.setuptools]
-packages = ["octopus"]
+
+[tool.setuptools.package-dir]
+"octopus" = "octopus"
+"octopus.examples" = "examples"
 
 [tool.uv]
 # licensecheck depends indirectly on attrs<24 but we need attrs>=25.3.0

--- a/uv.lock
+++ b/uv.lock
@@ -3202,11 +3202,11 @@ numpy = [
 
 [[package]]
 name = "packaging"
-version = "25.0"
+version = "26.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
original PR before history rewrite: #197 

Note that we switched from Marimo to Jupyter in the meantime, so this PR is for Jupyter notebooks now.

Current functionality:
- `octopus examples --list` lists available examples.
- `octopus examples <number|filename>` opens that example in Jupyter.
- `octopus examples` opens Jupyter on the examples directory.
- Falls back to help output for other commands.

This leaves the opportunity to extend CLI capabilities at a later time (if needed).