### PR TITLE
Fix double execution of workflow

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,12 @@
 name: Pre-commit Checks
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
This PR fixes the triggers for the `pre-commit` workflow. It should now run
- when code is pushed to `main` (i.e., when a PR is merged)
- when a PR targets `main`

This should avoid the double execution in the PR