### PR TITLE
Fix DataFrame fragmentation PerformanceWarning

### DIFF
--- a/octopus/study/data_preparator.py
+++ b/octopus/study/data_preparator.py
@@ -106,6 +106,7 @@ class OctoDataPreparator:
     def _create_row_id_col(self):
         """Create a unique row identifier if not provided."""
         if not self.row_id_col:
+            self.data = self.data.copy()
             self.data["row_id"] = list(range(len(self.data)))
             self.row_id_col = "row_id"
 


### PR DESCRIPTION
## Summary
- Defragment the DataFrame with `.copy()` in `_create_row_id_col` before inserting the `row_id` column, eliminating the pandas `PerformanceWarning` about high fragmentation.
- Prior preparation steps (`_standardize_null_values`, `_standardize_inf_values`, `_transform_bool_to_int`) fragment the DataFrame via repeated column-slice assignments; the `.copy()` consolidates blocks before the final insert.