### PR TITLE
Refactor study output folder logic, fixes #174

### DIFF
--- a/octopus/study/core.py
+++ b/octopus/study/core.py
@@ -1,11 +1,11 @@
 """Octo Study."""
 
+import datetime
 import json
 import os
 import platform
-import sys
 from abc import ABC, abstractmethod
-from datetime import UTC, datetime
+from datetime import UTC
 
 import pandas as pd
 from attrs import Factory, asdict, define, field, fields, has, validators
@@ -36,14 +36,14 @@ _RUNNING_IN_TESTSUITE = "RUNNING_IN_TESTSUITE" in os.environ
 class OctoStudy(ABC):
     """Abstract base class for all Octopus studies."""
 
-    name: str = field(validator=[validators.instance_of(str)])
-    """The name of the study."""
-
     feature_cols: list[str] = field(validator=[validators.instance_of(list)])
     """List of all feature columns in the dataset."""
 
     sample_id_col: str = field(validator=validators.instance_of(str))
     """Identifier for sample instances."""
+
+    name: str = field(default="Octopus", validator=[validators.instance_of(str)])
+    """The name of the study. Defaults to 'Octopus'."""
 
     row_id_col: str | None = field(
         default=Factory(lambda: None),
@@ -84,14 +84,14 @@ class OctoStudy(ABC):
     )
     """A list of tasks that defines the processing workflow. Each item in the list is an instance of `Task`."""
 
-    silently_overwrite_study: bool = field(default=Factory(lambda: False), validator=[validators.instance_of(bool)])
-    """If False, prompts user for confirmation when overwriting existing study. Defaults to False."""
-
     path: UPath = field(default=UPath("./studies/"), converter=lambda x: UPath(x))
     """The path where study outputs are saved. Defaults to "./studies/"."""
 
     ml_type: MLType = field(init=False)
     """The type of machine learning model. Set automatically by subclass."""
+
+    # Time of last fit() call (internal state)
+    _fit_timestamp: str | None = field(default=None, init=False)
 
     @property
     @abstractmethod
@@ -113,8 +113,12 @@ class OctoStudy(ABC):
 
     @property
     def output_path(self) -> UPath:
-        """Full output path for this study (path/name)."""
-        return self.path / self.name
+        """Full output path for this study (path/name-timestamp)."""
+        if self._fit_timestamp is None:
+            raise RuntimeError("output_path is not available until fit() has been called.")
+        fit_dt = datetime.datetime.fromisoformat(self._fit_timestamp)
+        folder_name = f"{self.name}-{fit_dt.strftime('%Y%m%d_%H%M%S')}"
+        return self.path / folder_name
 
     @property
     def log_dir(self) -> UPath:
@@ -144,18 +148,8 @@ class OctoStudy(ABC):
     def _initialize_study_directory(self) -> None:
         """Initialize study directory."""
         if self.output_path.exists():
-            if not self.silently_overwrite_study:
-                confirmation = input("Study exists, do you want to continue? (yes/no): ")
-                if confirmation.strip().lower() != "yes":
-                    print("Exiting...")
-                    sys.exit()
-                print("Continuing...")
-
-            print("Overwriting existing study....")
-            self.output_path.rmdir(recursive=True)
-
-        self.output_path.mkdir(parents=True, exist_ok=True)
-
+            raise FileExistsError(f"Study output folder already exists: {self.output_path}")
+        self.output_path.mkdir(parents=True, exist_ok=False)
         self.log_dir.mkdir(parents=True, exist_ok=True)
         set_logger_filename(log_file=self.log_dir / "study.log")
 
@@ -210,11 +204,12 @@ class OctoStudy(ABC):
             json.dump(config, f, indent=2)
 
         # Write study metadata (version, platform, timestamp)
+        assert self._fit_timestamp is not None  # Set at start of fit()
         study_meta = {
             "octopus_version": get_version(),
             "package_name": get_package_name(),
             "python_version": platform.python_version(),
-            "created_at": datetime.now(UTC).isoformat(),
+            "created_at": self._fit_timestamp,
         }
         meta_path = self.output_path / "study_meta.json"
         with meta_path.open("w") as f:
@@ -354,6 +349,12 @@ class OctoStudy(ABC):
             data: DataFrame containing the dataset.
             health_check_config: Optional configuration for health check thresholds.
         """
+        if self._fit_timestamp is not None:
+            raise RuntimeError("fit() can only be called once per study instance.")
+
+        # Generate single timestamp for this fit() call
+        self._fit_timestamp = datetime.datetime.now(UTC).isoformat()
+
         self._initialize_study_directory()
         ml_type, positive_class = self._resolve_ml_config(data)
         self._validate_data(data, ml_type, positive_class)
@@ -371,6 +372,7 @@ class OctoStudy(ABC):
             run_single_outersplit_num=self.run_single_outersplit_num,
         )
         manager.run_outersplits()
+        logger.info("Study completed. Results saved to: %s", self.output_path)
 
 
 @define

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,23 @@
 import os
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_datetime_for_studies():
+    """Mock datetime.now() to return a predictable timestamp per test."""
+    fixed_datetime = datetime(2024, 1, 15, 10, 30, 45, tzinfo=UTC)
+
+    with patch("octopus.study.core.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = fixed_datetime
+        mock_dt.datetime.fromisoformat.side_effect = datetime.fromisoformat
+        mock_dt.UTC = UTC
+        yield mock_dt
 
 
 def pytest_configure(config):
-    """Called after command line options have been parsed and all plugins loaded.
-
-    Set environment variables for all tests.
-    """
+    """Called after command line options have been parsed and all plugins loaded."""
     os.environ["RUNNING_IN_TESTSUITE"] = "1"
-    # Use non-interactive matplotlib backend to prevent GUI-related issues
     os.environ["MPLBACKEND"] = "Agg"

--- a/tests/infrastructure/test_fsspec.py
+++ b/tests/infrastructure/test_fsspec.py
@@ -196,7 +196,7 @@ class TestFSSpecIntegration:
 
                 study.fit(data=df)
 
-                study_path = root_dir / study.name
+                study_path = study.output_path
 
                 # Verify that the study was created and files exist
                 assert study_path.exists(), "Study directory should be created"

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -16,7 +16,6 @@ Covers:
 from __future__ import annotations
 
 import tempfile
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -56,12 +55,15 @@ def _no_plotly_show(monkeypatch):
 _STUDY_TMPDIR: tempfile.TemporaryDirectory | None = None
 
 
-def _run_classification_study() -> str:
-    """Run a minimal classification study and return the study path."""
-    global _STUDY_TMPDIR  # noqa: PLW0603
-    _STUDY_TMPDIR = tempfile.TemporaryDirectory()
-    tmp = _STUDY_TMPDIR.name
+def _create_classification_study(tmp_path: str) -> tuple[OctoClassification, pd.DataFrame]:
+    """Create a minimal classification study and data without calling fit().
 
+    Parameters:
+        tmp_path: Path to temporary directory for study output.
+
+    Returns:
+        Tuple of (study, data) for use in tests.
+    """
     # Use breast cancer dataset (enough samples for nonzero FI)
     bc = load_breast_cancer(as_frame=True)
     df = bc["frame"].reset_index()
@@ -78,7 +80,7 @@ def _run_classification_study() -> str:
         metrics=["AUCROC", "ACCBAL", "ACC"],
         datasplit_seed_outer=1234,
         n_folds_outer=2,
-        path=tmp,
+        path=tmp_path,
         ignore_data_health_warning=True,
         outer_parallelization=False,
         workflow=[
@@ -105,8 +107,18 @@ def _run_classification_study() -> str:
             ),
         ],
     )
+    return study, df
+
+
+def _run_classification_study() -> str:
+    """Run a minimal classification study and return the study path."""
+    global _STUDY_TMPDIR  # noqa: PLW0603
+    _STUDY_TMPDIR = tempfile.TemporaryDirectory()
+    tmp = _STUDY_TMPDIR.name
+
+    study, df = _create_classification_study(tmp)
     study.fit(data=df)
-    return str(Path(tmp) / "predict_test_study")
+    return str(study.output_path)
 
 
 @pytest.fixture(scope="session")

--- a/tests/study/test_core.py
+++ b/tests/study/test_core.py
@@ -5,7 +5,6 @@ import tempfile
 import numpy as np
 import pandas as pd
 import pytest
-from upath import UPath
 
 from octopus.modules import Octo
 from octopus.study import OctoClassification, OctoRegression
@@ -78,20 +77,6 @@ def test_string_to_enum_conversion(study_class, param_name, param_value, expecte
             **kwargs,
         )
         assert getattr(study, param_name) == expected_enum
-
-
-def test_output_path_property():
-    """Test that output_path is correctly computed."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        study = OctoClassification(
-            name="my_study",
-            target_metric="AUCROC",
-            feature_cols=["f1"],
-            target_col="target",
-            sample_id_col="id",
-            path=temp_dir,
-        )
-        assert study.output_path == UPath(temp_dir) / "my_study"
 
 
 def test_default_workflow():

--- a/tests/study/test_output.py
+++ b/tests/study/test_output.py
@@ -1,0 +1,37 @@
+"""Tests for study output path behavior."""
+
+import tempfile
+
+import pytest
+
+from tests.predict.test_predict import _create_classification_study
+
+
+def test_output_path_raises_before_fit():
+    """Test that accessing output_path before fit() raises RuntimeError."""
+    with tempfile.TemporaryDirectory() as tmp:
+        study, _ = _create_classification_study(tmp)
+        with pytest.raises(RuntimeError, match="not available until fit"):
+            _ = study.output_path
+
+
+def test_output_path_has_correct_timestamp_format():
+    """Test that output_path uses the timestamp from fit()."""
+    with tempfile.TemporaryDirectory() as tmp:
+        study, df = _create_classification_study(tmp)
+        study.fit(data=df)
+
+        # The mocked datetime returns 2024-01-15 10:30:45
+        expected_name = f"{study.name}-20240115_103045"
+        assert study.output_path.name == expected_name
+
+
+def test_fit_raises_on_second_call():
+    """Test that calling fit() twice raises RuntimeError."""
+    with tempfile.TemporaryDirectory() as tmp:
+        study, df = _create_classification_study(tmp)
+
+        study.fit(data=df)
+
+        with pytest.raises(RuntimeError, match="fit\\(\\) can only be called once"):
+            study.fit(data=df)

--- a/tests/workflows/test_ag_workflows.py
+++ b/tests/workflows/test_ag_workflows.py
@@ -7,7 +7,6 @@ import tempfile
 import pandas as pd
 import pytest
 from sklearn.datasets import make_classification, make_regression
-from upath import UPath
 
 from octopus import OctoClassification, OctoRegression
 from octopus.modules import AutoGluon
@@ -76,7 +75,7 @@ class TestAutogluonWorkflows:
         study.fit(data=self.df)
 
         # Verify that study files were created
-        study_path = UPath(self.studies_path) / "test_classification_workflow"
+        study_path = study.output_path
         assert study_path.exists(), "Study directory should be created"
 
         # Verify core study files
@@ -142,7 +141,7 @@ class TestAutogluonWorkflows:
         study.fit(data=df_regression)
 
         # Verify that study files were created
-        study_path = UPath(self.studies_path) / "test_regression_workflow"
+        study_path = study.output_path
         assert study_path.exists(), "Study directory should be created"
 
         # Verify core study files

--- a/tests/workflows/test_octo_classification.py
+++ b/tests/workflows/test_octo_classification.py
@@ -1,7 +1,6 @@
 """Test workflow for Octopus intro classification example."""
 
 import tempfile
-from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -230,7 +229,7 @@ class TestOctoIntroClassification:
             study.fit(data=df)
 
             # Verify that the study was created and files exist
-            study_path = Path(temp_dir) / "test_octo_intro_execution"
+            study_path = study.output_path
             assert study_path.exists(), "Study directory should be created"
 
             assert (study_path / "study.log").exists(), "Study log file should exist"

--- a/tests/workflows/test_octo_multiclass.py
+++ b/tests/workflows/test_octo_multiclass.py
@@ -1,7 +1,6 @@
 """Test workflow for Octopus multiclass classification using Wine dataset."""
 
 import tempfile
-from pathlib import Path
 from typing import ClassVar
 
 import pandas as pd
@@ -239,7 +238,7 @@ class TestOctoMulticlass:
             study.fit(data=df)
 
             # Verify that the study was created and files exist
-            study_path = Path(temp_dir) / "test_multiclass_execution"
+            study_path = study.output_path
             assert study_path.exists(), "Study directory should be created"
 
             assert (study_path / "study.log").exists(), "Study log file should exist"

--- a/tests/workflows/test_octo_regression.py
+++ b/tests/workflows/test_octo_regression.py
@@ -1,7 +1,6 @@
 """Test workflow for Octopus regression example."""
 
 import tempfile
-from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -236,7 +235,7 @@ class TestOctoRegression:
             study.fit(data=df)
 
             # Verify that the study was created and files exist
-            study_path = Path(temp_dir) / "test_octo_regression_execution"
+            study_path = study.output_path
             assert study_path.exists(), "Study directory should be created"
 
             assert (study_path / "study.log").exists(), "Study log file should exist"

--- a/tests/workflows/test_roc_octo_roc_workflow.py
+++ b/tests/workflows/test_roc_octo_roc_workflow.py
@@ -1,7 +1,6 @@
 """Test workflow for ROC-OCTO-ROC sequence."""
 
 import tempfile
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -323,7 +322,7 @@ class TestRocOctoRocWorkflow:
             study.fit(data=df)
 
             # Verify that the study was created and files exist
-            study_path = Path(temp_dir) / "test_roc_octo_roc_execution"
+            study_path = study.output_path
             assert study_path.exists(), "Study directory should be created"
 
             assert (study_path / "study.log").exists(), "Study log file should exist"


### PR DESCRIPTION
Fixes #174: This PR refactors study output directory handling to always create a unique, timestamped folder (e.g., `Octopus-YYYYMMDD_HHMMSS`), removes the overwrite prompt and related parameter, and makes the study name optional with a default.

Implementation: 
- Study has a private `_fit_timestamp` attribute that is updated at every `.fit()` call and used to define the outputpath. 
- This attribute is also saved as meta data. 
- Added logging statement that prints output directory for example workflow.