### PR TITLE
Replace string literals with enums, fixes #267, #273, #344, #345, #377

### DIFF
--- a/docs/concepts/feature_importance.md
+++ b/docs/concepts/feature_importance.md
@@ -69,11 +69,12 @@ This method extracts the built-in `feature_importances_` attribute from tree-bas
 **Example:**
 ```python
 from octopus.modules import Octo
+from octopus.types import ModelName
 
 # Configure Octo with RandomForest
 octo = Octo(
     task_id=0,
-    models=["RandomForestClassifier"],
+    models=[ModelName.RandomForestClassifier],
     n_trials=50,
 )
 
@@ -151,11 +152,12 @@ This method extracts and ranks features by the absolute magnitude of their coeff
 **Example:**
 ```python
 from octopus.modules import Octo
+from octopus.types import ModelName
 
 # Configure Octo with LogisticRegression
 octo = Octo(
     task_id=0,
-    models=["LogisticRegression"],
+    models=[ModelName.LogisticRegressionClassifier],
     n_trials=30,
 )
 
@@ -207,10 +209,11 @@ except ValueError as e:
 
 ```python
 from octopus.modules import Octo
+from octopus.types import ModelName
 
 octo = Octo(
     task_id=0,
-    models=["RandomForestClassifier", "XGBClassifier"],
+    models=[ModelName.RandomForestClassifier, ModelName.XGBClassifier],
     n_trials=100,
 )
 
@@ -242,7 +245,7 @@ from octopus.modules import Roc
 roc = Roc(
     task_id=0,
     threshold=0.8,
-    correlation_type="spearmanr",
+    correlation_type=CorrelationType.SPEARMAN,
 )
 
 selected_features, results = roc.fit(...)
@@ -256,10 +259,11 @@ selected_features, results = roc.fit(...)
 
 ```python
 from octopus.modules import Boruta
+from octopus.types import ModelName
 
 boruta = Boruta(
     task_id=0,
-    model="RandomForestClassifier",
+    model=ModelName.RandomForestClassifier,
     perc=100,
 )
 
@@ -338,10 +342,11 @@ Feature importances are automatically calculated and saved during workflow execu
 ```python
 from octopus.manager.workflow_runner import WorkflowTaskRunner
 from octopus.modules import Octo, Rfe
+from octopus.types import ModelName
 
 # Define workflow
 workflow = [
-    Octo(task_id=0, models=["RandomForestClassifier"]),
+    Octo(task_id=0, models=[ModelName.RandomForestClassifier]),
     Rfe(task_id=1, depends_on=0, n_features_to_select=20),
 ]
 
@@ -375,9 +380,10 @@ The feature importance methods automatically unwrap `GridSearchCV` objects:
 ```python
 from sklearn.model_selection import GridSearchCV
 from sklearn.ensemble import RandomForestClassifier
+from octopus.types import ModelName
 
 # Octo internally uses GridSearchCV
-octo = Octo(task_id=0, models=["RandomForestClassifier"])
+octo = Octo(task_id=0, models=[ModelName.RandomForestClassifier])
 octo.fit(...)
 
 # This automatically extracts best_estimator_ from GridSearchCV

--- a/docs/userguide/time_to_event.md
+++ b/docs/userguide/time_to_event.md
@@ -49,6 +49,7 @@ df = pd.DataFrame({
 ```python
 from octopus.study import OctoTimeToEvent
 from octopus.modules import Octo
+from octopus.types import ModelName
 
 study = OctoTimeToEvent(
     name="my_survival_study",
@@ -64,7 +65,7 @@ study = OctoTimeToEvent(
             task_id=0,
             depends_on=None,
             description="survival_step",
-            models=["CatBoostCoxSurvival"],
+            models=[ModelName.CatBoostCoxSurvival],
             n_trials=20,
             max_features=5,
             ensemble_selection=True,
@@ -126,7 +127,7 @@ Octo(
     task_id=0,
     depends_on=None,
     description="compare_models",
-    models=["CatBoostCoxSurvival", "XGBoostCoxSurvival"],
+    models=[ModelName.CatBoostCoxSurvival, ModelName.XGBoostCoxSurvival],
     n_trials=20,
     max_features=5,
     ensemble_selection=True,

--- a/examples/basic_classification.py
+++ b/examples/basic_classification.py
@@ -11,6 +11,7 @@ import os
 from octopus.example_data import load_breast_cancer_data
 from octopus.modules import Octo
 from octopus.study import OctoClassification
+from octopus.types import ModelName
 
 ### Load and Preprocess Data
 df, features, targets = load_breast_cancer_data()
@@ -35,7 +36,7 @@ study = OctoClassification(
             description="step1_octo_full",
             task_id=0,
             depends_on=None,  # First task, depends on input
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             n_trials=100,  # 100 trials for hyperparameter optimization
             n_folds_inner=5,  # 5 inner folds
             max_features=30,  # Use all 30 features

--- a/examples/multi_workflow.py
+++ b/examples/multi_workflow.py
@@ -9,6 +9,7 @@ import os
 from octopus.example_data import load_diabetes_data
 from octopus.modules import Mrmr, Octo
 from octopus.study import OctoRegression
+from octopus.types import CorrelationType, ModelName
 
 ### Load the diabetes dataset
 df, features, targets = load_diabetes_data()
@@ -35,7 +36,7 @@ study = OctoRegression(
             description="step1_octofull",
             task_id=0,
             depends_on=None,
-            models=["ExtraTreesRegressor", "RandomForestRegressor"],
+            models=[ModelName.ExtraTreesRegressor, ModelName.RandomForestRegressor],
             n_trials=2,
             max_features=70,
         ),
@@ -44,13 +45,13 @@ study = OctoRegression(
             task_id=1,
             depends_on=0,
             n_features=6,
-            correlation_type="rdc",
+            correlation_type=CorrelationType.RDC,
         ),
         Octo(
             description="step3_octo_reduced",
             task_id=2,
             depends_on=1,
-            models=["ExtraTreesRegressor", "RandomForestRegressor"],
+            models=[ModelName.ExtraTreesRegressor, ModelName.RandomForestRegressor],
             n_trials=1,
             max_features=70,
         ),

--- a/examples/use_own_hyperparameters.py
+++ b/examples/use_own_hyperparameters.py
@@ -16,6 +16,7 @@ from octopus.example_data import load_diabetes_data
 from octopus.models.hyperparameter import IntHyperparameter
 from octopus.modules import Octo
 from octopus.study import OctoRegression
+from octopus.types import ModelName
 
 ### Load the diabetes dataset
 df, features, targets = load_diabetes_data()
@@ -40,10 +41,10 @@ study = OctoRegression(
     workflow=[
         Octo(
             task_id=0,
-            models=["RandomForestRegressor"],
+            models=[ModelName.RandomForestRegressor],
             n_trials=3,
             hyperparameters={
-                "RandomForestRegressor": [
+                ModelName.RandomForestRegressor: [
                     IntHyperparameter(name="max_depth", low=2, high=32),
                     IntHyperparameter(name="min_samples_split", low=2, high=100),
                 ]

--- a/examples/wf_multiclass_wine.py
+++ b/examples/wf_multiclass_wine.py
@@ -13,6 +13,7 @@ import os
 from octopus.example_data import load_wine_data
 from octopus.modules import Octo
 from octopus.study import OctoClassification
+from octopus.types import FIComputeMethod, ModelName
 
 ### Load and Preprocess Data
 df, features, targets = load_wine_data()
@@ -44,15 +45,15 @@ study = OctoClassification(
             description="step_1_octo_multiclass",
             n_folds_inner=5,
             models=[
-                "ExtraTreesClassifier",
-                "RandomForestClassifier",
-                "XGBClassifier",
-                "CatBoostClassifier",
+                ModelName.ExtraTreesClassifier,
+                ModelName.RandomForestClassifier,
+                ModelName.XGBClassifier,
+                ModelName.CatBoostClassifier,
             ],
             model_seed=0,
             n_jobs=1,
             max_outl=0,
-            fi_methods_bestbag=["permutation"],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=5,
             n_trials=20,

--- a/examples/wf_octo_autogluon.py
+++ b/examples/wf_octo_autogluon.py
@@ -15,6 +15,7 @@ from sklearn.datasets import make_classification
 
 from octopus.modules import AutoGluon, Octo
 from octopus.study import OctoClassification
+from octopus.types import FIComputeMethod, ModelName
 
 ### Generate Synthetic Binary Classification Dataset
 n_informative = 30
@@ -85,9 +86,9 @@ study = OctoClassification(
             n_folds_inner=5,
             # Model selection - using tree-based models for feature importance
             models=[
-                "ExtraTreesClassifier",
+                ModelName.ExtraTreesClassifier,
             ],
-            fi_methods_bestbag=["permutation"],  # Feature importance method
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],  # Feature importance method
             # Parallelization settings
             inner_parallelization=True,
             n_workers=5,

--- a/examples/wf_octo_mrmr_octo.py
+++ b/examples/wf_octo_mrmr_octo.py
@@ -15,6 +15,7 @@ from sklearn.datasets import make_classification
 
 from octopus.modules import Mrmr, Octo
 from octopus.study import OctoClassification
+from octopus.types import CorrelationType, ModelName
 
 # Set random seed for reproducibility
 np.random.seed(42)
@@ -70,7 +71,7 @@ study = OctoClassification(
             description="step1_octo_full",
             task_id=0,
             depends_on=None,  # First task, depends on input
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             n_trials=100,  # 100 trials for hyperparameter optimization
             n_folds_inner=5,  # 5 inner folds
             max_features=30,  # Use all 30 features
@@ -81,14 +82,14 @@ study = OctoClassification(
             task_id=1,
             depends_on=0,
             n_features=15,  # Select top 15 features
-            correlation_type="spearman",
+            correlation_type=CorrelationType.SPEARMAN,
         ),
         # Task 2: Octo with reduced features
         Octo(
             description="step3_octo_reduced",
             task_id=2,
             depends_on=1,
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             n_trials=100,
             n_folds_inner=5,
             ensemble_selection=True,

--- a/examples/wf_roc_octo.py
+++ b/examples/wf_roc_octo.py
@@ -11,6 +11,7 @@ import os
 from octopus.example_data import load_breast_cancer_data
 from octopus.modules import Octo, Roc
 from octopus.study import OctoClassification
+from octopus.types import CorrelationType, FIComputeMethod, ModelName, ROCFilterMethod
 
 ### Load and Preprocess Data
 
@@ -47,8 +48,8 @@ study = OctoClassification(
             task_id=0,
             depends_on=None,  # First step, no input dependency
             threshold=0.85,  # Remove features with correlation > 0.85
-            correlation_type="spearmanr",  # Use Spearman correlation
-            filter_type="f_statistics",  # Apply F-statistics filtering
+            correlation_type=CorrelationType.SPEARMAN,  # Use Spearman correlation
+            filter_type=ROCFilterMethod.F_STATISTICS,  # Apply F-statistics filtering
         ),
         # Step 1: Octo - Train models on filtered features from ROC step
         Octo(
@@ -59,13 +60,13 @@ study = OctoClassification(
             n_folds_inner=5,
             # Model selection
             models=[
-                "ExtraTreesClassifier",
-                # "RandomForestClassifier",
+                ModelName.ExtraTreesClassifier,
+                # ModelName.RandomForestClassifier,
             ],
             model_seed=0,
             n_jobs=1,
             max_outl=0,  # No outlier removal
-            fi_methods_bestbag=["permutation"],  # Feature importance method
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],  # Feature importance method
             # Parallelization settings
             inner_parallelization=True,
             n_workers=5,

--- a/octopus/diagnostics/_plots.py
+++ b/octopus/diagnostics/_plots.py
@@ -7,7 +7,7 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from sklearn.metrics import confusion_matrix
 
-from octopus.types import FIResultLabel
+from octopus.types import FIResultLabel, MetricDirection
 
 
 def plot_feature_importance_chart(
@@ -308,7 +308,7 @@ def plot_optuna_trials_chart(
     *,
     outersplit_id: int | str = 0,
     task_id: int | str = 0,
-    direction: str = "minimize",
+    direction: MetricDirection = MetricDirection.MINIMIZE,
 ) -> go.Figure:
     """Create scatter + best-value line plot for Optuna trials.
 
@@ -332,7 +332,7 @@ def plot_optuna_trials_chart(
     trial_values = filtered.groupby("trial")["value"].first().reset_index().sort_values("trial")
 
     # Cumulative best
-    if direction == "maximize":
+    if direction == MetricDirection.MAXIMIZE:
         trial_values["best"] = trial_values["value"].cummax()
     else:
         trial_values["best"] = trial_values["value"].cummin()

--- a/octopus/diagnostics/core.py
+++ b/octopus/diagnostics/core.py
@@ -30,7 +30,7 @@ from octopus.diagnostics._plots import (
     plot_optuna_trials_chart,
     plot_predictions_vs_truth_chart,
 )
-from octopus.types import FIResultLabel, MLType
+from octopus.types import FIResultLabel, MetricDirection, MLType
 
 
 def _has_ipywidgets() -> bool:
@@ -295,7 +295,7 @@ class StudyDiagnostics:
         self,
         outersplit_id: int | None = None,
         task_id: int | None = None,
-        direction: str = "minimize",
+        direction: MetricDirection = MetricDirection.MINIMIZE,
     ) -> None:
         """Plot Optuna trial scatter + cumulative best line.
 

--- a/octopus/metrics/classification.py
+++ b/octopus/metrics/classification.py
@@ -13,7 +13,7 @@ from sklearn.metrics import (
     roc_auc_score,
 )
 
-from octopus.types import MLType
+from octopus.types import MLType, PredictionType
 
 from .config import Metric
 from .core import Metrics
@@ -27,7 +27,7 @@ def aucroc_metric() -> Metric:
         metric_function=roc_auc_score,
         ml_types=[MLType.BINARY],
         higher_is_better=True,
-        prediction_type="predict_proba",
+        prediction_type=PredictionType.PROBABILITIES,
         scorer_string="roc_auc",
     )
 
@@ -40,7 +40,7 @@ def acc_metric() -> Metric:
         metric_function=accuracy_score,
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="accuracy",
     )
 
@@ -53,7 +53,7 @@ def accbal_metric() -> Metric:
         metric_function=balanced_accuracy_score,
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="balanced_accuracy",
     )
 
@@ -66,7 +66,7 @@ def logloss_metric() -> Metric:
         metric_function=log_loss,
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict_proba",
+        prediction_type=PredictionType.PROBABILITIES,
         scorer_string="neg_log_loss",
     )
 
@@ -79,7 +79,7 @@ def f1_metric() -> Metric:
         metric_function=f1_score,
         ml_types=[MLType.BINARY],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="f1",
     )
 
@@ -92,7 +92,7 @@ def negbrierscore_metric() -> Metric:
         metric_function=brier_score_loss,
         ml_types=[MLType.BINARY],
         higher_is_better=True,
-        prediction_type="predict_proba",
+        prediction_type=PredictionType.PROBABILITIES,
         scorer_string="neg_brier_score",
     )
 
@@ -105,7 +105,7 @@ def aucpr_metric() -> Metric:
         metric_function=average_precision_score,
         ml_types=[MLType.BINARY],
         higher_is_better=True,
-        prediction_type="predict_proba",
+        prediction_type=PredictionType.PROBABILITIES,
         scorer_string="average_precision",
     )
 
@@ -118,7 +118,7 @@ def mcc_metric() -> Metric:
         metric_function=matthews_corrcoef,
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="matthews_corrcoef",
     )
 
@@ -131,7 +131,7 @@ def precision_metric() -> Metric:
         metric_function=precision_score,
         ml_types=[MLType.BINARY],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="precision",
     )
 
@@ -144,6 +144,6 @@ def recall_metric() -> Metric:
         metric_function=recall_score,
         ml_types=[MLType.BINARY],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="recall",
     )

--- a/octopus/metrics/config.py
+++ b/octopus/metrics/config.py
@@ -5,8 +5,8 @@ from typing import Any
 
 from attrs import define, field, validators
 
-from octopus.models.config import PRED_TYPES, OctoArrayLike, PredType
-from octopus.types import MLType, to_ml_types_frozenset, validate_ml_types
+from octopus.models.config import OctoArrayLike
+from octopus.types import MetricDirection, MLType, PredictionType, to_ml_types_frozenset, validate_ml_types
 
 # Type alias for metric functions
 # Metric functions should accept (y_true, y_pred, **kwargs) and return a numeric value.
@@ -28,7 +28,7 @@ class Metric:
     metric_function: MetricFunction = field(validator=validators.is_callable())
     ml_types: frozenset[MLType] = field(converter=to_ml_types_frozenset, validator=validate_ml_types)
     higher_is_better: bool = field(validator=validators.instance_of(bool))
-    prediction_type: PredType = field(validator=validators.in_(PRED_TYPES))
+    prediction_type: PredictionType = field(converter=PredictionType, validator=validators.in_(list(PredictionType)))
     scorer_string: str = field(validator=validators.instance_of(str))  # needed for some sklearn functionalities
     metric_params: dict[str, Any] = field(factory=dict)
 
@@ -37,9 +37,9 @@ class Metric:
         return ml_type in self.ml_types
 
     @property
-    def direction(self) -> str:
+    def direction(self) -> MetricDirection:
         """Optimization direction for Optuna ('maximize' or 'minimize')."""
-        return "maximize" if self.higher_is_better else "minimize"
+        return MetricDirection.MAXIMIZE if self.higher_is_better else MetricDirection.MINIMIZE
 
     def calculate(self, y_true: OctoArrayLike, y_pred: OctoArrayLike, **kwargs) -> float:
         """Calculate metric for classification/regression tasks.

--- a/octopus/metrics/core.py
+++ b/octopus/metrics/core.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, ClassVar
 
 from octopus.exceptions import UnknownMetricError
+from octopus.types import MetricDirection
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -99,16 +100,16 @@ class Metrics:
         return config
 
     @classmethod
-    def get_direction(cls, name: str) -> Literal["maximize", "minimize"]:
+    def get_direction(cls, name: str) -> MetricDirection:
         """Get the optuna direction by name.
 
         Args:
             name: The name of the metric.
 
         Returns:
-            "maximize" if higher_is_better is True, else "minimize".
+            MetricDirection.MAXIMIZE if higher_is_better is True, else MetricDirection.MINIMIZE.
         """
-        return "maximize" if cls.get_instance(name).higher_is_better else "minimize"
+        return MetricDirection.MAXIMIZE if cls.get_instance(name).higher_is_better else MetricDirection.MINIMIZE
 
     @classmethod
     def get_by_type(cls, *ml_types: MLType) -> list[str]:

--- a/octopus/metrics/multiclass.py
+++ b/octopus/metrics/multiclass.py
@@ -2,7 +2,7 @@
 
 from sklearn.metrics import balanced_accuracy_score, roc_auc_score
 
-from octopus.types import MLType
+from octopus.types import MLType, PredictionType
 
 from .config import Metric
 from .core import Metrics
@@ -16,7 +16,7 @@ def accbal_multiclass_metric() -> Metric:
         metric_function=balanced_accuracy_score,
         ml_types=[MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="balanced_accuracy",
     )
 
@@ -30,7 +30,7 @@ def aucroc_macro_multiclass_metric() -> Metric:
         metric_params={"multi_class": "ovr", "average": "macro"},
         ml_types=[MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict_proba",
+        prediction_type=PredictionType.PROBABILITIES,
         scorer_string="roc_auc_ovr",
     )
 
@@ -44,6 +44,6 @@ def aucroc_weighted_multiclass_metric() -> Metric:
         metric_params={"multi_class": "ovr", "average": "weighted"},
         ml_types=[MLType.MULTICLASS],
         higher_is_better=True,
-        prediction_type="predict_proba",
+        prediction_type=PredictionType.PROBABILITIES,
         scorer_string="roc_auc_ovr_weighted",
     )

--- a/octopus/metrics/regression.py
+++ b/octopus/metrics/regression.py
@@ -5,7 +5,7 @@ import math
 import numpy as np
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 
-from octopus.types import MLType
+from octopus.types import MLType, PredictionType
 
 from .config import Metric
 from .core import Metrics
@@ -32,7 +32,7 @@ def r2_metric() -> Metric:
         metric_function=r2_score,
         ml_types=[MLType.REGRESSION],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="r2",
     )
 
@@ -45,7 +45,7 @@ def mae_metric() -> Metric:
         metric_function=mean_absolute_error,
         ml_types=[MLType.REGRESSION],
         higher_is_better=False,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="neg_mean_absolute_error",
     )
 
@@ -58,7 +58,7 @@ def mse_metric() -> Metric:
         metric_function=mean_squared_error,
         ml_types=[MLType.REGRESSION],
         higher_is_better=False,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="neg_mean_squared_error",
     )
 
@@ -71,6 +71,6 @@ def rmse_metric() -> Metric:
         metric_function=root_mean_squared_error,
         ml_types=[MLType.REGRESSION],
         higher_is_better=False,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="neg_root_mean_squared_error",
     )

--- a/octopus/metrics/timetoevent.py
+++ b/octopus/metrics/timetoevent.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from octopus.types import MLType
+from octopus.types import MLType, PredictionType
 
 from .config import Metric
 from .core import Metrics
@@ -292,7 +292,7 @@ def cindex_metric() -> Metric:
         metric_function=_harrell_concordance_index,
         ml_types=[MLType.TIMETOEVENT],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="concordance_index",
     )
 
@@ -305,6 +305,6 @@ def cindex_uno_metric() -> Metric:
         metric_function=_uno_concordance_index,
         ml_types=[MLType.TIMETOEVENT],
         higher_is_better=True,
-        prediction_type="predict",
+        prediction_type=PredictionType.PREDICTIONS,
         scorer_string="concordance_index_uno",
     )

--- a/octopus/metrics/utils.py
+++ b/octopus/metrics/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 from octopus.metrics import Metrics
-from octopus.types import MLType
+from octopus.types import MetricDirection, MLType, PredictionType
 
 
 def _to_numpy(data: Any) -> np.ndarray:
@@ -104,7 +104,7 @@ def get_performance_from_model(
 
         probabilities = _to_numpy(model.predict_proba(input_data))[:, positive_class_idx]
 
-        if metric.prediction_type == "predict_proba":
+        if metric.prediction_type == PredictionType.PROBABILITIES:
             return metric.calculate(target, probabilities)
 
         predictions = (probabilities >= threshold).astype(int)
@@ -112,7 +112,7 @@ def get_performance_from_model(
 
     # Multiclass classification: no positive_class means multiclass context
     if metric.supports_ml_type(MLType.MULTICLASS) and positive_class is None:
-        if metric.prediction_type == "predict_proba":
+        if metric.prediction_type == PredictionType.PROBABILITIES:
             probabilities = _to_numpy(model.predict_proba(input_data))
             return metric.calculate(target, probabilities)
 
@@ -121,7 +121,7 @@ def get_performance_from_model(
 
     # Regression
     if metric.supports_ml_type(MLType.REGRESSION):
-        if metric.prediction_type == "predict_proba":
+        if metric.prediction_type == PredictionType.PROBABILITIES:
             raise ValueError("predict_proba not supported for regression")
 
         predictions = _to_numpy(model.predict(input_data))
@@ -184,7 +184,7 @@ def get_performance_from_predictions(
                 if positive_class is not None and metric.supports_ml_type(MLType.BINARY):
                     probabilities = pred_df[positive_class]
 
-                    if metric.prediction_type == "predict_proba":
+                    if metric.prediction_type == PredictionType.PROBABILITIES:
                         perf_value = metric.calculate(target, probabilities)
                     else:
                         predictions_binary = (probabilities >= threshold).astype(int)
@@ -192,7 +192,7 @@ def get_performance_from_predictions(
 
                 # Multiclass classification: no positive_class means multiclass context
                 elif metric.supports_ml_type(MLType.MULTICLASS) and positive_class is None:
-                    if metric.prediction_type == "predict_proba":
+                    if metric.prediction_type == PredictionType.PROBABILITIES:
                         prob_columns = _get_probability_columns(pred_df, target_col)
                         probabilities = pred_df[prob_columns].values
                         perf_value = metric.calculate(target, probabilities)
@@ -202,7 +202,7 @@ def get_performance_from_predictions(
 
                 # Regression
                 elif metric.supports_ml_type(MLType.REGRESSION):
-                    if metric.prediction_type == "predict_proba":
+                    if metric.prediction_type == PredictionType.PROBABILITIES:
                         raise ValueError("predict_proba not supported for regression")
 
                     predictions_reg = pred_df["prediction"]
@@ -261,7 +261,7 @@ def get_score_from_prediction(
     for training_id, partitions in performance.items():
         scores[training_id] = {}
         for part, perf_value in partitions.items():
-            if metric.direction == "maximize":
+            if metric.direction == MetricDirection.MAXIMIZE:
                 scores[training_id][part] = perf_value
             else:
                 scores[training_id][part] = -perf_value
@@ -299,4 +299,4 @@ def get_score_from_model(
 
     # Apply optimization direction
     metric = Metrics.get_instance(target_metric)
-    return performance if metric.direction == "maximize" else -performance
+    return performance if metric.direction == MetricDirection.MAXIMIZE else -performance

--- a/octopus/models/classification_models.py
+++ b/octopus/models/classification_models.py
@@ -10,7 +10,7 @@ from sklearn.ensemble import (
 from sklearn.linear_model import LogisticRegression
 from xgboost import XGBClassifier
 
-from octopus.types import FIComputeMethod, MLType
+from octopus.types import FIComputeMethod, MLType, ModelName
 
 from .config import ModelConfig
 from .core import Models
@@ -18,7 +18,7 @@ from .hyperparameter import CategoricalHyperparameter, FixedHyperparameter, Floa
 from .wrapper_models.GaussianProcessClassifier import GPClassifierWrapper
 
 
-@Models.register("ExtraTreesClassifier")
+@Models.register(ModelName.ExtraTreesClassifier)
 def extra_trees_classifier() -> ModelConfig:
     """ExtraTrees classification model config."""
     return ModelConfig(
@@ -45,7 +45,7 @@ def extra_trees_classifier() -> ModelConfig:
     )
 
 
-@Models.register("HistGradientBoostingClassifier")
+@Models.register(ModelName.HistGradientBoostingClassifier)
 def hist_gradient_boosting_classifier() -> ModelConfig:
     """Histogram-based gradient boosting classification model config (scikit-learn 1.6.1)."""
     return ModelConfig(
@@ -72,7 +72,7 @@ def hist_gradient_boosting_classifier() -> ModelConfig:
     )
 
 
-@Models.register("GradientBoostingClassifier")
+@Models.register(ModelName.GradientBoostingClassifier)
 def gradient_boosting_classifier() -> ModelConfig:
     """Gradient boosting classification model config."""
     return ModelConfig(
@@ -97,7 +97,7 @@ def gradient_boosting_classifier() -> ModelConfig:
     )
 
 
-@Models.register("RandomForestClassifier")
+@Models.register(ModelName.RandomForestClassifier)
 def random_forest_classifier() -> ModelConfig:
     """Random forest classification model config."""
     return ModelConfig(
@@ -122,7 +122,7 @@ def random_forest_classifier() -> ModelConfig:
     )
 
 
-@Models.register("XGBClassifier")
+@Models.register(ModelName.XGBClassifier)
 def xgb_classifier() -> ModelConfig:
     """XGBoost classification model config."""
     return ModelConfig(
@@ -147,7 +147,7 @@ def xgb_classifier() -> ModelConfig:
     )
 
 
-@Models.register("CatBoostClassifier")
+@Models.register(ModelName.CatBoostClassifier)
 def catboost_classifier() -> ModelConfig:
     """CatBoost classification model config."""
     return ModelConfig(
@@ -177,7 +177,7 @@ def catboost_classifier() -> ModelConfig:
     )
 
 
-@Models.register("LogisticRegressionClassifier")
+@Models.register(ModelName.LogisticRegressionClassifier)
 def logistic_regression_classifier() -> ModelConfig:
     """Logistic regression classification model config."""
     return ModelConfig(
@@ -204,7 +204,7 @@ def logistic_regression_classifier() -> ModelConfig:
     )
 
 
-@Models.register("GaussianProcessClassifier")
+@Models.register(ModelName.GaussianProcessClassifier)
 def gaussian_process_classifier() -> ModelConfig:
     """Gaussian process classification model config."""
     return ModelConfig(

--- a/octopus/models/config.py
+++ b/octopus/models/config.py
@@ -1,7 +1,5 @@
 """Machine learning models config."""
 
-from typing import Literal
-
 import numpy as np
 import pandas as pd
 from attrs import Attribute, define, field, validators
@@ -34,9 +32,6 @@ def validate_hyperparameters(instance: "ModelConfig", attribute: Attribute, valu
 
 type OctoArrayLike = np.typing.ArrayLike
 type OctoMatrixLike = np.ndarray | pd.DataFrame
-
-PRED_TYPES = ["predict", "predict_proba"]
-type PredType = Literal["predict", "predict_proba"]
 
 
 class BaseModel(BaseEstimator):

--- a/octopus/models/regression_models.py
+++ b/octopus/models/regression_models.py
@@ -11,7 +11,7 @@ from sklearn.linear_model import ARDRegression, ElasticNet, Ridge
 from sklearn.svm import SVR
 from xgboost import XGBRegressor
 
-from octopus.types import FIComputeMethod, MLType
+from octopus.types import FIComputeMethod, MLType, ModelName
 
 from .config import ModelConfig
 from .core import Models
@@ -19,7 +19,7 @@ from .hyperparameter import CategoricalHyperparameter, FixedHyperparameter, Floa
 from .wrapper_models.GaussianProcessRegressor import GPRegressorWrapper
 
 
-@Models.register("ARDRegressor")
+@Models.register(ModelName.ARDRegressor)
 def ard_regressor() -> ModelConfig:
     """ARD regression model class."""
     return ModelConfig(
@@ -45,7 +45,7 @@ def ard_regressor() -> ModelConfig:
     )
 
 
-@Models.register("CatBoostRegressor")
+@Models.register(ModelName.CatBoostRegressor)
 def catboost_regressor() -> ModelConfig:
     """Cat boost regression model class."""
     return ModelConfig(
@@ -74,7 +74,7 @@ def catboost_regressor() -> ModelConfig:
     )
 
 
-@Models.register("ElasticNetRegressor")
+@Models.register(ModelName.ElasticNetRegressor)
 def elastic_net_regressor() -> ModelConfig:
     """ElasticNet regression model class."""
     return ModelConfig(
@@ -99,7 +99,7 @@ def elastic_net_regressor() -> ModelConfig:
     )
 
 
-@Models.register("ExtraTreesRegressor")
+@Models.register(ModelName.ExtraTreesRegressor)
 def extra_trees_regressor() -> ModelConfig:
     """ExtraTrees regression model class."""
     return ModelConfig(
@@ -123,7 +123,7 @@ def extra_trees_regressor() -> ModelConfig:
     )
 
 
-@Models.register("GaussianProcessRegressor")
+@Models.register(ModelName.GaussianProcessRegressor)
 def gaussian_process_regressor() -> ModelConfig:
     """Gaussian process regression model class."""
     return ModelConfig(
@@ -148,7 +148,7 @@ def gaussian_process_regressor() -> ModelConfig:
     )
 
 
-@Models.register("GradientBoostingRegressor")
+@Models.register(ModelName.GradientBoostingRegressor)
 def gradient_boosting_regressor() -> ModelConfig:
     """Gradient boost regression model class."""
     return ModelConfig(
@@ -173,7 +173,7 @@ def gradient_boosting_regressor() -> ModelConfig:
     )
 
 
-@Models.register("RandomForestRegressor")
+@Models.register(ModelName.RandomForestRegressor)
 def random_forest_regressor() -> ModelConfig:
     """Random forrest regression model class."""
     return ModelConfig(
@@ -197,7 +197,7 @@ def random_forest_regressor() -> ModelConfig:
     )
 
 
-@Models.register("RidgeRegressor")
+@Models.register(ModelName.RidgeRegressor)
 def ridge_regressor() -> ModelConfig:
     """Ridge regression model class."""
     return ModelConfig(
@@ -218,7 +218,7 @@ def ridge_regressor() -> ModelConfig:
     )
 
 
-@Models.register("SvrRegressor")
+@Models.register(ModelName.SvrRegressor)
 def svr_regressor() -> ModelConfig:
     """Svr regression model class."""
     return ModelConfig(
@@ -240,7 +240,7 @@ def svr_regressor() -> ModelConfig:
     )
 
 
-@Models.register("XGBRegressor")
+@Models.register(ModelName.XGBRegressor)
 def xgb_regressor() -> ModelConfig:
     """XGBoost regression model class."""
     return ModelConfig(
@@ -266,7 +266,7 @@ def xgb_regressor() -> ModelConfig:
     )
 
 
-@Models.register("HistGradientBoostingRegressor")
+@Models.register(ModelName.HistGradientBoostingRegressor)
 def hist_gradient_boosting_regressor() -> ModelConfig:
     """Histogram-based gradient boosting regression model class (scikit-learn 1.6.1)."""
     return ModelConfig(
@@ -292,7 +292,7 @@ def hist_gradient_boosting_regressor() -> ModelConfig:
     )
 
 
-@Models.register("TabularNNRegressor")
+@Models.register(ModelName.TabularNNRegressor)
 def tabular_nn_regressor() -> ModelConfig:
     """Tabular Neural Network regression model class with categorical embeddings."""
     from .wrapper_models.TabularNNRegressor import TabularNNRegressor  # noqa: PLC0415

--- a/octopus/models/time_to_event_models.py
+++ b/octopus/models/time_to_event_models.py
@@ -1,6 +1,6 @@
 """Time to event models."""
 
-from octopus.types import MLType
+from octopus.types import FIComputeMethod, MLType, ModelName
 
 from .config import ModelConfig
 from .core import Models
@@ -9,13 +9,13 @@ from .wrapper_models.CatBoostCoxSurvival import CatBoostCoxSurvival
 from .wrapper_models.XGBoostCoxSurvival import XGBoostCoxSurvival
 
 
-@Models.register("CatBoostCoxSurvival")
+@Models.register(ModelName.CatBoostCoxSurvival)
 def catboost_cox_survival() -> ModelConfig:
     """CatBoost Cox survival model config."""
     return ModelConfig(
         model_class=CatBoostCoxSurvival,  # type: ignore[arg-type]
         ml_types=[MLType.TIMETOEVENT],
-        feature_method="internal",
+        feature_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -37,13 +37,13 @@ def catboost_cox_survival() -> ModelConfig:
     )
 
 
-@Models.register("XGBoostCoxSurvival")
+@Models.register(ModelName.XGBoostCoxSurvival)
 def xgboost_cox_survival() -> ModelConfig:
     """XGBoost Cox survival model config."""
     return ModelConfig(
         model_class=XGBoostCoxSurvival,  # type: ignore[arg-type]
         ml_types=[MLType.TIMETOEVENT],
-        feature_method="internal",
+        feature_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,

--- a/octopus/modules/autogluon/module.py
+++ b/octopus/modules/autogluon/module.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 from attrs import define, field, validators
 
+from octopus.types import AutoGluonFitStrategy
+
 from ..base import ModuleExecution, Task
 
 
@@ -43,8 +45,10 @@ class AutoGluon(Task):
     )
     """Memory limit in GB."""
 
-    fit_strategy: Literal["sequential", "parallel"] = field(
-        default="sequential", validator=validators.in_(["sequential", "parallel"])
+    fit_strategy: AutoGluonFitStrategy = field(
+        default=AutoGluonFitStrategy.SEQUENTIAL,
+        converter=AutoGluonFitStrategy,
+        validator=validators.in_(list(AutoGluonFitStrategy)),
     )
     """Model fitting strategy."""
 

--- a/octopus/modules/efs/core.py
+++ b/octopus/modules/efs/core.py
@@ -7,7 +7,7 @@ import itertools
 import json
 import random
 from collections import Counter
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -17,7 +17,7 @@ from sklearn.model_selection import GridSearchCV, KFold, StratifiedKFold, cross_
 from octopus.metrics import Metrics
 from octopus.models import Models
 from octopus.modules import ModuleExecution, ModuleResult, StudyContext
-from octopus.types import DataPartition, FIResultLabel, MLType, ModelName, ResultType
+from octopus.types import DataPartition, FIResultLabel, MetricDirection, MLType, ModelName, PredictionType, ResultType
 
 if TYPE_CHECKING:
     from upath import UPath
@@ -87,9 +87,7 @@ class EfsModule(ModuleExecution["Efs"]):
         y_traindev = data_traindev[list(study_context.target_assignments.values())]
         row_traindev = data_traindev[study_context.row_id_col]
 
-        metric_input: Literal["predictions", "probabilities"] = (
-            "probabilities" if study_context.target_metric in ["AUCROC", "LOGLOSS"] else "predictions"
-        )
+        metric_input = Metrics.get_instance(study_context.target_metric).prediction_type
         direction = Metrics.get_direction(study_context.target_metric)
 
         self._create_modeltable(
@@ -154,8 +152,8 @@ class EfsModule(ModuleExecution["Efs"]):
         y_traindev: pd.DataFrame,
         row_traindev: pd.Series,
         feature_cols: list[str],
-        metric_input: Literal["predictions", "probabilities"],
-        direction: Literal["maximize", "minimize"],
+        metric_input: PredictionType,
+        direction: MetricDirection,
     ):
         """Create model table."""
         print("Creating model table.")
@@ -241,7 +239,7 @@ class EfsModule(ModuleExecution["Efs"]):
 
             # ensemble metric
             metric = Metrics.get_instance(study_context.target_metric)
-            if metric_input == "probabilities":
+            if metric_input == PredictionType.PROBABILITIES:
                 best_ensel_performance = metric.calculate(y, cv_preds_df["probabilities"])  # type: ignore[arg-type]
             else:
                 best_ensel_performance = metric.calculate(y, cv_preds_df["predictions"])  # type: ignore[arg-type]
@@ -268,7 +266,7 @@ class EfsModule(ModuleExecution["Efs"]):
 
         # order of table is important, depending on metric,
         # (a) direction (b) dev_pool_soft or dev_pool_hard
-        ascending = direction != "maximize"
+        ascending = direction != MetricDirection.MAXIMIZE
 
         self.model_table_ = self.model_table_.sort_values(by="performance", ascending=ascending).reset_index(drop=True)
 
@@ -276,7 +274,7 @@ class EfsModule(ModuleExecution["Efs"]):
         self,
         study_context: StudyContext,
         y_traindev: pd.DataFrame,
-        metric_input: Literal["predictions", "probabilities"],
+        metric_input: PredictionType,
         model_ids,
     ) -> float:
         """Ensemble predictions of models in model_table."""
@@ -299,7 +297,7 @@ class EfsModule(ModuleExecution["Efs"]):
         y = y_traindev.squeeze(axis=1)
         ensel_performance = (
             metric.calculate(y, model_predictions)  # type: ignore[arg-type]
-            if metric_input == "predictions"
+            if metric_input == PredictionType.PREDICTIONS
             else metric.calculate(y, groupby_df["probabilities"])  # type: ignore[arg-type]
         )
 
@@ -309,8 +307,8 @@ class EfsModule(ModuleExecution["Efs"]):
         self,
         study_context: StudyContext,
         y_traindev: pd.DataFrame,
-        metric_input: Literal["predictions", "probabilities"],
-        direction: Literal["maximize", "minimize"],
+        metric_input: PredictionType,
+        direction: MetricDirection,
     ):
         """Perform ensemble scan."""
         # (B) perform ensemble scan, hillclimb
@@ -328,7 +326,7 @@ class EfsModule(ModuleExecution["Efs"]):
                 self._ensemble_models(study_context, y_traindev, metric_input, model_ids),
             ]
 
-        if direction == "maximize":
+        if direction == MetricDirection.MAXIMIZE:
             n_best_models = self.scan_table_.loc[self.scan_table_["performance"].idxmax()]["#models"]
             best_performance = self.scan_table_.loc[self.scan_table_["performance"].idxmax()]["performance"]
         else:  # minimize
@@ -343,14 +341,16 @@ class EfsModule(ModuleExecution["Efs"]):
         self,
         study_context: StudyContext,
         y_traindev: pd.DataFrame,
-        metric_input: Literal["predictions", "probabilities"],
-        direction: Literal["maximize", "minimize"],
+        metric_input: PredictionType,
+        direction: MetricDirection,
     ):
         """Ensembling optimization with replacement."""
         # we start with an best N models example derived from self.scan_table_,
         # assuming that is sorted correctly
         best_performance = (
-            self.scan_table_["performance"].max() if direction == "maximize" else self.scan_table_["performance"].min()
+            self.scan_table_["performance"].max()
+            if direction == MetricDirection.MAXIMIZE
+            else self.scan_table_["performance"].min()
         )
         # get the last index with best performance
         best_rows = self.scan_table_[self.scan_table_["performance"] == best_performance]
@@ -393,7 +393,7 @@ class EfsModule(ModuleExecution["Efs"]):
                 df.loc[len(df)] = [model, perf]
             df["model"] = df["model"].astype(int)
 
-            if direction == "maximize":
+            if direction == MetricDirection.MAXIMIZE:
                 best_performance = df["performance"].max()
                 best_rows = df[df["performance"] == best_performance]
                 random_best_row = best_rows.sample(n=1, random_state=42)

--- a/octopus/modules/mrmr/core.py
+++ b/octopus/modules/mrmr/core.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -12,7 +12,7 @@ from sklearn.feature_selection import f_classif, f_regression
 from octopus.logger import get_logger
 from octopus.modules import ModuleExecution, ModuleResult
 from octopus.modules.utils import rdc_correlation_matrix
-from octopus.types import FIResultLabel, LogGroup, MLType, ResultType
+from octopus.types import CorrelationType, FIResultLabel, LogGroup, MLType, MRMRRelevance, ResultType
 
 if TYPE_CHECKING:
     from octopus.modules import StudyContext
@@ -82,7 +82,7 @@ class MrmrModule(ModuleExecution["Mrmr"]):
 
     def _validate_configuration(self, prior_results: dict) -> None:
         """Validate MRMR configuration."""
-        if self.config.relevance_type == "permutation":
+        if self.config.relevance_type == MRMRRelevance.PERMUTATION:
             if self.config.task_id == 0:
                 raise ValueError("MRMR module should not be the first workflow task.")
             fi_df = prior_results.get("feature_importances", pd.DataFrame())
@@ -116,9 +116,9 @@ class MrmrModule(ModuleExecution["Mrmr"]):
         prior_results: dict,
     ) -> pd.DataFrame:
         """Get relevance data based on relevance type."""
-        if self.config.relevance_type == "permutation":
+        if self.config.relevance_type == MRMRRelevance.PERMUTATION:
             return self._get_permutation_relevance(feature_cols, prior_results)
-        elif self.config.relevance_type == "f-statistics":
+        elif self.config.relevance_type == MRMRRelevance.F_STATISTICS:
             return self._get_fstats_relevance(x_traindev, y_traindev, feature_cols, ml_type)
         else:
             raise ValueError(f"Relevance type {self.config.relevance_type} not supported for MRMR.")
@@ -175,8 +175,7 @@ def _maxrminr(
     features: pd.DataFrame,
     relevance: pd.DataFrame,
     requested_feature_counts: list[int],
-    correlation_type: Literal["pearson", "spearman", "rdc"] = "pearson",
-    method: Literal["ratio", "difference"] = "ratio",
+    correlation_type: CorrelationType = CorrelationType.PEARSON,
 ) -> dict[int, list[str]]:
     """Perform mRMR feature selection.
 
@@ -187,8 +186,7 @@ def _maxrminr(
         features: Dataset with columns as feature names
         relevance: DataFrame with "feature" and "importance" columns
         requested_feature_counts: List of feature counts for partial snapshots
-        correlation_type: Correlation method ("pearson", "spearman", or "rdc")
-        method: Score method ("ratio" or "difference")
+        correlation_type: Correlation method (CorrelationType.PEARSON, CorrelationType.SPEARMAN, or CorrelationType.RDC)
 
     Returns:
         Dictionary mapping feature counts to lists of selected features
@@ -199,10 +197,6 @@ def _maxrminr(
     MIN_RED = 1e-6  # minimum redundancy to avoid division by zero
 
     # Validate arguments
-    if correlation_type not in {"pearson", "spearman", "rdc"}:
-        raise ValueError("correlation_type must be one of {'pearson','spearman','rdc'}")
-    if method not in {"ratio", "difference"}:
-        raise ValueError("method must be 'ratio' or 'difference'")
     if "feature" not in relevance.columns or "importance" not in relevance.columns:
         raise ValueError("relevance must contain 'feature' and 'importance' columns")
 
@@ -236,7 +230,7 @@ def _maxrminr(
         raise ValueError(f"Some relevant feature columns contain non-numeric/NaN values: {bad_cols}")
 
     # Calculate correlation matrix
-    if correlation_type in {"pearson", "spearman"}:
+    if correlation_type in (CorrelationType.PEARSON, CorrelationType.SPEARMAN):
         corr = feats.corr(method=correlation_type).abs()
     else:  # rdc
         corr_vals = rdc_correlation_matrix(feats)
@@ -264,10 +258,7 @@ def _maxrminr(
             mean_red = mean_red.fillna(LARGE_RED).clip(lower=MIN_RED)
 
             candidates["redundancy"] = mean_red.values
-            if method == "ratio":
-                candidates["score"] = candidates["importance"] / candidates["redundancy"]
-            else:
-                candidates["score"] = candidates["importance"] - candidates["redundancy"]
+            candidates["score"] = candidates["importance"] / candidates["redundancy"]
 
         # Replace infinite scores with NaN
         candidates["score"] = candidates["score"].replace([np.inf, -np.inf], np.nan)

--- a/octopus/modules/mrmr/module.py
+++ b/octopus/modules/mrmr/module.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Literal
-
 from attrs import Factory, define, field, validators
 
-from octopus.types import FIComputeMethod
+from octopus.types import CorrelationType, FIComputeMethod, MRMRFIAggregation, MRMRRelevance
 
 from ..base import ModuleExecution, Task
 
@@ -22,22 +20,24 @@ class Mrmr(Task):
     Configuration:
         n_features: Number of features to select
         correlation_type: Type of correlation to measure redundancy
-        relevance_type: Method to calculate relevance ("permutation" or "f-statistics")
+        relevance_type: Method to calculate relevance (MRMRRelevance.PERMUTATION or MRMRRelevance.INTERNAL)
         results_module: Module name to filter prior results' feature importances (for permutation relevance)
-        feature_importance_type: Type of FI aggregation ("mean" or "count")
-        feature_importance_method: FI calculation method
+        feature_importance_type: Type of FI aggregation (MRMRFIAggregation.MEAN or MRMRFIAggregation.COUNT)
+        feature_importance_method: FI calculation method (FIComputeMethod.PERMUTATION, FIComputeMethod.SHAP, FIComputeMethod.INTERNAL, FIComputeMethod.LOFO)
     """
 
     n_features: int = field(validator=[validators.instance_of(int)], default=Factory(lambda: 30))
     """Number of features selected by MRMR."""
 
-    correlation_type: Literal["pearson", "rdc", "spearman"] = field(
-        validator=validators.in_(["pearson", "rdc", "spearman"]), default="spearman"
+    correlation_type: CorrelationType = field(
+        converter=CorrelationType,
+        validator=validators.in_([CorrelationType.PEARSON, CorrelationType.SPEARMAN, CorrelationType.RDC]),
+        default=CorrelationType.SPEARMAN,
     )
     """Selection of correlation type."""
 
-    relevance_type: Literal["permutation", "f-statistics"] = field(
-        validator=validators.in_(["permutation", "f-statistics"]), default="permutation"
+    relevance_type: MRMRRelevance = field(
+        converter=MRMRRelevance, validator=validators.in_(list(MRMRRelevance)), default=MRMRRelevance.PERMUTATION
     )
     """Selection of relevance measure."""
 
@@ -47,8 +47,8 @@ class Mrmr(Task):
     )
     """Module name from which feature importances were created."""
 
-    feature_importance_type: Literal["mean", "count"] = field(
-        validator=validators.in_(["mean", "count"]), default="mean"
+    feature_importance_type: MRMRFIAggregation = field(
+        converter=MRMRFIAggregation, validator=validators.in_(list(MRMRFIAggregation)), default=MRMRFIAggregation.MEAN
     )
     """Selection of feature importance type."""
 

--- a/octopus/modules/octo/bag.py
+++ b/octopus/modules/octo/bag.py
@@ -710,12 +710,12 @@ class BagBase(BaseEstimator):
         # internal, permutation_dev, shap_dev only
         # save in bag
         for method in fi_methods:
-            if method == "internal":
+            if method == FIComputeMethod.INTERNAL:
                 method_str = "internal"
-            elif method == "constant":
+            elif method == FIComputeMethod.CONSTANT:
                 method_str = "constant"
             else:
-                method_str = method + "_dev"
+                method_str = method.value + "_dev"
             fi_pool = []
             for training in self.trainings:
                 fi_pool.append(training.feature_importances[method_str])

--- a/octopus/modules/octo/core.py
+++ b/octopus/modules/octo/core.py
@@ -17,7 +17,7 @@ from octopus.metrics import Metrics
 from octopus.models import Models
 from octopus.modules import ModuleExecution, ModuleResult
 from octopus.modules.mrmr.core import _maxrminr, _relevance_fstats
-from octopus.types import LogGroup, ResultType
+from octopus.types import CorrelationType, LogGroup, MetricDirection, ResultType
 from octopus.utils import joblib_load, parquet_save
 
 from .bag import Bag
@@ -220,7 +220,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             features=x_traindev,
             relevance=re_df,
             requested_feature_counts=feature_numbers,
-            correlation_type="spearman",
+            correlation_type=CorrelationType.SPEARMAN,
         )
         # add original features
         self.mrmr_features_[len(feature_cols)] = feature_cols
@@ -375,7 +375,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         # create study with in-memory storage
         study = optuna.create_study(
             study_name=study_name,
-            direction="maximize",  # metric adjustment in optuna objective
+            direction=MetricDirection.MAXIMIZE,  # metric adjustment in optuna objective
             sampler=sampler,
         )
 

--- a/octopus/modules/octo/enssel.py
+++ b/octopus/modules/octo/enssel.py
@@ -20,6 +20,7 @@ from upath import UPath
 from octopus.logger import get_logger
 from octopus.metrics import Metrics
 from octopus.metrics.utils import get_performance_from_predictions
+from octopus.types import MetricDirection
 from octopus.utils import joblib_load
 
 logger = get_logger()
@@ -50,7 +51,7 @@ class EnSel:
     bags: dict[UPath, dict[str, Any]] = field(init=False, validator=[validators.instance_of(dict)])
 
     @property
-    def direction(self) -> str:
+    def direction(self) -> MetricDirection:
         """Optuna direction."""
         return Metrics.get_direction(self.target_metric)
 
@@ -98,7 +99,7 @@ class EnSel:
 
         # order of table is important, depending on metric,
         # (a) direction
-        ascending = self.direction != "maximize"
+        ascending = self.direction != MetricDirection.MAXIMIZE
 
         self.model_table = self.model_table.sort_values(by="dev_pool", ascending=ascending).reset_index(drop=True)
 
@@ -185,7 +186,7 @@ class EnSel:
         assuming that it is sorted correctly. When there are multiple rows
         with the same best value, we take the last one (more models).
         """
-        if self.direction == "maximize":
+        if self.direction == MetricDirection.MAXIMIZE:
             # Get all indices with the max value, then take the last one
             best_value = self.scan_table["dev_pool"].max()
             best_idx = self.scan_table[self.scan_table["dev_pool"] == best_value].index[-1]
@@ -226,7 +227,7 @@ class EnSel:
                 perf = self._ensemble_models(bags_lst)
                 df.loc[len(df)] = [model, perf["dev_pool"], perf["test_pool"]]
 
-            if self.direction == "maximize":
+            if self.direction == MetricDirection.MAXIMIZE:
                 idx_best = df["performance_dev"].idxmax()
                 best_model: UPath = df.loc[idx_best]["model"]
                 best_performance: float = df.loc[idx_best]["performance_dev"]  # type: ignore[assignment]

--- a/octopus/modules/octo/module.py
+++ b/octopus/modules/octo/module.py
@@ -9,7 +9,7 @@ from attrs import Factory, define, field, validators
 from octopus.logger import get_logger
 from octopus.models import Models
 from octopus.modules import ModuleExecution, Task
-from octopus.types import FIComputeMethod, ModelName
+from octopus.types import FIComputeMethod, ModelName, OptunaReturnType
 
 logger = get_logger()
 
@@ -113,7 +113,11 @@ class Octo(Task):
     mrmr_feature_numbers: list = field(validator=[validators.instance_of(list)], default=Factory(list))
     """List of feature numbers to be investigated by mrmr."""
 
-    optuna_return: str = field(default="pool", validator=[validators.in_(["pool", "average"])])
+    optuna_return: OptunaReturnType = field(
+        default=OptunaReturnType.POOL,
+        converter=OptunaReturnType,
+        validator=validators.in_(list(OptunaReturnType)),
+    )
     """How to calculate the bag performance for the optuna optimization target."""
 
     def __attrs_post_init__(self):

--- a/octopus/modules/octo/objective_optuna.py
+++ b/octopus/modules/octo/objective_optuna.py
@@ -8,7 +8,7 @@ from octopus.datasplit import InnerSplits
 from octopus.logger import get_logger
 from octopus.metrics import Metrics
 from octopus.models import Models
-from octopus.types import LogGroup, MLType, ModelName
+from octopus.types import LogGroup, MetricDirection, MLType, ModelName, OptunaReturnType
 from octopus.utils import joblib_save
 
 from .bag import Bag, BagClassifier, BagRegressor
@@ -182,14 +182,14 @@ class ObjectiveOptuna:
         self._log_trial_scores(bag_performance)
 
         # define optuna target
-        if self.config.optuna_return == "pool":
+        if self.config.optuna_return == OptunaReturnType.POOL:
             optuna_target = bag_performance["dev_pool"]
         else:
             optuna_target = bag_performance["dev_avg"]
 
         # adjust direction, optuna in octofull always minimizes
         target_metric = self.target_metric
-        if Metrics.get_direction(target_metric) == "minimize":
+        if Metrics.get_direction(target_metric) == MetricDirection.MINIMIZE:
             optuna_target = -optuna_target
 
         # add penaltiy for n_features > max_features if configured

--- a/octopus/modules/octo/training.py
+++ b/octopus/modules/octo/training.py
@@ -684,7 +684,7 @@ class Training:
     def calculate_fi_featuresused_shap(self, partition="dev", bg_max=200):
         """SHAP feature importance (for calc_features_used) with robust fallbacks.
 
-        Used when model property: feature_method = "shap". The shap method used is automatically determined
+        Used when model property: feature_method = FIComputeMethod.SHAP. The shap method used is automatically determined
         by shap. The main advantage is that for linear and tree model the feature importances are calculated
         much faster.
         """

--- a/octopus/modules/rfe/core.py
+++ b/octopus/modules/rfe/core.py
@@ -15,7 +15,7 @@ from octopus.metrics import Metrics
 from octopus.metrics.utils import get_score_from_model
 from octopus.models import Models
 from octopus.modules import ModuleExecution, ModuleResult
-from octopus.types import DataPartition, FIResultLabel, MLType, ModelName, ResultType
+from octopus.types import DataPartition, FIResultLabel, MLType, ModelName, ResultType, RFEMode
 
 if TYPE_CHECKING:
     from upath import UPath
@@ -141,10 +141,10 @@ class RfeModule(ModuleExecution["Rfe"]):
         print(f"Best params: {best_params}")
 
         # Select estimator based on mode
-        if self.config.mode == "Mode1":
+        if self.config.mode == RFEMode.FIXED:
             # RFE with the trained model
             estimator = best_model
-        elif self.config.mode == "Mode2":
+        elif self.config.mode == RFEMode.REFIT:
             # RFE with hyperparameter optimization at each step
             estimator = grid_search
         else:

--- a/octopus/modules/rfe/module.py
+++ b/octopus/modules/rfe/module.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from attrs import define, field, validators
 
+from octopus.types import RFEMode
+
 from ..base import ModuleExecution, Task
 
 
@@ -19,7 +21,7 @@ class Rfe(Task):
         step: Number of features to remove at each iteration
         min_features_to_select: Minimum number of features to keep
         cv: Number of CV folds for RFECV
-        mode: "Mode1" (use optimized model) or "Mode2" (reoptimize at each step)
+        mode: RFEMode.FIXED (use optimized model) or RFEMode.REFIT (reoptimize at each step)
     """
 
     model: str = field(validator=[validators.instance_of(str)], default="")
@@ -34,8 +36,8 @@ class Rfe(Task):
     cv: int = field(validator=[validators.instance_of(int)], default=5)
     """Number of CV folds for RFE_CV."""
 
-    mode: str = field(validator=[validators.in_(["Mode1", "Mode2"])], default="Mode1")
-    """Mode used by RFE: Mode1=optimized model, Mode2=reoptimize each step."""
+    mode: RFEMode = field(converter=RFEMode, validator=validators.in_(list(RFEMode)), default=RFEMode.FIXED)
+    """Mode used by RFE: fixed=optimized model, refit=reoptimize each step."""
 
     def create_module(self) -> ModuleExecution:
         """Create RfeModule execution instance."""

--- a/octopus/modules/rfe2/core.py
+++ b/octopus/modules/rfe2/core.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from octopus.modules import StudyContext
     from octopus.modules.octo.bag import BagBase
-from octopus.types import DataPartition, FIComputeMethod, FIResultLabel, ResultType
+from octopus.types import DataPartition, FIComputeMethod, FIResultLabel, ResultType, RFE2SelectionMethod
 
 
 @define
@@ -147,9 +147,9 @@ class Rfe2Module(OctoModuleTemplate[Rfe2]):
             self._print_step_information()
 
         # (4) Analyze results and select best model
-        if self.config.selection_method == "best":
+        if self.config.selection_method == RFE2SelectionMethod.BEST:
             selected_row = self.rfe_results_.loc[self.rfe_results_["performance_mean"].idxmax()]
-        elif self.config.selection_method == "parsimonious":
+        elif self.config.selection_method == RFE2SelectionMethod.PARSIMONIOUS:
             # best performance mean and sem
             best_performance_mean = self.rfe_results_["performance_mean"].max()
             best_performance_sem = self.rfe_results_.loc[

--- a/octopus/modules/rfe2/module.py
+++ b/octopus/modules/rfe2/module.py
@@ -6,7 +6,7 @@ from attrs import define, field, validators
 
 from octopus.modules import ModuleExecution
 from octopus.modules.octo.module import Octo
-from octopus.types import FIComputeMethod
+from octopus.types import FIComputeMethod, RFE2SelectionMethod
 
 
 @define
@@ -34,7 +34,11 @@ class Rfe2(Octo):
     )
     """Feature importance method for RFE."""
 
-    selection_method: str = field(validator=[validators.in_(["best", "parsimonious"])], default="best")
+    selection_method: RFE2SelectionMethod = field(
+        converter=RFE2SelectionMethod,
+        validator=validators.in_(list(RFE2SelectionMethod)),
+        default=RFE2SelectionMethod.BEST,
+    )
     """Method to select best solution. Parsimonious: smallest solutions within sem."""
 
     abs_on_fi: bool = field(validator=[validators.instance_of(bool)], default=False)

--- a/octopus/modules/roc/core.py
+++ b/octopus/modules/roc/core.py
@@ -20,7 +20,7 @@ from sklearn.feature_selection import (
 from octopus.logger import get_logger
 from octopus.modules import ModuleExecution, ModuleResult
 from octopus.modules.utils import rdc_correlation_matrix
-from octopus.types import MLType, ResultType
+from octopus.types import CorrelationType, MLType, ResultType, ROCFilterMethod
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -33,13 +33,13 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 # Filter functions for feature selection
-filter_inventory: dict[str, dict[MLType, Callable]] = {
-    "mutual_info": {
+filter_inventory: dict[ROCFilterMethod, dict[MLType, Callable]] = {
+    ROCFilterMethod.MUTUAL_INFO: {
         MLType.BINARY: mutual_info_classif,
         MLType.MULTICLASS: mutual_info_classif,
         MLType.REGRESSION: mutual_info_regression,
     },
-    "f_statistics": {
+    ROCFilterMethod.F_STATISTICS: {
         MLType.BINARY: f_classif,
         MLType.MULTICLASS: f_classif,
         MLType.REGRESSION: f_regression,
@@ -79,13 +79,13 @@ class RocModule(ModuleExecution["Roc"]):
         logger.info("Calculating dependency to target")
         if study_context.ml_type == MLType.TIMETOEVENT:
             logger.info("Time2Event: Note, that the first group element is selected.")
-        elif self.config.filter_type == "mutual_info":
+        elif self.config.filter_type == ROCFilterMethod.MUTUAL_INFO:
             # Set random state
             values = filter_inventory[self.config.filter_type][study_context.ml_type](
                 x_traindev, y_traindev.to_numpy().ravel(), random_state=0
             )
             dependency = pd.Series(values, index=feature_cols)
-        elif self.config.filter_type == "f_statistics":
+        elif self.config.filter_type == ROCFilterMethod.F_STATISTICS:
             # Ignoring p-values
             values, _ = filter_inventory[self.config.filter_type][study_context.ml_type](
                 x_traindev, y_traindev.to_numpy().ravel()
@@ -94,10 +94,10 @@ class RocModule(ModuleExecution["Roc"]):
 
         # Calculate correlation matrix
         logger.info("Calculating feature groups.")
-        if self.config.correlation_type == "spearmanr":
+        if self.config.correlation_type == CorrelationType.SPEARMAN:
             pos_corr_matrix, _ = scipy.stats.spearmanr(np.nan_to_num(x_traindev.values))
             pos_corr_matrix = np.abs(pos_corr_matrix)
-        elif self.config.correlation_type == "rdc":
+        elif self.config.correlation_type == CorrelationType.RDC:
             pos_corr_matrix = np.abs(rdc_correlation_matrix(x_traindev))
         else:
             raise ValueError(f"Correlation type {self.config.correlation_type} not supported")

--- a/octopus/modules/roc/module.py
+++ b/octopus/modules/roc/module.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from attrs import define, field, validators
 
+from octopus.types import CorrelationType, ROCFilterMethod
+
 from ..base import ModuleExecution, Task
 
 
@@ -18,19 +20,24 @@ class Roc(Task):
 
     Configuration:
         threshold: Correlation threshold above which features are considered correlated
-        correlation_type: Type of correlation measure ("spearmanr" or "rdc")
-        filter_type: Method to select best feature in group ("mutual_info" or "f_statistics")
+        correlation_type: Type of correlation measure (CorrelationType.SPEARMAN or CorrelationType.RDC)
+        filter_type: Method to select best feature in group (ROCFilterMethod.MUTUAL_INFO or ROCFilterMethod.F_STATISTICS)
     """
 
     threshold: float = field(validator=[validators.instance_of(float)], default=0.8)
     """Threshold for feature removal (features with correlation > threshold are grouped)."""
 
-    correlation_type: str = field(validator=[validators.in_(["spearmanr", "rdc"])], default="spearmanr")
+    correlation_type: CorrelationType = field(
+        converter=CorrelationType,
+        validator=validators.in_([CorrelationType.SPEARMAN, CorrelationType.RDC]),
+        default=CorrelationType.SPEARMAN,
+    )
     """Selection of correlation type."""
 
-    filter_type: str = field(
-        validator=[validators.in_(["mutual_info", "f_statistics"])],
-        default="f_statistics",
+    filter_type: ROCFilterMethod = field(
+        converter=ROCFilterMethod,
+        validator=validators.in_([ROCFilterMethod.MUTUAL_INFO, ROCFilterMethod.F_STATISTICS]),
+        default=ROCFilterMethod.F_STATISTICS,
     )
     """Selection of filter type for correlated features."""
 

--- a/octopus/modules/sfs/core.py
+++ b/octopus/modules/sfs/core.py
@@ -15,7 +15,7 @@ from octopus.metrics import Metrics
 from octopus.metrics.utils import get_score_from_model
 from octopus.models import Models
 from octopus.modules import ModuleExecution, ModuleResult
-from octopus.types import DataPartition, FIResultLabel, MLType, ModelName, ResultType
+from octopus.types import DataPartition, FIResultLabel, MLType, ModelName, ResultType, SFSDirection
 
 if TYPE_CHECKING:
     from upath import UPath
@@ -141,16 +141,16 @@ class SfsModule(ModuleExecution["Sfs"]):
         print(f"Number of features before SFS: {x_traindev.shape[1]}")
 
         # Select type of SFS
-        if self.config.sfs_type == "forward":
+        if self.config.sfs_type == SFSDirection.FORWARD:
             forward = True
             floating = False
-        elif self.config.sfs_type == "backward":
+        elif self.config.sfs_type == SFSDirection.BACKWARD:
             forward = False
             floating = False
-        elif self.config.sfs_type == "floating_forward":
+        elif self.config.sfs_type == SFSDirection.FLOATING_FORWARD:
             forward = True
             floating = True
-        elif self.config.sfs_type == "floating_backward":
+        elif self.config.sfs_type == SFSDirection.FLOATING_BACKWARD:
             forward = False
             floating = True
         else:

--- a/octopus/modules/sfs/module.py
+++ b/octopus/modules/sfs/module.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from attrs import define, field, validators
 
+from octopus.types import SFSDirection
+
 from ..base import ModuleExecution, Task
 
 
@@ -26,9 +28,8 @@ class Sfs(Task):
     cv: int = field(validator=[validators.instance_of(int)], default=5)
     """Number of CV folds for SFS."""
 
-    sfs_type: str = field(
-        validator=[validators.in_(["forward", "backward", "floating_forward", "floating_backward"])],
-        default="backward",
+    sfs_type: SFSDirection = field(
+        converter=SFSDirection, validator=validators.in_(list(SFSDirection)), default=SFSDirection.BACKWARD
     )
     """SFS type used."""
 

--- a/octopus/study/core.py
+++ b/octopus/study/core.py
@@ -17,7 +17,7 @@ from octopus.logger import get_logger, set_logger_filename
 from octopus.manager.core import OctoManager
 from octopus.metrics import Metrics
 from octopus.modules import Octo, StudyContext, Task
-from octopus.types import ImputationMethod, MLType
+from octopus.types import MLType
 from octopus.utils import csv_save, get_package_name, get_version, parquet_save
 
 from .data_preparator import OctoDataPreparator
@@ -61,12 +61,6 @@ class OctoStudy(ABC):
 
     datasplit_seed_outer: int = field(default=0, validator=[validators.instance_of(int)])
     """The seed used for data splitting in outer cross-validation. Defaults to 0."""
-
-    imputation_method: ImputationMethod = field(
-        default=ImputationMethod.MEDIAN,
-        converter=lambda x: ImputationMethod(x.lower()) if isinstance(x, str) else x,
-        validator=validators.instance_of(ImputationMethod),
-    )
 
     ignore_data_health_warning: bool = field(default=Factory(lambda: False), validator=[validators.instance_of(bool)])
     """Ignore data health checks warning and run machine learning workflow."""

--- a/octopus/study/healthChecker.py
+++ b/octopus/study/healthChecker.py
@@ -3,12 +3,13 @@
 import logging
 import re
 from itertools import combinations
-from typing import Literal
 
 import numpy as np
 import pandas as pd
 from attrs import define, field, validators
 from rapidfuzz import fuzz
+
+from octopus.types import CorrelationType
 
 from .data_preparator import DEFAULT_NULL_VALUES
 
@@ -499,7 +500,7 @@ class OctoDataHealthChecker:
                 ),
             )
 
-    def _check_feature_feature_correlation(self, method: Literal["pearson", "kendall", "spearman"] = "spearman"):
+    def _check_feature_feature_correlation(self, method: CorrelationType = CorrelationType.SPEARMAN):
         """Detect highly correlated feature pairs.
 
         Calculates pairwise correlations between all numeric features and identifies
@@ -520,7 +521,7 @@ class OctoDataHealthChecker:
         """
         threshold = self.config.feature_correlation_threshold
         numeric_features = self.data[self.feature_cols].select_dtypes(include=[float, int]).columns
-        corr_matrix = self.data[numeric_features].corr(method=method)
+        corr_matrix = self.data[numeric_features].corr(method=method)  # type: ignore[arg-type]
 
         highly_correlated: dict[str, set[str]] = {}
         corr_values = corr_matrix.values

--- a/octopus/study/types.py
+++ b/octopus/study/types.py
@@ -1,5 +1,0 @@
-"""Study types."""
-
-from octopus.types import ImputationMethod
-
-__all__ = ["ImputationMethod"]

--- a/octopus/types.py
+++ b/octopus/types.py
@@ -36,14 +36,6 @@ class LogGroup(Enum):
     AUTOGLUON = auto()
 
 
-class ImputationMethod(str, Enum):
-    """Imputation methods for handling missing data."""
-
-    MEDIAN = "median"
-    HALFMIN = "halfmin"
-    MICE = "mice"
-
-
 class ModelName(StrEnum):
     """Available model names.
 
@@ -51,9 +43,7 @@ class ModelName(StrEnum):
 
         Octo(task_id=0, models=[ModelName.XGBClassifier, ModelName.CatBoostClassifier])
 
-    Plain strings still work too::
-
-        Octo(task_id=0, models=["XGBClassifier", "CatBoostClassifier"])
+    Plain strings still work too, but `ModelName` keeps call sites consistent.
     """
 
     # Classification models
@@ -150,6 +140,148 @@ class ShapType(StrEnum):
     KERNEL = "kernel"
     PERMUTATION = "permutation"
     EXACT = "exact"
+
+
+class CorrelationType(StrEnum):
+    """Correlation method used for measuring feature-feature or feature-target relationships.
+
+    Used in:
+    - ``Mrmr.correlation_type``: redundancy measure between features
+    - ``Roc.correlation_type``: grouping correlated features for removal
+    - ``HealthChecker._check_feature_feature_correlation``: data health report
+    """
+
+    PEARSON = "pearson"
+    SPEARMAN = "spearman"
+    KENDALL = "kendall"
+    RDC = "rdc"
+
+
+class MRMRRelevance(StrEnum):
+    """Method used to compute feature relevance to the target in MRMR.
+
+    Used in ``Mrmr.relevance_type``:
+    - ``PERMUTATION``: re-uses permutation importances from a prior workflow module
+    - ``F_STATISTICS``: computes F-statistics (f_classif / f_regression) from scratch
+    """
+
+    PERMUTATION = "permutation"
+    F_STATISTICS = "f-statistics"
+
+
+class AutoGluonFitStrategy(StrEnum):
+    """Controls whether AutoGluon trains models sequentially or in parallel.
+
+    Used in ``AutoGluon.fit_strategy``, passed directly to ``TabularPredictor.fit()``.
+    """
+
+    SEQUENTIAL = "sequential"
+    PARALLEL = "parallel"
+
+
+class RFE2SelectionMethod(StrEnum):
+    """Strategy for picking the final feature set from the RFE2 scan results.
+
+    Used in ``Rfe2.selection_method``:
+    - ``BEST``: selects the step with the highest mean cross-validation performance
+    - ``PARSIMONIOUS``: selects the smallest feature set whose performance is within
+      one standard error of the best (bias-variance trade-off)
+    """
+
+    BEST = "best"
+    PARSIMONIOUS = "parsimonious"
+
+
+class ROCFilterMethod(StrEnum):
+    """Scoring method used to rank features within a correlated group in the ROC module.
+
+    The highest-scoring feature in each group is kept; the rest are removed.
+    Used in ``Roc.filter_type``.
+    """
+
+    MUTUAL_INFO = "mutual_info"
+    F_STATISTICS = "f_statistics"
+
+
+class SFSDirection(StrEnum):
+    """Search direction for Sequential Feature Selection (mlxtend SequentialFeatureSelector).
+
+    Used in ``Sfs.sfs_type``. Forward variants add features; backward variants remove them.
+    Floating variants allow backtracking after each add/remove step.
+    """
+
+    FORWARD = "forward"
+    BACKWARD = "backward"
+    FLOATING_FORWARD = "floating_forward"
+    FLOATING_BACKWARD = "floating_backward"
+
+
+class RFEMode(StrEnum):
+    """Execution mode for the RFE module.
+
+    Used in ``Rfe.mode``:
+    - ``FIXED``: runs RFE with the already-optimised model (faster)
+    - ``REFIT``: re-optimises the model at each elimination step (slower, potentially better)
+    """
+
+    FIXED = "fixed"
+    REFIT = "refit"
+
+
+class OptunaReturnType(StrEnum):
+    """Determines which bag performance statistic is used as the Optuna optimisation target.
+
+    Used in ``Octo.optuna_return``:
+    - ``POOL``: uses the pooled dev score across all inner folds (dev_pool)
+    - ``AVERAGE``: uses the average of per-fold dev scores (dev_avg)
+    """
+
+    POOL = "pool"
+    AVERAGE = "average"
+
+
+class MetricDirection(StrEnum):
+    """Optimisation direction passed to Optuna and used for sorting scan/ensemble results.
+
+    Derived from ``Metric.higher_is_better`` via ``Metric.direction`` and ``Metrics.get_direction()``.
+    Used in EFS scan/ensemble optimisation and diagnostics plots.
+    """
+
+    MAXIMIZE = "maximize"
+    MINIMIZE = "minimize"
+
+
+class PredictionType(StrEnum):
+    """The format in which a metric expects its predictions.
+
+    - ``PREDICTIONS``: the metric receives hard class labels (0/1 for binary,
+      integer class indices for multiclass, continuous values for regression).
+      For binary classification, these are derived by thresholding
+      ``predict_proba`` output — ``predict`` is not called directly.
+    - ``PROBABILITIES``: the metric receives raw probability scores or
+      continuous outputs directly from ``predict_proba``.
+
+    Used in:
+    - ``Metric.prediction_type``: declared per metric in the registry
+    - ``metrics/utils.py``: used to prepare the correct input before calling
+      the metric function
+    - ``EfsModule``: selects the correct column from the CV predictions table
+    """
+
+    PREDICTIONS = "predictions"
+    PROBABILITIES = "probabilities"
+
+
+class MRMRFIAggregation(StrEnum):
+    """How per-training feature importances are aggregated before MRMR relevance scoring.
+
+    Used in ``Mrmr.feature_importance_type``:
+    - ``MEAN``: averages importance values across training runs
+    - ``COUNT``: counts how often a feature has non-zero importance
+    """
+
+    MEAN = "mean"
+    COUNT = "count"
 
 
 ML_TYPES = [e.value for e in MLType]

--- a/tests/infrastructure/test_fsspec.py
+++ b/tests/infrastructure/test_fsspec.py
@@ -12,6 +12,7 @@ from upath import UPath
 
 from octopus.modules import Octo
 from octopus.study import OctoClassification
+from octopus.types import FIComputeMethod, ModelName
 from octopus.utils import joblib_load, joblib_save
 
 
@@ -174,11 +175,11 @@ class TestFSSpecIntegration:
                             task_id=0,
                             depends_on=None,
                             n_folds_inner=3,
-                            models=["ExtraTreesClassifier"],
+                            models=[ModelName.ExtraTreesClassifier],
                             model_seed=0,
                             n_jobs=1,
                             max_outl=0,
-                            fi_methods_bestbag=["permutation"],
+                            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
                             inner_parallelization=True,
                             n_workers=2,
                             optuna_seed=0,

--- a/tests/metrics/test_metrics_uniqueness.py
+++ b/tests/metrics/test_metrics_uniqueness.py
@@ -10,7 +10,7 @@ import pytest
 
 from octopus.metrics import Metrics
 from octopus.metrics.config import Metric
-from octopus.types import ML_TYPES, MLType
+from octopus.types import ML_TYPES, MLType, PredictionType
 
 
 class TestMetricsUniqueness:
@@ -121,7 +121,7 @@ class TestMetricsUniqueness:
 
     def test_all_metrics_have_valid_prediction_types(self):
         """Test that all metrics have valid prediction_type values."""
-        valid_prediction_types = {"predict", "predict_proba"}
+        valid_prediction_types = set(PredictionType)
         invalid_metrics = []
 
         for registry_key in self.all_metrics:

--- a/tests/modules/octo/test_ensemble_selection.py
+++ b/tests/modules/octo/test_ensemble_selection.py
@@ -10,11 +10,10 @@ from sklearn.metrics import mean_absolute_error
 from sklearn.model_selection import KFold
 from upath import UPath
 
-from octopus.models.model_name import ModelName
 from octopus.modules.octo.bag import Bag
 from octopus.modules.octo.enssel import EnSel
 from octopus.modules.octo.training import Training
-from octopus.types import MLType
+from octopus.types import MLType, ModelName
 from octopus.utils import joblib_save
 
 

--- a/tests/modules/octo/test_ensemble_selection_unit.py
+++ b/tests/modules/octo/test_ensemble_selection_unit.py
@@ -7,11 +7,10 @@ import pandas as pd
 from sklearn.linear_model import LinearRegression
 from upath import UPath
 
-from octopus.models.model_name import ModelName
 from octopus.modules.octo.bag import Bag
 from octopus.modules.octo.enssel import EnSel
 from octopus.modules.octo.training import Training
-from octopus.types import MLType
+from octopus.types import MLType, ModelName
 from octopus.utils import joblib_save
 
 # Utility functions for creating mock data and bags

--- a/tests/modules/roc/test_roc.py
+++ b/tests/modules/roc/test_roc.py
@@ -6,6 +6,7 @@ import pytest
 from sklearn.datasets import make_classification
 
 from octopus.modules import Roc
+from octopus.types import CorrelationType, ROCFilterMethod
 
 
 class TestRocModule:
@@ -19,8 +20,8 @@ class TestRocModule:
         assert roc.depends_on is None
         assert roc.description == ""
         assert roc.threshold == 0.8
-        assert roc.correlation_type == "spearmanr"
-        assert roc.filter_type == "f_statistics"
+        assert roc.correlation_type == CorrelationType.SPEARMAN
+        assert roc.filter_type == ROCFilterMethod.F_STATISTICS
         assert roc.module == "roc"
 
     def test_roc_module_initialization_custom_params(self):
@@ -30,25 +31,25 @@ class TestRocModule:
             depends_on=0,
             description="test_roc",
             threshold=0.9,
-            correlation_type="rdc",
-            filter_type="mutual_info",
+            correlation_type=CorrelationType.RDC,
+            filter_type=ROCFilterMethod.MUTUAL_INFO,
         )
 
         assert roc.task_id == 1
         assert roc.depends_on == 0
         assert roc.description == "test_roc"
         assert roc.threshold == 0.9
-        assert roc.correlation_type == "rdc"
-        assert roc.filter_type == "mutual_info"
+        assert roc.correlation_type == CorrelationType.RDC
+        assert roc.filter_type == ROCFilterMethod.MUTUAL_INFO
 
     def test_roc_module_invalid_correlation_type(self):
         """Test ROC module with invalid correlation type."""
-        with pytest.raises(ValueError, match="must be in"):
+        with pytest.raises(ValueError, match="is not a valid CorrelationType"):
             Roc(task_id=0, correlation_type="invalid_correlation")
 
     def test_roc_module_invalid_filter_type(self):
         """Test ROC module with invalid filter type."""
-        with pytest.raises(ValueError, match="must be in"):
+        with pytest.raises(ValueError, match="is not a valid ROCFilterMethod"):
             Roc(task_id=0, filter_type="invalid_filter")
 
     def test_roc_module_invalid_threshold_type(self):
@@ -67,13 +68,13 @@ class TestRocModule:
         roc = Roc(task_id=0, threshold=threshold)
         assert roc.threshold == threshold
 
-    @pytest.mark.parametrize("correlation_type", ["spearmanr", "rdc"])
+    @pytest.mark.parametrize("correlation_type", [CorrelationType.SPEARMAN, CorrelationType.RDC])
     def test_roc_module_correlation_types(self, correlation_type):
         """Test ROC module with different correlation types."""
         roc = Roc(task_id=0, correlation_type=correlation_type)
         assert roc.correlation_type == correlation_type
 
-    @pytest.mark.parametrize("filter_type", ["mutual_info", "f_statistics"])
+    @pytest.mark.parametrize("filter_type", [ROCFilterMethod.MUTUAL_INFO, ROCFilterMethod.F_STATISTICS])
     def test_roc_module_filter_types(self, filter_type):
         """Test ROC module with different filter types."""
         roc = Roc(task_id=0, filter_type=filter_type)
@@ -100,12 +101,12 @@ class TestRocIntegration:
             task_id=0,
             description="integration_test",
             threshold=0.85,
-            correlation_type="spearmanr",
-            filter_type="mutual_info",
+            correlation_type=CorrelationType.SPEARMAN,
+            filter_type=ROCFilterMethod.MUTUAL_INFO,
         )
 
         # Verify module configuration
         assert roc_module.threshold == 0.85
-        assert roc_module.correlation_type == "spearmanr"
-        assert roc_module.filter_type == "mutual_info"
+        assert roc_module.correlation_type == CorrelationType.SPEARMAN
+        assert roc_module.filter_type == ROCFilterMethod.MUTUAL_INFO
         assert roc_module.description == "integration_test"

--- a/tests/modules/test_mrmr.py
+++ b/tests/modules/test_mrmr.py
@@ -1,7 +1,6 @@
 """Test MRMR."""
 
 import time
-from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -9,6 +8,7 @@ import pytest
 from sklearn.datasets import make_regression
 
 from octopus.modules.mrmr.core import _maxrminr as maxrminr
+from octopus.types import CorrelationType
 
 
 def generate_sample_data(n_samples, n_features, random_state):
@@ -43,9 +43,9 @@ def test_mrmr_feature_selection_order(sample_data):
     (df_features, df_feature_importances), data_name = sample_data
 
     results = {
-        "pearson": maxrminr(df_features, df_feature_importances, [5], correlation_type="pearson"),
-        "spearman": maxrminr(df_features, df_feature_importances, [5], correlation_type="spearman"),
-        "rdc": maxrminr(df_features, df_feature_importances, [5], correlation_type="rdc"),
+        "pearson": maxrminr(df_features, df_feature_importances, [5], correlation_type=CorrelationType.PEARSON),
+        "spearman": maxrminr(df_features, df_feature_importances, [5], correlation_type=CorrelationType.SPEARMAN),
+        "rdc": maxrminr(df_features, df_feature_importances, [5], correlation_type=CorrelationType.RDC),
     }
 
     if data_name == "sample_data_1":
@@ -109,8 +109,7 @@ def test_mrmr_scalability(scalability_data):
     execution_times = {}
 
     # Test different correlation types: pearson only
-    types: list[Literal["pearson", "spearman", "rdc"]] = ["pearson"]
-    for corr_type in types:
+    for corr_type in [CorrelationType.PEARSON]:
         start_time = time.time()
 
         # Select top 20 features

--- a/tests/modules/test_training_feature_importances.py
+++ b/tests/modules/test_training_feature_importances.py
@@ -21,9 +21,8 @@ from octopus.models.hyperparameter import (
     FloatHyperparameter,
     IntHyperparameter,
 )
-from octopus.models.model_name import ModelName
 from octopus.modules.octo.training import Training, TrainingConfig
-from octopus.types import MLType
+from octopus.types import MLType, ModelName, ShapType
 
 
 class TEST_CONFIG:
@@ -181,7 +180,7 @@ def _run_fi_method(training: Training, method_name: str):
         training.calculate_fi_featuresused_shap(partition="dev")
         return ["shap_dev"]
     elif method_name == "calculate_fi_shap":
-        training.calculate_fi_shap(partition="dev", shap_type="permutation")
+        training.calculate_fi_shap(partition="dev", shap_type=ShapType.PERMUTATION)
         return ["shap_dev"]
     else:
         raise ValueError(f"Unknown method: {method_name}")

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -23,7 +23,6 @@ import plotly.graph_objects as go
 import pytest
 
 from octopus.example_data import load_breast_cancer_data
-from octopus.models import ModelName
 from octopus.modules import Octo
 from octopus.predict.notebook_utils import (
     display_table,
@@ -40,7 +39,7 @@ from octopus.predict.study_io import StudyLoader, StudyMetadata
 from octopus.predict.task_predictor import TaskPredictor
 from octopus.predict.task_predictor_test import TaskPredictorTest
 from octopus.study import OctoClassification
-from octopus.types import FIComputeMethod, FIType, MLType
+from octopus.types import FIComputeMethod, FIType, MLType, ModelName
 from octopus.utils import parquet_load
 
 # ── Prevent plotly from opening browser windows ─────────────────

--- a/tests/study/test_core.py
+++ b/tests/study/test_core.py
@@ -9,7 +9,7 @@ import pytest
 from octopus.modules import Octo
 from octopus.study import OctoClassification, OctoRegression
 from octopus.study.core import _RUNNING_IN_TESTSUITE
-from octopus.types import ImputationMethod, MLType
+from octopus.types import MLType
 
 
 @pytest.fixture
@@ -52,30 +52,18 @@ def test_initialization(basic_study):
     assert basic_study.sample_id_col == "sample_id_col"
 
 
-@pytest.mark.parametrize(
-    "study_class,param_name,param_value,expected_enum,kwargs",
-    [
-        (OctoRegression, "ml_type", "regression", MLType.REGRESSION, {"target_metric": "R2", "target_col": "target"}),
-        (
-            OctoClassification,
-            "imputation_method",
-            "halfmin",
-            ImputationMethod.HALFMIN,
-            {"target_metric": "AUCROC", "imputation_method": "halfmin", "target_col": "target"},
-        ),
-    ],
-)
-def test_string_to_enum_conversion(study_class, param_name, param_value, expected_enum, kwargs):
-    """Test that parameters accept strings and convert to enum types."""
+def test_regression_ml_type():
+    """Test that OctoRegression sets ml_type to regression."""
     with tempfile.TemporaryDirectory() as temp_dir:
-        study = study_class(
+        study = OctoRegression(
             name="test",
+            target_metric="R2",
             feature_cols=["f1"],
+            target_col="target",
             sample_id_col="id",
             path=temp_dir,
-            **kwargs,
         )
-        assert getattr(study, param_name) == expected_enum
+        assert study.ml_type == MLType.REGRESSION
 
 
 def test_default_workflow():
@@ -110,7 +98,6 @@ def test_default_values():
         assert study.positive_class is None  # positive_class is determined during data validation
         assert study.n_folds_outer == 5 if not _RUNNING_IN_TESTSUITE else 2
         assert study.datasplit_seed_outer == 0
-        assert study.imputation_method == ImputationMethod.MEDIAN
         assert study.ignore_data_health_warning is False
         assert study.outer_parallelization is True
         assert study.run_single_outersplit_num == -1

--- a/tests/study/test_validation.py
+++ b/tests/study/test_validation.py
@@ -6,6 +6,7 @@ import pytest
 
 from octopus.modules import Mrmr, Octo
 from octopus.study import OctoClassification
+from octopus.types import ModelName
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def octo_task():
         task_id=0,
         depends_on=None,
         description="step_1",
-        models=["RandomForestRegressor", "XGBRegressor"],
+        models=[ModelName.RandomForestRegressor, ModelName.XGBRegressor],
     )
 
 

--- a/tests/workflows/test_octo_classification.py
+++ b/tests/workflows/test_octo_classification.py
@@ -8,6 +8,7 @@ from sklearn.datasets import make_classification
 
 from octopus.modules import Octo
 from octopus.study import OctoClassification
+from octopus.types import FIComputeMethod, ModelName
 
 
 @pytest.mark.windows
@@ -83,8 +84,8 @@ class TestOctoIntroClassification:
             task_id=0,
             depends_on=None,
             n_folds_inner=3,
-            models=["ExtraTreesClassifier", "RandomForestClassifier"],
-            fi_methods_bestbag=["permutation"],
+            models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=3,
             optuna_seed=0,
@@ -102,9 +103,9 @@ class TestOctoIntroClassification:
         assert octo_task.description == "step_1_octo"
         assert octo_task.n_folds_inner == 3
         assert octo_task.models is not None
-        assert set(octo_task.models) == {"ExtraTreesClassifier", "RandomForestClassifier"}
+        assert set(octo_task.models) == {ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier}
 
-    @pytest.mark.parametrize("model", ["ExtraTreesClassifier", "RandomForestClassifier"])
+    @pytest.mark.parametrize("model", [ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier])
     def test_single_model_configuration(self, model):
         """Test configuration with different single models."""
         octo_task = Octo(
@@ -120,7 +121,7 @@ class TestOctoIntroClassification:
 
     def test_multiple_models_configuration(self):
         """Test configuration with multiple models."""
-        models = ["ExtraTreesClassifier", "RandomForestClassifier"]
+        models = [ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier]
         octo_task = Octo(
             description="step_1_octo",
             task_id=0,
@@ -134,12 +135,12 @@ class TestOctoIntroClassification:
 
     def test_feature_importance_configuration(self):
         """Test feature importance method configuration."""
-        fi_methods = ["permutation"]
+        fi_methods = [FIComputeMethod.PERMUTATION]
         octo_task = Octo(
             description="step_1_octo",
             task_id=0,
             depends_on=None,
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             fi_methods_bestbag=fi_methods,
             n_trials=3,
         )
@@ -152,7 +153,7 @@ class TestOctoIntroClassification:
             description="step_1_octo",
             task_id=0,
             depends_on=None,
-            models=["ExtraTreesClassifier", "RandomForestClassifier"],
+            models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
             ensemble_selection=True,
             ensel_n_save_trials=15,
             n_trials=5,
@@ -167,7 +168,7 @@ class TestOctoIntroClassification:
             description="step_1_octo",
             task_id=0,
             depends_on=None,
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             optuna_seed=42,
             n_optuna_startup_trials=5,
             n_trials=5,
@@ -206,11 +207,11 @@ class TestOctoIntroClassification:
                         task_id=0,
                         depends_on=None,
                         n_folds_inner=3,
-                        models=["ExtraTreesClassifier"],
+                        models=[ModelName.ExtraTreesClassifier],
                         model_seed=0,
                         n_jobs=1,
                         max_outl=0,
-                        fi_methods_bestbag=["permutation"],
+                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
                         inner_parallelization=True,
                         n_workers=2,
                         optuna_seed=0,
@@ -253,11 +254,11 @@ class TestOctoIntroClassification:
             task_id=0,
             depends_on=None,
             n_folds_inner=5,
-            models=["ExtraTreesClassifier", "RandomForestClassifier"],
+            models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
             model_seed=0,
             n_jobs=1,
             max_outl=0,
-            fi_methods_bestbag=["permutation"],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=5,
             optuna_seed=0,
@@ -276,11 +277,11 @@ class TestOctoIntroClassification:
 
         assert octo_task.n_folds_inner == 5
         assert octo_task.models is not None
-        assert set(octo_task.models) == {"ExtraTreesClassifier", "RandomForestClassifier"}
+        assert set(octo_task.models) == {ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier}
         assert octo_task.model_seed == 0
         assert octo_task.n_jobs == 1
         assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == ["permutation"]
+        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
         assert octo_task.inner_parallelization is True
         assert octo_task.n_workers == 5
         assert octo_task.optuna_seed == 0

--- a/tests/workflows/test_octo_multiclass.py
+++ b/tests/workflows/test_octo_multiclass.py
@@ -9,7 +9,7 @@ from sklearn.datasets import make_classification
 
 from octopus.modules import Octo
 from octopus.study import OctoClassification
-from octopus.types import MLType
+from octopus.types import FIComputeMethod, MLType, ModelName
 
 
 class TestOctoMulticlass:
@@ -94,15 +94,15 @@ class TestOctoMulticlass:
             depends_on=None,
             n_folds_inner=5,
             models=[
-                "ExtraTreesClassifier",
-                "RandomForestClassifier",
-                "XGBClassifier",
-                "CatBoostClassifier",
+                ModelName.ExtraTreesClassifier,
+                ModelName.RandomForestClassifier,
+                ModelName.XGBClassifier,
+                ModelName.CatBoostClassifier,
             ],
             model_seed=0,
             n_jobs=1,
             max_outl=0,
-            fi_methods_bestbag=["permutation"],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=5,
             n_trials=20,
@@ -115,14 +115,20 @@ class TestOctoMulticlass:
         assert octo_task.n_folds_inner == 5
         assert octo_task.models is not None
         assert set(octo_task.models) == {
-            "ExtraTreesClassifier",
-            "RandomForestClassifier",
-            "XGBClassifier",
-            "CatBoostClassifier",
+            ModelName.ExtraTreesClassifier,
+            ModelName.RandomForestClassifier,
+            ModelName.XGBClassifier,
+            ModelName.CatBoostClassifier,
         }
 
     @pytest.mark.parametrize(
-        "model", ["ExtraTreesClassifier", "RandomForestClassifier", "XGBClassifier", "CatBoostClassifier"]
+        "model",
+        [
+            ModelName.ExtraTreesClassifier,
+            ModelName.RandomForestClassifier,
+            ModelName.XGBClassifier,
+            ModelName.CatBoostClassifier,
+        ],
     )
     def test_multiclass_single_model_configuration(self, model):
         """Test configuration with different single multiclass models."""
@@ -139,7 +145,12 @@ class TestOctoMulticlass:
 
     def test_multiclass_multiple_models_configuration(self):
         """Test configuration with multiple multiclass models."""
-        models = ["ExtraTreesClassifier", "RandomForestClassifier", "XGBClassifier", "CatBoostClassifier"]
+        models = [
+            ModelName.ExtraTreesClassifier,
+            ModelName.RandomForestClassifier,
+            ModelName.XGBClassifier,
+            ModelName.CatBoostClassifier,
+        ]
         octo_task = Octo(
             description="step_1_octo_multiclass",
             task_id=0,
@@ -153,12 +164,12 @@ class TestOctoMulticlass:
 
     def test_feature_importance_configuration(self):
         """Test feature importance method configuration for multiclass."""
-        fi_methods = ["permutation"]
+        fi_methods = [FIComputeMethod.PERMUTATION]
         octo_task = Octo(
             description="step_1_octo_multiclass",
             task_id=0,
             depends_on=None,
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             fi_methods_bestbag=fi_methods,
             n_trials=5,
         )
@@ -171,7 +182,7 @@ class TestOctoMulticlass:
             description="step_1_octo_multiclass",
             task_id=0,
             depends_on=None,
-            models=["ExtraTreesClassifier"],
+            models=[ModelName.ExtraTreesClassifier],
             n_trials=25,
             n_folds_inner=5,
         )
@@ -204,11 +215,11 @@ class TestOctoMulticlass:
                         task_id=0,
                         depends_on=None,
                         n_folds_inner=3,
-                        models=["ExtraTreesClassifier"],
+                        models=[ModelName.ExtraTreesClassifier],
                         model_seed=0,
                         n_jobs=1,
                         max_outl=0,
-                        fi_methods_bestbag=["permutation"],
+                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
                         inner_parallelization=True,
                         n_workers=3,
                         n_trials=12,
@@ -247,15 +258,15 @@ class TestOctoMulticlass:
             depends_on=None,
             n_folds_inner=5,
             models=[
-                "ExtraTreesClassifier",
-                "RandomForestClassifier",
-                "XGBClassifier",
-                "CatBoostClassifier",
+                ModelName.ExtraTreesClassifier,
+                ModelName.RandomForestClassifier,
+                ModelName.XGBClassifier,
+                ModelName.CatBoostClassifier,
             ],
             model_seed=0,
             n_jobs=1,
             max_outl=0,
-            fi_methods_bestbag=["permutation"],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=5,
             n_trials=20,
@@ -269,15 +280,15 @@ class TestOctoMulticlass:
         assert octo_task.n_folds_inner == 5
         assert octo_task.models is not None
         assert set(octo_task.models) == {
-            "ExtraTreesClassifier",
-            "RandomForestClassifier",
-            "XGBClassifier",
-            "CatBoostClassifier",
+            ModelName.ExtraTreesClassifier,
+            ModelName.RandomForestClassifier,
+            ModelName.XGBClassifier,
+            ModelName.CatBoostClassifier,
         }
         assert octo_task.model_seed == 0
         assert octo_task.n_jobs == 1
         assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == ["permutation"]
+        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
         assert octo_task.inner_parallelization is True
         assert octo_task.n_workers == 5
         assert octo_task.n_trials == 20

--- a/tests/workflows/test_octo_regression.py
+++ b/tests/workflows/test_octo_regression.py
@@ -8,6 +8,7 @@ from sklearn.datasets import make_regression
 
 from octopus.modules import Octo
 from octopus.study import OctoRegression
+from octopus.types import FIComputeMethod, ModelName
 
 
 class TestOctoRegression:
@@ -76,12 +77,12 @@ class TestOctoRegression:
             depends_on=None,
             description="step_1",
             models=[
-                "RandomForestRegressor",
-                "XGBRegressor",
-                "ExtraTreesRegressor",
-                "ElasticNetRegressor",
-                "GradientBoostingRegressor",
-                "CatBoostRegressor",
+                ModelName.RandomForestRegressor,
+                ModelName.XGBRegressor,
+                ModelName.ExtraTreesRegressor,
+                ModelName.ElasticNetRegressor,
+                ModelName.GradientBoostingRegressor,
+                ModelName.CatBoostRegressor,
             ],
             n_trials=12,
             max_features=6,
@@ -99,12 +100,12 @@ class TestOctoRegression:
         assert octo_task.ensel_n_save_trials == 10
 
         expected_models = {
-            "RandomForestRegressor",
-            "XGBRegressor",
-            "ExtraTreesRegressor",
-            "ElasticNetRegressor",
-            "GradientBoostingRegressor",
-            "CatBoostRegressor",
+            ModelName.RandomForestRegressor,
+            ModelName.XGBRegressor,
+            ModelName.ExtraTreesRegressor,
+            ModelName.ElasticNetRegressor,
+            ModelName.GradientBoostingRegressor,
+            ModelName.CatBoostRegressor,
         }
         assert octo_task.models is not None
         assert set(octo_task.models) == expected_models
@@ -112,12 +113,12 @@ class TestOctoRegression:
     @pytest.mark.parametrize(
         "model",
         [
-            "RandomForestRegressor",
-            "XGBRegressor",
-            "ExtraTreesRegressor",
-            "ElasticNetRegressor",
-            "GradientBoostingRegressor",
-            "CatBoostRegressor",
+            ModelName.RandomForestRegressor,
+            ModelName.XGBRegressor,
+            ModelName.ExtraTreesRegressor,
+            ModelName.ElasticNetRegressor,
+            ModelName.GradientBoostingRegressor,
+            ModelName.CatBoostRegressor,
         ],
     )
     def test_single_model_configuration(self, model):
@@ -141,7 +142,7 @@ class TestOctoRegression:
 
     def test_multiple_models_configuration(self):
         """Test configuration with multiple models."""
-        models = ["RandomForestRegressor", "XGBRegressor", "ExtraTreesRegressor"]
+        models = [ModelName.RandomForestRegressor, ModelName.XGBRegressor, ModelName.ExtraTreesRegressor]
         octo_task = Octo(
             task_id=0,
             depends_on=None,
@@ -161,7 +162,7 @@ class TestOctoRegression:
             task_id=0,
             depends_on=None,
             description="step_1",
-            models=["RandomForestRegressor", "XGBRegressor"],
+            models=[ModelName.RandomForestRegressor, ModelName.XGBRegressor],
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
@@ -177,7 +178,7 @@ class TestOctoRegression:
             task_id=0,
             depends_on=None,
             description="step_1",
-            models=["RandomForestRegressor"],
+            models=[ModelName.RandomForestRegressor],
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
@@ -216,7 +217,7 @@ class TestOctoRegression:
                         task_id=0,
                         depends_on=None,
                         description="step_1",
-                        models=["RandomForestRegressor", "XGBRegressor"],
+                        models=[ModelName.RandomForestRegressor, ModelName.XGBRegressor],
                         n_trials=12,
                         max_features=6,
                         ensemble_selection=True,
@@ -262,12 +263,12 @@ class TestOctoRegression:
             depends_on=None,
             description="step_1",
             models=[
-                "RandomForestRegressor",
-                "XGBRegressor",
-                "ExtraTreesRegressor",
-                "ElasticNetRegressor",
-                "GradientBoostingRegressor",
-                "CatBoostRegressor",
+                ModelName.RandomForestRegressor,
+                ModelName.XGBRegressor,
+                ModelName.ExtraTreesRegressor,
+                ModelName.ElasticNetRegressor,
+                ModelName.GradientBoostingRegressor,
+                ModelName.CatBoostRegressor,
             ],
             n_trials=12,
             max_features=6,
@@ -276,7 +277,7 @@ class TestOctoRegression:
             model_seed=0,
             n_jobs=1,
             max_outl=0,
-            fi_methods_bestbag=["permutation"],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=5,
             optuna_seed=0,
@@ -291,19 +292,19 @@ class TestOctoRegression:
         assert octo_task.description == "step_1"
 
         expected_models = {
-            "RandomForestRegressor",
-            "XGBRegressor",
-            "ExtraTreesRegressor",
-            "ElasticNetRegressor",
-            "GradientBoostingRegressor",
-            "CatBoostRegressor",
+            ModelName.RandomForestRegressor,
+            ModelName.XGBRegressor,
+            ModelName.ExtraTreesRegressor,
+            ModelName.ElasticNetRegressor,
+            ModelName.GradientBoostingRegressor,
+            ModelName.CatBoostRegressor,
         }
         assert octo_task.models is not None
         assert set(octo_task.models) == expected_models
         assert octo_task.model_seed == 0
         assert octo_task.n_jobs == 1
         assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == ["permutation"]
+        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
         assert octo_task.inner_parallelization is True
         assert octo_task.n_workers == 5
         assert octo_task.optuna_seed == 0

--- a/tests/workflows/test_octo_t2e.py
+++ b/tests/workflows/test_octo_t2e.py
@@ -9,6 +9,7 @@ import pytest
 from octopus.models import ModelName
 from octopus.modules import Octo
 from octopus.study import OctoTimeToEvent
+from octopus.types import FIComputeMethod
 
 
 class TestOctoTimeToEvent:
@@ -223,7 +224,7 @@ class TestOctoTimeToEvent:
                         ensel_n_save_trials=10,
                         model_seed=0,
                         n_jobs=1,
-                        fi_methods_bestbag=["permutation"],
+                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
                         inner_parallelization=True,
                         n_workers=2,
                         optuna_seed=0,
@@ -270,7 +271,7 @@ class TestOctoTimeToEvent:
             model_seed=0,
             n_jobs=1,
             max_outl=0,
-            fi_methods_bestbag=["permutation"],
+            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
             inner_parallelization=True,
             n_workers=5,
             optuna_seed=0,
@@ -286,7 +287,7 @@ class TestOctoTimeToEvent:
         assert octo_task.model_seed == 0
         assert octo_task.n_jobs == 1
         assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == ["permutation"]
+        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
         assert octo_task.inner_parallelization is True
         assert octo_task.n_workers == 5
         assert octo_task.optuna_seed == 0

--- a/tests/workflows/test_roc_octo_roc_workflow.py
+++ b/tests/workflows/test_roc_octo_roc_workflow.py
@@ -9,6 +9,7 @@ from sklearn.datasets import make_classification
 
 from octopus.modules import Octo, Roc
 from octopus.study import OctoClassification
+from octopus.types import CorrelationType, FIComputeMethod, ModelName, ROCFilterMethod
 
 
 class TestRocOctoRocWorkflow:
@@ -58,19 +59,19 @@ class TestRocOctoRocWorkflow:
                 task_id=0,
                 depends_on=None,
                 threshold=0.85,
-                correlation_type="spearmanr",
-                filter_type="f_statistics",
+                correlation_type=CorrelationType.SPEARMAN,
+                filter_type=ROCFilterMethod.F_STATISTICS,
             ),
             Octo(
                 description="step_1_octo",
                 task_id=1,
                 depends_on=0,
                 n_folds_inner=3,
-                models=["ExtraTreesClassifier"],
+                models=[ModelName.ExtraTreesClassifier],
                 model_seed=0,
                 n_jobs=1,
                 max_outl=0,
-                fi_methods_bestbag=["permutation"],
+                fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
                 inner_parallelization=True,
                 n_trials=6,
             ),
@@ -79,8 +80,8 @@ class TestRocOctoRocWorkflow:
                 task_id=2,
                 depends_on=1,
                 threshold=0.5,
-                correlation_type="spearmanr",
-                filter_type="mutual_info",
+                correlation_type=CorrelationType.SPEARMAN,
+                filter_type=ROCFilterMethod.MUTUAL_INFO,
             ),
         ]
 
@@ -130,15 +131,15 @@ class TestRocOctoRocWorkflow:
                         task_id=0,
                         depends_on=None,
                         threshold=0.85,
-                        correlation_type="spearmanr",
-                        filter_type="f_statistics",
+                        correlation_type=CorrelationType.SPEARMAN,
+                        filter_type=ROCFilterMethod.F_STATISTICS,
                     ),
                     Octo(
                         description="step_1_octo",
                         task_id=1,
                         depends_on=0,
                         n_folds_inner=3,
-                        models=["ExtraTreesClassifier"],
+                        models=[ModelName.ExtraTreesClassifier],
                         model_seed=0,
                         n_jobs=1,
                         n_trials=15,
@@ -148,8 +149,8 @@ class TestRocOctoRocWorkflow:
                         task_id=2,
                         depends_on=1,
                         threshold=0.5,
-                        correlation_type="spearmanr",
-                        filter_type="mutual_info",
+                        correlation_type=CorrelationType.SPEARMAN,
+                        filter_type=ROCFilterMethod.MUTUAL_INFO,
                     ),
                 ],
             )
@@ -160,7 +161,7 @@ class TestRocOctoRocWorkflow:
         """Test that the sequence dependency chain is correctly configured."""
         workflow = [
             Roc(task_id=0, depends_on=None, threshold=0.85),
-            Octo(task_id=1, depends_on=0, models=["ExtraTreesClassifier"], n_trials=6),
+            Octo(task_id=1, depends_on=0, models=[ModelName.ExtraTreesClassifier], n_trials=6),
             Roc(task_id=2, depends_on=1, threshold=0.5),
         ]
 
@@ -188,8 +189,8 @@ class TestRocOctoRocWorkflow:
         # Verify that final ROC has more aggressive filtering
         assert second_roc.threshold < first_roc.threshold
 
-    @pytest.mark.parametrize("correlation_type", ["spearmanr", "rdc"])
-    @pytest.mark.parametrize("filter_type", ["f_statistics", "mutual_info"])
+    @pytest.mark.parametrize("correlation_type", [CorrelationType.SPEARMAN, CorrelationType.RDC])
+    @pytest.mark.parametrize("filter_type", [ROCFilterMethod.F_STATISTICS, ROCFilterMethod.MUTUAL_INFO])
     def test_roc_configuration_variations(self, correlation_type, filter_type):
         """Test ROC configuration with different correlation and filter types."""
         first_roc = Roc(
@@ -211,7 +212,7 @@ class TestRocOctoRocWorkflow:
             Octo(
                 task_id=1,
                 depends_on=0,
-                models=["ExtraTreesClassifier", "RandomForestClassifier"],
+                models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
                 n_trials=10,
                 max_features=15,
                 n_folds_inner=5,
@@ -224,7 +225,7 @@ class TestRocOctoRocWorkflow:
 
         assert isinstance(octo_step, Octo)
         assert octo_step.models is not None
-        assert set(octo_step.models) == {"ExtraTreesClassifier", "RandomForestClassifier"}
+        assert set(octo_step.models) == {ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier}
         assert octo_step.n_trials == 10
         assert octo_step.max_features == 15
         assert octo_step.n_folds_inner == 5
@@ -234,7 +235,7 @@ class TestRocOctoRocWorkflow:
         """Test that the workflow sequence is properly validated."""
         workflow = [
             Roc(task_id=0, depends_on=None, threshold=0.85),
-            Octo(task_id=1, depends_on=0, models=["ExtraTreesClassifier"], n_trials=6),
+            Octo(task_id=1, depends_on=0, models=[ModelName.ExtraTreesClassifier], n_trials=6),
             Roc(task_id=2, depends_on=1, threshold=0.5),
         ]
 
@@ -273,28 +274,28 @@ class TestRocOctoRocWorkflow:
                         task_id=0,
                         depends_on=None,
                         threshold=0.9,
-                        correlation_type="spearmanr",
-                        filter_type="f_statistics",
+                        correlation_type=CorrelationType.SPEARMAN,
+                        filter_type=ROCFilterMethod.F_STATISTICS,
                     ),
                     Octo(
                         description="step_1_octo",
                         task_id=1,
                         depends_on=0,
                         n_folds_inner=5,
-                        models=["ExtraTreesClassifier"],
+                        models=[ModelName.ExtraTreesClassifier],
                         model_seed=0,
                         n_jobs=1,
                         n_trials=13,
                         inner_parallelization=True,
-                        fi_methods_bestbag=["permutation"],
+                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
                     ),
                     Roc(
                         description="step_2_roc_final",
                         task_id=2,
                         depends_on=1,
                         threshold=0.5,
-                        correlation_type="spearmanr",
-                        filter_type="f_statistics",
+                        correlation_type=CorrelationType.SPEARMAN,
+                        filter_type=ROCFilterMethod.F_STATISTICS,
                     ),
                 ],
             )


### PR DESCRIPTION
## Replace string literals with enums

Replaces  bare string comparisons with `StrEnum` types. Fixes #267, #273, #344, #345, #377.

Three prior cleanups:
- ac1300ac313f929e222eb0c7159f5954d890d5d6: Remove unused MRMR scoring method, fixes #344
- ac1300ac313f929e222eb0c7159f5954d890d5d6: Normalized `"spearmanr"` → `"spearman"` everywhere (the ROC module had drifted from the rest), fixes #267
- 7615ae28039794ce1f7c975508f7860538649831: Merged `PredType` (`"predict"`/`"predict_proba"`) and the EFS `metric_input` concept (`"predictions"`/`"probabilities"`) into a single `PredictionType` enum — they encoded the same thing with different vocabulary, and EFS was re-deriving what `Metric.prediction_type` already knew via a hardcoded metric name list
- ad9cdd6fd67c1f5d7269928cebd3ea6004acd955: Remove unused `imputation_method` attribute from study and corresponding enum `ImputationMethod`, fixes #377 

New enums added to `octopus/types.py`:

- **`CorrelationType`** — correlation method in MRMR, ROC, and the health checker
- **`MRMRRelevance`** — whether MRMR uses permutation importances or F-statistics
- **`MRMRFIAggregation`** — how FI values are aggregated before MRMR scoring
- **`AutoGluonFitStrategy`** — sequential vs. parallel AutoGluon training
- **`RFE2SelectionMethod`** — best vs. parsimonious feature count selection in RFE2
- **`ROCFilterMethod`** — mutual info vs. F-statistics for ranking within correlated groups
- **`SFSDirection`** — forward/backward/floating search direction in SFS
- **`RFEMode`** — whether RFE re-optimises the model at each elimination step (renamed to `FIXED` and `REFIT`, fixes #345)
- **`OptunaReturnType`** — whether Optuna targets pooled or averaged bag performance
- **`MetricDirection`** — maximize vs. minimize, derived from `higher_is_better`
- **`PredictionType`** — whether a metric needs hard predictions or probabilities
