### PR TITLE
Add tests for data split function, fixes  #84, #397

### DIFF
--- a/octopus/datasplit.py
+++ b/octopus/datasplit.py
@@ -1,8 +1,5 @@
 """Data splitting utilities for nested cross-validation."""
 
-import random
-
-import numpy as np
 import pandas as pd
 from attrs import Factory, define, field, frozen, validators
 from sklearn.model_selection import KFold, StratifiedKFold
@@ -89,9 +86,6 @@ class DataSplit:
         self, datasplit_seed, name_a: str, name_b: str
     ) -> dict[int, tuple[pd.DataFrame, pd.DataFrame]]:
         """Get datasplits for single seed."""
-        random.seed(datasplit_seed)
-        np.random.seed(datasplit_seed)
-
         dataset_unique = self.dataset.drop_duplicates(subset=DATASPLIT_COL, keep="first", inplace=False)
         dataset_unique.reset_index(drop=True, inplace=True)
 

--- a/tests/test_datasplit.py
+++ b/tests/test_datasplit.py
@@ -1,0 +1,438 @@
+"""Tests for the data splitting logic."""
+
+import random
+
+import numpy as np
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from octopus.datasplit import DATASPLIT_COL, DataSplit, InnerSplit, OuterSplit
+
+
+def _grouped_df() -> pd.DataFrame:
+    """Return a tiny grouped dataset with stable row IDs."""
+    return pd.DataFrame(
+        {
+            "row_id": [10, 11, 20, 30, 31, 40],
+            "feature": [1.0, 1.1, 2.0, 3.0, 3.1, 4.0],
+            "target": [0, 0, 1, 0, 0, 1],
+            DATASPLIT_COL: [0, 0, 1, 2, 2, 3],
+        }
+    )
+
+
+def _norm(df: pd.DataFrame) -> pd.DataFrame:
+    """Sort by row_id and reset index for reliable frame comparisons."""
+    return df.sort_values("row_id").reset_index(drop=True)
+
+
+def test_get_outer_splits_keeps_groups_together_and_covers_all_rows_once():
+    """Outer splits keep each group intact and cover each row once in test."""
+    df = _grouped_df()
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[7],
+        num_folds=2,
+    ).get_outer_splits()
+
+    assert len(splits) == 2
+    assert all(isinstance(split, OuterSplit) for split in splits.values())
+
+    all_test_rows = []
+    test_fold_by_row = {}
+
+    for fold_id, split in splits.items():
+        train_groups = set(split.traindev[DATASPLIT_COL])
+        test_groups = set(split.test[DATASPLIT_COL])
+
+        assert train_groups.isdisjoint(test_groups)
+
+        for row_id in split.test["row_id"]:
+            all_test_rows.append(row_id)
+            test_fold_by_row[row_id] = fold_id
+
+    assert sorted(all_test_rows) == [10, 11, 20, 30, 31, 40]
+    assert test_fold_by_row[10] == test_fold_by_row[11]
+    assert test_fold_by_row[30] == test_fold_by_row[31]
+
+
+def test_get_inner_splits_keeps_groups_together_and_covers_all_rows_once():
+    """Inner splits follow the same rules as outer splits, just train/dev named."""
+    df = _grouped_df()
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[7],
+        num_folds=2,
+    ).get_inner_splits()
+
+    assert len(splits) == 2
+    assert all(isinstance(split, InnerSplit) for split in splits.values())
+
+    all_dev_rows = []
+
+    for split in splits.values():
+        train_groups = set(split.train[DATASPLIT_COL])
+        dev_groups = set(split.dev[DATASPLIT_COL])
+
+        assert train_groups.isdisjoint(dev_groups)
+        all_dev_rows.extend(split.dev["row_id"].tolist())
+
+    assert sorted(all_dev_rows) == [10, 11, 20, 30, 31, 40]
+
+
+def test_multiple_seeds_concatenate_seed_results_in_seed_then_fold_order():
+    """With multiple seeds, results are returned seed by seed, then fold by fold."""
+    df = _grouped_df()
+
+    seed_11 = DataSplit(dataset=df.copy(), seeds=[11], num_folds=2).get_outer_splits()
+    seed_22 = DataSplit(dataset=df.copy(), seeds=[22], num_folds=2).get_outer_splits()
+
+    combined = DataSplit(
+        dataset=df.copy(),
+        seeds=[11, 22],
+        num_folds=2,
+    ).get_outer_splits()
+
+    assert len(combined) == 4
+
+    pdt.assert_frame_equal(_norm(combined[0].test), _norm(seed_11[0].test))
+    pdt.assert_frame_equal(_norm(combined[1].test), _norm(seed_11[1].test))
+    pdt.assert_frame_equal(_norm(combined[2].test), _norm(seed_22[0].test))
+    pdt.assert_frame_equal(_norm(combined[3].test), _norm(seed_22[1].test))
+
+
+def test_same_seed_is_deterministic_for_outer_splits():
+    """Running the same seed twice should give the exact same partitions."""
+    df = _grouped_df()
+
+    first = DataSplit(dataset=df.copy(), seeds=[123], num_folds=2).get_outer_splits()
+    second = DataSplit(dataset=df.copy(), seeds=[123], num_folds=2).get_outer_splits()
+
+    for i in range(2):
+        pdt.assert_frame_equal(_norm(first[i].traindev), _norm(second[i].traindev))
+        pdt.assert_frame_equal(_norm(first[i].test), _norm(second[i].test))
+
+
+def test_stratified_splitting_preserves_class_presence_across_folds():
+    """In this balanced setup, each stratified test fold should include both classes."""
+    df = pd.DataFrame(
+        {
+            "row_id": list(range(8)),
+            "feature": list(range(8)),
+            "target": [0, 0, 0, 0, 1, 1, 1, 1],
+            DATASPLIT_COL: list(range(8)),
+        }
+    )
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[0],
+        num_folds=4,
+        stratification_col="target",
+    ).get_outer_splits()
+
+    assert len(splits) == 4
+
+    for split in splits.values():
+        assert len(split.test) == 2
+        assert set(split.test["target"]) == {0, 1}
+
+
+@pytest.mark.xfail(
+    reason="Custom data splitting implementation can accidentally create test folds that contain only one class label, even if the datasplit classes from the data preperator contain multiple labels. Will be fixed by replacing the custom implementation with a standard sklearn splitter."
+)
+def test_stratified_group_split_with_mixed_label_group_has_expected_target_counts():
+    """Regression test: seed 0 should yield the known stratified target counts per fold."""
+    df = pd.DataFrame(
+        {
+            "row_id": list(range(32)),
+            "feature": [1.0] * 32,
+            # group 0 is mixed (8x class 0, 2x class 1)
+            "target": ([0] * 8) + ([1] * 2) + ([1] * 10) + ([0] * 10) + ([0] * 2),
+            DATASPLIT_COL: ([0] * 10) + ([1] * 10) + ([2] * 10) + ([3] * 2),
+        }
+    )
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[0],
+        num_folds=2,
+        stratification_col="target",
+    ).get_outer_splits()
+
+    assert len(splits) == 2
+    assert splits[0].test["target"].value_counts().to_dict() == {0: 8, 1: 2}
+    assert splits[1].test["target"].value_counts().to_dict() == {0: 12, 1: 10}
+
+
+def test_datasplit_resets_input_index_in_place():
+    """The splitter resets the input index in place during initialization."""
+    df = _grouped_df()
+    df.index = [100, 101, 102, 103, 104, 105]
+
+    splitter = DataSplit(
+        dataset=df,
+        seeds=[0],
+        num_folds=2,
+    )
+
+    assert splitter.dataset.index.tolist() == [0, 1, 2, 3, 4, 5]
+    assert df.index.tolist() == [0, 1, 2, 3, 4, 5]
+
+
+def test_missing_datasplit_group_column_raises_key_error():
+    """Missing datasplit_group should fail immediately."""
+    df = pd.DataFrame(
+        {
+            "row_id": [0, 1, 2],
+            "feature": [1.0, 2.0, 3.0],
+            "target": [0, 1, 0],
+        }
+    )
+
+    with pytest.raises(KeyError):
+        DataSplit(
+            dataset=df,
+            seeds=[0],
+            num_folds=2,
+        ).get_outer_splits()
+
+
+def test_num_folds_greater_than_number_of_groups_raises_value_error():
+    """KFold should reject a fold count larger than the number of groups."""
+    df = pd.DataFrame(
+        {
+            "row_id": [0, 1],
+            "feature": [1.0, 2.0],
+            "target": [0, 1],
+            DATASPLIT_COL: [0, 1],
+        }
+    )
+
+    with pytest.raises(ValueError, match="n_splits=3"):
+        DataSplit(
+            dataset=df,
+            seeds=[0],
+            num_folds=3,
+        ).get_outer_splits()
+
+
+def test_stratified_split_warns_when_class_has_too_few_groups():
+    """StratifiedKFold emits a warning when one class is too small."""
+    df = pd.DataFrame(
+        {
+            "row_id": [0, 1, 2, 3],
+            "feature": [1.0, 2.0, 3.0, 4.0],
+            "target": [0, 0, 0, 1],
+            DATASPLIT_COL: [0, 1, 2, 3],
+        }
+    )
+
+    with pytest.warns(UserWarning, match="least populated class"):
+        splits = DataSplit(
+            dataset=df,
+            seeds=[0],
+            num_folds=2,
+            stratification_col="target",
+        ).get_outer_splits()
+
+    assert len(splits) == 2
+
+
+def test_each_fold_traindev_plus_test_equals_all_rows():
+    """Within each fold, traindev + test must equal the full dataset."""
+    df = _grouped_df()
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[7],
+        num_folds=2,
+    ).get_outer_splits()
+
+    all_row_ids = sorted(df["row_id"].tolist())
+
+    for split in splits.values():
+        fold_rows = sorted(split.traindev["row_id"].tolist() + split.test["row_id"].tolist())
+        assert fold_rows == all_row_ids
+
+
+def test_each_fold_train_plus_dev_equals_all_rows_inner():
+    """Within each inner fold, train + dev must equal the full dataset."""
+    df = _grouped_df()
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[7],
+        num_folds=2,
+    ).get_inner_splits()
+
+    all_row_ids = sorted(df["row_id"].tolist())
+
+    for split in splits.values():
+        fold_rows = sorted(split.train["row_id"].tolist() + split.dev["row_id"].tolist())
+        assert fold_rows == all_row_ids
+
+
+def test_datasplit_does_not_corrupt_global_random_state():
+    """DataSplit must not leave numpy/random global state altered for the caller."""
+    random.seed(999)
+    np.random.seed(999)
+
+    random_before = random.random()
+    numpy_before = np.random.random()
+
+    # Reset to the same state and run DataSplit in between
+    random.seed(999)
+    np.random.seed(999)
+
+    DataSplit(
+        dataset=_grouped_df(),
+        seeds=[42],
+        num_folds=2,
+    ).get_outer_splits()
+
+    random_after = random.random()
+    numpy_after = np.random.random()
+
+    assert random_before == random_after
+    assert numpy_before == numpy_after
+
+
+def test_inner_splits_with_stratification_preserves_class_presence():
+    """Stratified inner splits should include both classes in each dev fold."""
+    df = pd.DataFrame(
+        {
+            "row_id": list(range(8)),
+            "feature": list(range(8)),
+            "target": [0, 0, 0, 0, 1, 1, 1, 1],
+            DATASPLIT_COL: list(range(8)),
+        }
+    )
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[0],
+        num_folds=4,
+        stratification_col="target",
+    ).get_inner_splits()
+
+    assert len(splits) == 4
+
+    for split in splits.values():
+        assert len(split.dev) == 2
+        assert set(split.dev["target"]) == {0, 1}
+
+
+def test_single_fold_raises_value_error():
+    """num_folds=1 is rejected by sklearn KFold."""
+    df = _grouped_df()
+
+    with pytest.raises(ValueError, match=r"k-fold.*n_splits=2 or more"):
+        DataSplit(
+            dataset=df,
+            seeds=[0],
+            num_folds=1,
+        ).get_outer_splits()
+
+
+def test_three_seeds_produce_correct_index_numbering():
+    """Three seeds x 2 folds -> 6 entries keyed 0..5 matching individual runs."""
+    df = _grouped_df()
+
+    individual = {}
+    for seed in [10, 20, 30]:
+        individual[seed] = DataSplit(dataset=df.copy(), seeds=[seed], num_folds=2).get_outer_splits()
+
+    combined = DataSplit(
+        dataset=df.copy(),
+        seeds=[10, 20, 30],
+        num_folds=2,
+    ).get_outer_splits()
+
+    assert list(combined.keys()) == [0, 1, 2, 3, 4, 5]
+
+    pdt.assert_frame_equal(_norm(combined[0].test), _norm(individual[10][0].test))
+    pdt.assert_frame_equal(_norm(combined[1].test), _norm(individual[10][1].test))
+    pdt.assert_frame_equal(_norm(combined[2].test), _norm(individual[20][0].test))
+    pdt.assert_frame_equal(_norm(combined[3].test), _norm(individual[20][1].test))
+    pdt.assert_frame_equal(_norm(combined[4].test), _norm(individual[30][0].test))
+    pdt.assert_frame_equal(_norm(combined[5].test), _norm(individual[30][1].test))
+
+
+def test_different_seeds_produce_different_splits():
+    """Two different seeds must produce at least one different partition."""
+    df = pd.DataFrame(
+        {
+            "row_id": list(range(20)),
+            "feature": list(range(20)),
+            "target": [0, 1] * 10,
+            DATASPLIT_COL: list(range(20)),
+        }
+    )
+
+    splits_a = DataSplit(dataset=df.copy(), seeds=[0], num_folds=5).get_outer_splits()
+    splits_b = DataSplit(dataset=df.copy(), seeds=[999], num_folds=5).get_outer_splits()
+
+    some_differ = False
+    for i in range(5):
+        test_a = set(splits_a[i].test["row_id"])
+        test_b = set(splits_b[i].test["row_id"])
+        if test_a != test_b:
+            some_differ = True
+            break
+
+    assert some_differ, "Different seeds should produce at least one different fold"
+
+
+def test_single_group_with_two_folds_raises_value_error():
+    """A dataset with only one group cannot be split into 2 folds."""
+    df = pd.DataFrame(
+        {
+            "row_id": [0, 1, 2],
+            "feature": [1.0, 2.0, 3.0],
+            "target": [0, 1, 0],
+            DATASPLIT_COL: [0, 0, 0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="n_splits=2"):
+        DataSplit(
+            dataset=df,
+            seeds=[0],
+            num_folds=2,
+        ).get_outer_splits()
+
+
+def _unequal_groups_df() -> pd.DataFrame:
+    """Return a dataset with 4 groups of very different sizes."""
+    return pd.DataFrame(
+        {
+            "row_id": list(range(104)),
+            "feature": [1.0] * 104,
+            "target": [0] * 104,
+            # group 0: 50 rows, group 1: 50 rows, group 2: 2 rows, group 3: 2 rows
+            DATASPLIT_COL: ([0] * 50) + ([1] * 50) + ([2] * 2) + ([3] * 2),
+        }
+    )
+
+
+def test_unequal_group_sizes_balances_group_count_across_folds():
+    """With unequal group sizes, each fold gets the same number of groups."""
+    df = _unequal_groups_df()
+
+    splits = DataSplit(
+        dataset=df,
+        seeds=[0],
+        num_folds=2,
+    ).get_outer_splits()
+
+    for split in splits.values():
+        train_groups = set(split.traindev[DATASPLIT_COL])
+        test_groups = set(split.test[DATASPLIT_COL])
+        assert train_groups.isdisjoint(test_groups)
+
+    test_group_counts = [len(set(s.test[DATASPLIT_COL])) for s in splits.values()]
+    assert test_group_counts == [2, 2]


### PR DESCRIPTION
Fixes  #84, #397.

## Tests

- **Outer splits keep groups together** and cover every row exactly once across test folds.
- **Inner splits keep groups together** with the same guarantees for train/dev.
- **Per-fold completeness (outer)**: traindev + test = all rows within each fold.
- **Per-fold completeness (inner)**: train + dev = all rows within each fold.
- **Same seed is deterministic**: identical seed produces identical partitions.
- **Different seeds produce different splits**: at least one fold differs.
- **Multiple seeds concatenate in seed-then-fold order**, matching individual runs.
- **Three seeds produce correct index numbering**: 3 seeds x 2 folds = keys 0–5.
- **Stratified outer splits** preserve both classes in every test fold.
- **Stratified inner splits** preserve both classes in every dev fold.
- **Stratified split with mixed-label groups** *(xfail)*: documents that the current splitter can lose a class when groups contain mixed labels.
- **Stratified split warns** when a class has too few groups.
- **num_folds=1 raises ValueError**.
- **More folds than groups raises ValueError**.
- **Single group with 2 folds raises ValueError**.
- **Missing datasplit_group column raises KeyError**.
- **Index is reset in place** during initialization.
- **Unequal group sizes**: group count is balanced across folds even when row counts differ dramatically.
- **DataSplit does not corrupt global random state**.

## Bugfix

- Removed redundant `random.seed()` / `np.random.seed()` calls that overwrote global state as a side effect — sklearn's splitters already use their own `random_state` parameter.