### PR TITLE
fixes #244: reduce module core duplication

### DIFF
--- a/octopus/modules/base.py
+++ b/octopus/modules/base.py
@@ -1,0 +1,196 @@
+"""Base core class with shared functionality for all module cores."""
+
+import pandas as pd
+from attrs import define, field, validators
+from upath import UPath
+
+from octopus.experiment import OctoExperiment
+from octopus.task import Task
+
+
+@define
+class ModuleBaseCore[TaskConfigType: Task]:
+    """Base class for module cores providing common functionality.
+
+    Provides shared properties and initialization logic for all module cores:
+    - Path management (path_module, path_results)
+    - Data access properties (x_traindev, y_traindev, x_test, y_test, etc.)
+    - Experiment metadata (feature_columns, target_metric, ml_type, etc.)
+    - Directory initialization and cleanup
+
+    Type Parameters:
+        TaskConfigType: The module configuration type (must be a Task subclass)
+
+    Attributes:
+        experiment: The OctoExperiment instance containing configuration and data
+    """
+
+    experiment: OctoExperiment[TaskConfigType] = field(validator=[validators.instance_of(OctoExperiment)])
+
+    @property
+    def path_module(self) -> UPath:
+        """Module directory path.
+
+        Returns:
+            Path to module results directory: {study_path}/{task_path}
+        """
+        return self.experiment.path_study / self.experiment.task_path
+
+    @property
+    def path_results(self) -> UPath:
+        """Results directory path within module.
+
+        Returns:
+            Path to results directory: {path_module}/results
+        """
+        return self.path_module / "results"
+
+    @property
+    def data_traindev(self) -> pd.DataFrame:
+        """Training and development dataset.
+
+        Returns:
+            Full training/development dataset from experiment
+        """
+        return self.experiment.data_traindev
+
+    @property
+    def data_test(self) -> pd.DataFrame:
+        """Test dataset.
+
+        Returns:
+            Full test dataset from experiment
+        """
+        return self.experiment.data_test
+
+    @property
+    def x_traindev(self) -> pd.DataFrame:
+        """Feature matrix for training/development set.
+
+        Returns:
+            Subset of data_traindev containing only feature columns
+        """
+        return self.experiment.data_traindev[self.experiment.feature_columns]
+
+    @property
+    def y_traindev(self) -> pd.DataFrame:
+        """Target values for training/development set.
+
+        Returns:
+            Subset of data_traindev containing only target columns
+        """
+        return self.experiment.data_traindev[self.experiment.target_assignments.values()]
+
+    @property
+    def x_test(self) -> pd.DataFrame:
+        """Feature matrix for test set.
+
+        Returns:
+            Subset of data_test containing only feature columns
+        """
+        return self.experiment.data_test[self.experiment.feature_columns]
+
+    @property
+    def y_test(self) -> pd.DataFrame:
+        """Target values for test set.
+
+        Returns:
+            Subset of data_test containing only target columns
+        """
+        return self.experiment.data_test[self.experiment.target_assignments.values()]
+
+    @property
+    def feature_columns(self) -> list[str]:
+        """Feature column names.
+
+        Returns:
+            List of feature column names used in the experiment
+        """
+        return self.experiment.feature_columns
+
+    @property
+    def target_assignments(self) -> dict:
+        """Target column assignments.
+
+        Returns:
+            Dictionary mapping target names to column names
+        """
+        return self.experiment.target_assignments
+
+    @property
+    def target_metric(self) -> str:
+        """Primary target metric for optimization.
+
+        Returns:
+            Name of the metric to optimize for
+        """
+        return self.experiment.target_metric
+
+    @property
+    def ml_type(self) -> str:
+        """Machine learning problem type.
+
+        Returns:
+            One of: "classification", "regression", "timetoevent"
+        """
+        return self.experiment.ml_type
+
+    @property
+    def config(self) -> TaskConfigType:
+        """Module-specific configuration.
+
+        Returns:
+            The ml_config from experiment (typed as TaskConfigType)
+        """
+        return self.experiment.ml_config
+
+    @property
+    def metrics(self) -> list[str]:
+        """All metrics to track during execution.
+
+        Returns:
+            List of metric names to calculate
+        """
+        return self.experiment.metrics
+
+    @property
+    def stratification_column(self) -> str | None:
+        """Column to use for stratified splitting.
+
+        Returns:
+            Column name for stratification, or None if not stratified
+        """
+        return self.experiment.stratification_column
+
+    @property
+    def row_column(self) -> str:
+        """Row identifier column name.
+
+        Returns:
+            Name of the column containing row identifiers
+        """
+        return self.experiment.row_column
+
+    def __attrs_post_init__(self) -> None:
+        """Post-initialization hook to prepare results directory.
+
+        Called automatically after attrs initialization. Resets the results
+        directory to ensure a clean state for module execution.
+
+        Can be overridden by subclasses that need custom initialization.
+        Subclasses should call super().__attrs_post_init__() if they want
+        the ModuleBaseCore default directory setup behavior.
+        """
+        self._reset_results_dir()
+
+    def _reset_results_dir(self) -> None:
+        """Reset and recreate the results directory.
+
+        Deletes existing results directory if present and creates a fresh one.
+        This ensures a clean state for each module run and prevents stale files
+        from previous runs interfering with new results.
+        """
+        for directory in [self.path_results]:
+            if directory.exists():
+                directory.rmdir(recursive=True)
+            directory.mkdir(parents=True, exist_ok=True)

--- a/octopus/modules/boruta/core.py
+++ b/octopus/modules/boruta/core.py
@@ -8,14 +8,13 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from attrs import define, field, validators
+from attrs import define
 from sklearn.model_selection import GridSearchCV, StratifiedKFold, cross_val_score
-from upath import UPath
 
-from octopus.experiment import OctoExperiment
 from octopus.metrics.inventory import MetricsInventory
 from octopus.metrics.utils import get_score_from_model
 from octopus.models.inventory import ModelInventory
+from octopus.modules.base import ModuleBaseCore
 from octopus.modules.boruta.module import Boruta
 from octopus.results import ModuleResults
 
@@ -61,79 +60,8 @@ def get_param_grid(model_type):
 
 
 @define
-class BorutaCore:
+class BorutaCore(ModuleBaseCore[Boruta]):
     """Boruta Module."""
-
-    experiment: OctoExperiment[Boruta] = field(validator=[validators.instance_of(OctoExperiment)])
-
-    @property
-    def path_module(self) -> UPath:
-        """Module path."""
-        return self.experiment.path_study / self.experiment.task_path
-
-    @property
-    def path_results(self) -> UPath:
-        """Results path."""
-        return self.path_module / "results"
-
-    @property
-    def x_traindev(self) -> pd.DataFrame:
-        """x_train."""
-        return self.experiment.data_traindev[self.experiment.feature_columns]
-
-    @property
-    def y_traindev(self) -> pd.DataFrame:
-        """y_train."""
-        return self.experiment.data_traindev[self.experiment.target_assignments.values()]
-
-    @property
-    def data_test(self) -> pd.DataFrame:
-        """data_test."""
-        return self.experiment.data_test
-
-    @property
-    def x_test(self) -> pd.DataFrame:
-        """x_test."""
-        return self.experiment.data_test[self.experiment.feature_columns]
-
-    @property
-    def y_test(self) -> pd.DataFrame:
-        """y_test."""
-        return self.experiment.data_test[self.experiment.target_assignments.values()]
-
-    @property
-    def target_assignments(self) -> dict:
-        """Target assignments."""
-        return self.experiment.target_assignments
-
-    @property
-    def target_metric(self) -> str:
-        """Target metric."""
-        return self.experiment.target_metric
-
-    @property
-    def config(self) -> Boruta:
-        """Module configuration."""
-        return self.experiment.ml_config
-
-    @property
-    def feature_columns(self) -> list[str]:
-        """Feature Columns."""
-        return self.experiment.feature_columns
-
-    @property
-    def stratification_column(self) -> str | None:
-        """Stratification Column."""
-        return self.experiment.stratification_column
-
-    def __attrs_post_init__(self):
-        # delete directories /trials /optuna /results to ensure clean state
-        # of module when restarted
-        # create directory if it does not exist
-        for directory in [self.path_results]:
-            if directory.exists():
-                directory.rmdir(recursive=True)
-            directory.mkdir(parents=True, exist_ok=True)
 
     def run_experiment(self):
         """Run Boruta module on experiment."""

--- a/octopus/modules/mrmr/core.py
+++ b/octopus/modules/mrmr/core.py
@@ -17,8 +17,8 @@ from attrs import define, field, validators
 from sklearn.feature_selection import f_classif, f_regression
 from upath import UPath
 
-from octopus.experiment import OctoExperiment
 from octopus.logger import LogGroup, get_logger
+from octopus.modules.base import ModuleBaseCore
 from octopus.modules.mrmr.module import Mrmr
 from octopus.modules.utils import rdc_correlation_matrix
 
@@ -26,36 +26,13 @@ logger = get_logger()
 
 
 @define
-class MrmrCore:
-    """MRMR module."""
+class MrmrCore(ModuleBaseCore[Mrmr]):
+    """MRMR module for feature selection based on mutual information and redundancy.
 
-    experiment: OctoExperiment[Mrmr] = field(validator=[validators.instance_of(OctoExperiment)])
+    Inherits common properties from BaseCore.
+    """
+
     log_dir: UPath = field(validator=[validators.instance_of(UPath)])
-
-    @property
-    def data_traindev(self) -> pd.DataFrame:
-        """data_traindev."""
-        return self.experiment.data_traindev
-
-    @property
-    def x_traindev(self) -> pd.DataFrame:
-        """x_traindev."""
-        return self.experiment.data_traindev[self.experiment.feature_columns]
-
-    @property
-    def y_traindev(self) -> pd.DataFrame:
-        """y_traindev."""
-        return self.experiment.data_traindev[self.experiment.target_assignments.values()]
-
-    @property
-    def feature_columns(self) -> list:
-        """feature_columns."""
-        return self.experiment.feature_columns
-
-    @property
-    def ml_type(self) -> str:
-        """ML type."""
-        return self.experiment.ml_type
 
     @property
     def correlation_type(self) -> Literal["pearson", "spearman", "rdc"]:
@@ -90,6 +67,8 @@ class MrmrCore:
         return f"{'internal' if fi_method == 'internal' else fi_method + '_dev'}_{fi_type}"
 
     def __attrs_post_init__(self):
+        """Initialize and validate MRMR configuration."""
+        super().__attrs_post_init__()  # Create/clean results directory
         logger.set_log_group(LogGroup.PROCESSING, "MRMR")
         self._validate_configuration()
 

--- a/octopus/modules/rfe/core.py
+++ b/octopus/modules/rfe/core.py
@@ -6,15 +6,14 @@ import copy
 import json
 
 import pandas as pd
-from attrs import define, field, validators
+from attrs import define
 from sklearn.feature_selection import RFECV
 from sklearn.model_selection import GridSearchCV, StratifiedKFold
-from upath import UPath
 
-from octopus.experiment import OctoExperiment
 from octopus.metrics.inventory import MetricsInventory
 from octopus.metrics.utils import get_score_from_model
 from octopus.models.inventory import ModelInventory
+from octopus.modules.base import ModuleBaseCore
 from octopus.modules.rfe.module import Rfe
 from octopus.results import ModuleResults
 
@@ -105,79 +104,8 @@ def get_param_grid(model_type):
 
 
 @define
-class RfeCore:
+class RfeCore(ModuleBaseCore[Rfe]):
     """RFE Module."""
-
-    experiment: OctoExperiment[Rfe] = field(validator=[validators.instance_of(OctoExperiment)])
-
-    @property
-    def path_module(self) -> UPath:
-        """Module path."""
-        return self.experiment.path_study / self.experiment.task_path
-
-    @property
-    def path_results(self) -> UPath:
-        """Results path."""
-        return self.path_module / "results"
-
-    @property
-    def x_traindev(self) -> pd.DataFrame:
-        """x_train."""
-        return self.experiment.data_traindev[self.experiment.feature_columns]
-
-    @property
-    def y_traindev(self) -> pd.DataFrame:
-        """y_train."""
-        return self.experiment.data_traindev[self.experiment.target_assignments.values()]
-
-    @property
-    def x_test(self) -> pd.DataFrame:
-        """x_test."""
-        return self.experiment.data_test[self.experiment.feature_columns]
-
-    @property
-    def y_test(self) -> pd.DataFrame:
-        """y_test."""
-        return self.experiment.data_test[self.experiment.target_assignments.values()]
-
-    @property
-    def data_test(self) -> pd.DataFrame:
-        """data_test."""
-        return self.experiment.data_test
-
-    @property
-    def target_assignments(self) -> dict:
-        """Target assignments."""
-        return self.experiment.target_assignments
-
-    @property
-    def target_metric(self) -> str:
-        """Target metric."""
-        return self.experiment.target_metric
-
-    @property
-    def config(self) -> Rfe:
-        """Module configuration."""
-        return self.experiment.ml_config
-
-    @property
-    def feature_columns(self) -> list[str]:
-        """Feature Columns."""
-        return self.experiment.feature_columns
-
-    @property
-    def stratification_column(self) -> str | None:
-        """Stratification Column."""
-        return self.experiment.stratification_column
-
-    def __attrs_post_init__(self):
-        # delete directories /trials /optuna /results to ensure clean state
-        # of module when restarted
-        # create directory if it does not exist
-        for directory in [self.path_results]:
-            if directory.exists():
-                directory.rmdir(recursive=True)
-            directory.mkdir(parents=True, exist_ok=True)
 
     def run_experiment(self):
         """Run RFE module on experiment."""

--- a/octopus/modules/sfs/core.py
+++ b/octopus/modules/sfs/core.py
@@ -7,14 +7,13 @@ import json
 import warnings
 
 import pandas as pd
-from attrs import define, field, validators
+from attrs import define
 from sklearn.model_selection import BaseCrossValidator, GridSearchCV, StratifiedKFold
-from upath import UPath
 
-from octopus.experiment import OctoExperiment
 from octopus.metrics.inventory import MetricsInventory
 from octopus.metrics.utils import get_score_from_model
 from octopus.models.inventory import ModelInventory
+from octopus.modules.base import ModuleBaseCore
 from octopus.modules.sfs.module import Sfs
 from octopus.results import ModuleResults
 
@@ -75,74 +74,8 @@ def get_param_grid(model_type):
 
 
 @define
-class SfsCore:
+class SfsCore(ModuleBaseCore[Sfs]):
     """SFS Module."""
-
-    experiment: OctoExperiment[Sfs] = field(validator=[validators.instance_of(OctoExperiment)])
-
-    @property
-    def path_module(self) -> UPath:
-        """Module path."""
-        return self.experiment.path_study / self.experiment.task_path
-
-    @property
-    def path_results(self) -> UPath:
-        """Results path."""
-        return self.path_module / "results"
-
-    @property
-    def x_traindev(self) -> pd.DataFrame:
-        """x_train."""
-        return self.experiment.data_traindev[self.experiment.feature_columns]
-
-    @property
-    def y_traindev(self) -> pd.DataFrame:
-        """y_train."""
-        return self.experiment.data_traindev[self.experiment.target_assignments.values()]
-
-    @property
-    def data_test(self) -> pd.DataFrame:
-        """data_test."""
-        return self.experiment.data_test
-
-    @property
-    def x_test(self) -> pd.DataFrame:
-        """x_test."""
-        return self.experiment.data_test[self.experiment.feature_columns]
-
-    @property
-    def y_test(self) -> pd.DataFrame:
-        """y_test."""
-        return self.experiment.data_test[self.experiment.target_assignments.values()]
-
-    @property
-    def target_assignments(self) -> dict:
-        """Target assignments."""
-        return self.experiment.target_assignments
-
-    @property
-    def target_metric(self) -> str:
-        """Target metric."""
-        return self.experiment.target_metric
-
-    @property
-    def config(self) -> Sfs:
-        """Module configuration."""
-        return self.experiment.ml_config
-
-    @property
-    def stratification_column(self) -> str | None:
-        """Stratification Column."""
-        return self.experiment.stratification_column
-
-    def __attrs_post_init__(self):
-        # delete directories /trials /optuna /results to ensure clean state
-        # of module when restarted
-        # create directory if it does not exist
-        for directory in [self.path_results]:
-            if directory.exists():
-                directory.rmdir(recursive=True)
-            directory.mkdir(parents=True, exist_ok=True)
 
     def run_experiment(self):
         """Run SFS module on experiment."""


### PR DESCRIPTION
## Summary
- add a shared `BaseCore` with common experiment accessors and results setup
- update module core classes to inherit the shared base
- align Octo core post-init handling with the shared base