### PR TITLE
fix: remove resume_optimization

### DIFF
--- a/examples/wf_roc_octo.py
+++ b/examples/wf_roc_octo.py
@@ -73,7 +73,6 @@ study = OctoClassification(
             # Hyperparameter optimization with Optuna
             optuna_seed=0,
             n_optuna_startup_trials=10,
-            resume_optimization=False,
             n_trials=12,  # Number of hyperparameter optimization trials
             max_features=12,  # Maximum number of features to select
             penalty_factor=1.0,

--- a/octopus/modules/octo/module.py
+++ b/octopus/modules/octo/module.py
@@ -111,9 +111,6 @@ class Octo(Task):
     mrmr_feature_numbers: list = field(validator=[validators.instance_of(list)], default=Factory(list))
     """List of feature numbers to be investigated by mrmr."""
 
-    resume_optimization: bool = field(validator=[validators.instance_of(bool)], default=False)
-    """Resume HPO, use existing optuna.db, don't delete optuna.db"""
-
     optuna_return: str = field(default="pool", validator=[validators.in_(["pool", "average"])])
     """How to calculate the bag performance for the optuna optimization target."""
 

--- a/tests/infrastructure/test_fsspec.py
+++ b/tests/infrastructure/test_fsspec.py
@@ -184,7 +184,6 @@ class TestFSSpecIntegration:
                             n_workers=2,
                             optuna_seed=0,
                             n_optuna_startup_trials=3,
-                            resume_optimization=False,
                             n_trials=5,
                             max_features=5,
                             penalty_factor=1.0,

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -99,7 +99,6 @@ def _create_classification_study(tmp_path: str) -> tuple[OctoClassification, pd.
                 n_workers=2,
                 optuna_seed=0,
                 n_optuna_startup_trials=3,
-                resume_optimization=False,
                 n_trials=5,
                 max_features=5,
                 penalty_factor=1.0,

--- a/tests/workflows/test_octo_classification.py
+++ b/tests/workflows/test_octo_classification.py
@@ -89,7 +89,6 @@ class TestOctoIntroClassification:
             n_workers=3,
             optuna_seed=0,
             n_optuna_startup_trials=5,
-            resume_optimization=False,
             n_trials=6,
             max_features=5,
             penalty_factor=1.0,
@@ -216,7 +215,6 @@ class TestOctoIntroClassification:
                         n_workers=2,
                         optuna_seed=0,
                         n_optuna_startup_trials=3,
-                        resume_optimization=False,
                         n_trials=5,
                         max_features=5,
                         penalty_factor=1.0,
@@ -264,7 +262,6 @@ class TestOctoIntroClassification:
             n_workers=5,
             optuna_seed=0,
             n_optuna_startup_trials=10,
-            resume_optimization=False,
             n_trials=5,
             max_features=5,
             penalty_factor=1.0,
@@ -287,7 +284,6 @@ class TestOctoIntroClassification:
         assert octo_task.n_workers == 5
         assert octo_task.optuna_seed == 0
         assert octo_task.n_optuna_startup_trials == 10
-        assert octo_task.resume_optimization is False
         assert octo_task.n_trials == 5
         assert octo_task.max_features == 5
         assert octo_task.penalty_factor == 1.0

--- a/tests/workflows/test_octo_regression.py
+++ b/tests/workflows/test_octo_regression.py
@@ -226,7 +226,6 @@ class TestOctoRegression:
                         n_workers=2,
                         optuna_seed=0,
                         n_optuna_startup_trials=3,
-                        resume_optimization=False,
                         penalty_factor=1.0,
                     )
                 ],
@@ -281,7 +280,6 @@ class TestOctoRegression:
             n_workers=5,
             optuna_seed=0,
             n_optuna_startup_trials=10,
-            resume_optimization=False,
             penalty_factor=1.0,
             n_folds_inner=5,
         )
@@ -308,7 +306,6 @@ class TestOctoRegression:
         assert octo_task.n_workers == 5
         assert octo_task.optuna_seed == 0
         assert octo_task.n_optuna_startup_trials == 10
-        assert octo_task.resume_optimization is False
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.penalty_factor == 1.0

--- a/tests/workflows/test_octo_t2e.py
+++ b/tests/workflows/test_octo_t2e.py
@@ -224,7 +224,6 @@ class TestOctoTimeToEvent:
                         n_workers=2,
                         optuna_seed=0,
                         n_optuna_startup_trials=3,
-                        resume_optimization=False,
                         penalty_factor=1.0,
                     )
                 ],
@@ -272,7 +271,6 @@ class TestOctoTimeToEvent:
             n_workers=5,
             optuna_seed=0,
             n_optuna_startup_trials=10,
-            resume_optimization=False,
             penalty_factor=1.0,
             n_folds_inner=5,
         )
@@ -289,7 +287,6 @@ class TestOctoTimeToEvent:
         assert octo_task.n_workers == 5
         assert octo_task.optuna_seed == 0
         assert octo_task.n_optuna_startup_trials == 10
-        assert octo_task.resume_optimization is False
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.penalty_factor == 1.0


### PR DESCRIPTION
`resume_optimzation` parameter is not used anywhere. Therefore we should remove the parameter too.