### PR TITLE
Fix: make results df creation agnostic to keys of FI computation method

### DIFF
--- a/octopus/modules/octo/bag.py
+++ b/octopus/modules/octo/bag.py
@@ -617,11 +617,7 @@ class BagBase(BaseEstimator):
                 by="importance", ascending=False
             ).reset_index(drop=True)
 
-        # Return only training-level feature importances (keys like "0_0_0")
-        training_fi = {}
-        for training in self.trainings:
-            training_fi[training.training_id] = training.feature_importances
-        return training_fi
+        return self.feature_importances
 
     def predict(self, x):
         """Predict with sklearn compatibility."""

--- a/octopus/results.py
+++ b/octopus/results.py
@@ -86,14 +86,13 @@ class ModuleResults:
         df_feature_importance = pd.DataFrame()
 
         for key, value in self.feature_importances.items():
-            _, _, split_id = key.split("_")
             for fi_type, df in value.items():
                 if fi_type in ["internal", "permutation_dev"]:
                     temp_df = df.copy()
                     temp_df["fi_type"] = fi_type
                     temp_df["experiment_id"] = self.experiment_id
                     temp_df["task_id"] = self.task_id
-                    temp_df["split_id"] = split_id
+                    temp_df["training_id"] = key
 
                     df_feature_importance = pd.concat([df_feature_importance, temp_df], ignore_index=True)
         return df_feature_importance


### PR DESCRIPTION
original PR before history rewrite: #212 