### PR TITLE
fix: replace outersplit dataset copies with row ID references

### DIFF
--- a/octopus/manager/workflow_runner.py
+++ b/octopus/manager/workflow_runner.py
@@ -13,7 +13,7 @@ from octopus.datasplit import OuterSplit
 from octopus.logger import get_logger
 from octopus.modules import ModuleResult, StudyContext, Task
 from octopus.types import ResultType
-from octopus.utils import calculate_feature_groups, parquet_save, rmtree
+from octopus.utils import calculate_feature_groups, rmtree
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -46,13 +46,17 @@ class WorkflowTaskRunner:
             outersplit: OuterSplit containing traindev and test DataFrames
             num_assigned_cpus: Number of CPUs assigned to this outer split for inner parallel processing
         """
-        # Save split data
+        # Save split row IDs (not full datasets) for reproducibility
         outer_split_dir = self.study_context.output_path / f"outersplit{outersplit_id}"
         outer_split_dir.mkdir(parents=True, exist_ok=True)
-        train_path = outer_split_dir / "data_traindev.parquet"
-        parquet_save(outersplit.traindev, train_path)
-        test_path = outer_split_dir / "data_test.parquet"
-        parquet_save(outersplit.test, test_path)
+        row_id_col = self.study_context.row_id_col
+        split_ids = {
+            "row_id_col": row_id_col,
+            "traindev_row_ids": outersplit.traindev[row_id_col].tolist(),
+            "test_row_ids": outersplit.test[row_id_col].tolist(),
+        }
+        with (outer_split_dir / "split_row_ids.json").open("w") as f:
+            json.dump(split_ids, f)
 
         # task_results: dict[task_id -> dict[ResultType, ModuleResult]]
         task_results: dict[int, dict[ResultType, ModuleResult]] = {}

--- a/octopus/predict/study_io.py
+++ b/octopus/predict/study_io.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 from attrs import field, frozen
@@ -105,7 +105,7 @@ class TaskOutersplitLoader:
     """Load data for a single outersplit from disk.
 
     Matches actual disk structure:
-    - data_test.parquet, data_traindev.parquet at outersplit level
+    - split_row_ids.json at outersplit level (row IDs into data_prepared.parquet)
     - feature_cols.json, feature_groups.json inside task/config/
     - model.joblib, predictor.json inside task/results/{result_type}/model/
     - selected_features.json, scores.parquet, predictions.parquet,
@@ -185,33 +185,49 @@ class TaskOutersplitLoader:
             feature_groups=self.load_feature_groups(),
         )
 
-    def load_test_data(self) -> pd.DataFrame:
-        """Load test data (at outersplit level).
+    def load_partition(self, partition: Literal["traindev", "test"]) -> pd.DataFrame:
+        """Load one data partition by filtering prepared data with stored row IDs.
+
+        Rows are returned in the order they were stored in split_row_ids.json,
+        matching the original split order. Raises if any stored row IDs are
+        missing from the prepared data.
+
+        Args:
+            partition: Which partition to load — ``"traindev"`` or ``"test"``.
 
         Returns:
-            DataFrame with test data.
+            DataFrame for the requested partition.
 
         Raises:
-            FileNotFoundError: If test data file is missing.
+            FileNotFoundError: If split_row_ids.json or data_prepared.parquet is missing.
+            KeyError: If any stored row IDs are not found in data_prepared.parquet.
         """
-        path = self.fold_dir / "data_test.parquet"
-        if not path.exists():
-            raise FileNotFoundError(f"Test data not found: {path}")
-        return parquet_load(path)
+        if partition not in ("traindev", "test"):
+            raise ValueError(f"partition must be 'traindev' or 'test', got {partition!r}")
 
-    def load_train_data(self) -> pd.DataFrame:
-        """Load train data (at outersplit level).
+        split_ids_path = self.fold_dir / "split_row_ids.json"
+        if not split_ids_path.exists():
+            raise FileNotFoundError(f"Split row IDs not found: {split_ids_path}")
 
-        Returns:
-            DataFrame with train data.
+        prepared_path = self.study_path / "data_prepared.parquet"
+        if not prepared_path.exists():
+            raise FileNotFoundError(f"Prepared data not found: {prepared_path}")
 
-        Raises:
-            FileNotFoundError: If train data file is missing.
-        """
-        path = self.fold_dir / "data_traindev.parquet"
-        if not path.exists():
-            raise FileNotFoundError(f"Train data not found: {path}")
-        return parquet_load(path)
+        with split_ids_path.open() as f:
+            split_info: dict[str, Any] = json.load(f)
+        row_ids: list = split_info[f"{partition}_row_ids"]
+        row_id_col: str = split_info["row_id_col"]
+
+        prepared_data = parquet_load(prepared_path)
+
+        indexed = prepared_data.set_index(row_id_col)
+        missing = set(row_ids) - set(indexed.index)
+        if missing:
+            raise KeyError(
+                f"{len(missing)} {partition} row IDs not found in data_prepared.parquet "
+                f"(first 5: {sorted(missing)[:5]})"
+            )
+        return indexed.loc[row_ids].reset_index()
 
     def load_model(self) -> Any:
         """Load fitted model from result_dir/model/model.joblib.
@@ -354,7 +370,10 @@ class StudyLoader:
         """
         row_id_col = config.get("prepared", {}).get("row_id_col")
         if not row_id_col:
-            row_id_col = config.get("row_id_col") or "row_id"
+            raise ValueError(
+                "row_id_col not found in study config under 'prepared.row_id_col'. "
+                "The study config may be from an incompatible version."
+            )
 
         return StudyMetadata(
             ml_type=MLType(config["ml_type"]),
@@ -363,7 +382,7 @@ class StudyLoader:
             target_assignments=config.get("prepared", {}).get("target_assignments", {}),
             positive_class=config.get("positive_class"),
             row_id_col=row_id_col,
-            feature_cols=config.get("feature_cols", []),
+            feature_cols=config.get("prepared", {}).get("feature_cols", []),
             n_outersplits=config.get("n_folds_outer", 0),
         )
 

--- a/octopus/predict/task_predictor.py
+++ b/octopus/predict/task_predictor.py
@@ -350,10 +350,10 @@ class TaskPredictor:
         """Build per-split pool data for permutation FI.
 
         In study-connected mode (constructed via ``TaskPredictor(study_path,
-        task_id)``), loads per-split ``data_traindev.parquet`` from the study
-        directory.  This provides a richer pool of replacement values for
-        permutation FI, better approximating the marginal distribution of
-        each feature.
+        task_id)``), filters ``data_prepared.parquet`` using the stored split
+        row IDs to recover per-split traindev data.  This provides a richer
+        pool of replacement values for permutation FI, better approximating
+        the marginal distribution of each feature.
 
         In deployment mode (loaded via ``TaskPredictor.load(path)``), the
         original study directory is not available, so the user-provided
@@ -374,10 +374,9 @@ class TaskPredictor:
                 task_id=self._task_id,
                 result_type=self._result_type,
             )
-            traindev_path = split_loader.fold_dir / "data_traindev.parquet"
-            if traindev_path.exists():
-                pool[split_id] = split_loader.load_train_data()
-            else:
+            try:
+                pool[split_id] = split_loader.load_partition("traindev")
+            except FileNotFoundError:
                 pool[split_id] = data
 
         return pool

--- a/octopus/predict/task_predictor_test.py
+++ b/octopus/predict/task_predictor_test.py
@@ -55,16 +55,16 @@ class TaskPredictorTest(TaskPredictor):
         # Call parent __attrs_post_init__ to load config, validate, and load models
         super().__attrs_post_init__()
 
-        # Additionally load test and train data per split via StudyLoader factory
         loader = StudyLoader(self._study_path)
+
         for split_id in self._outersplits:
             split_loader = loader.get_outersplit_loader(
                 outersplit_id=split_id,
                 task_id=self._task_id,
                 result_type=self._result_type,
             )
-            self._test_data[split_id] = split_loader.load_test_data()
-            self._train_data[split_id] = split_loader.load_train_data()
+            self._train_data[split_id] = split_loader.load_partition("traindev")
+            self._test_data[split_id] = split_loader.load_partition("test")
 
     # ── Prediction (per-split on own test data) ─────────────────
 

--- a/octopus/study/core.py
+++ b/octopus/study/core.py
@@ -186,7 +186,7 @@ class OctoStudy(ABC):
             config["positive_class"] = positive_class
         config["prepared"] = {
             "feature_cols": prepared.feature_cols,
-            "row_id": prepared.row_id_col,
+            "row_id_col": prepared.row_id_col,
             "target_assignments": self.target_assignments,
         }
 


### PR DESCRIPTION
## Summary

Closes #336

- Replace full parquet copies of traindev/test DataFrames per outersplit with a lightweight `split_row_ids.json` containing only row IDs
- Reconstruct DataFrames on load by filtering `data_prepared.parquet` (already saved at the study level)
- Load `data_prepared.parquet` once in `TaskPredictorTest` and pass it to each split loader, avoiding N redundant file reads

This eliminates redundant data storage — previously the dataset was stored 6 times for 5 outersplits (1 prepared + 5 copies), now it's stored once plus small JSON index files.