### PR TITLE
Refactor/335 replace custom datasplit by sklearn

### DIFF
--- a/octopus/datasplit.py
+++ b/octopus/datasplit.py
@@ -1,10 +1,7 @@
 """Data splitting utilities for nested cross-validation."""
 
-<<<<<<< HEAD
-=======
 from typing import Any
 
->>>>>>> 1de9f14 (Replace custom datasplit logic by scikit learns built in functions, fixes #84, #384)
 import pandas as pd
 from attrs import Factory, define, field, frozen, validators
 from sklearn.model_selection import GroupKFold, StratifiedGroupKFold
@@ -93,17 +90,10 @@ class DataSplit:
         self, datasplit_seed, name_a: str, name_b: str
     ) -> dict[int, tuple[pd.DataFrame, pd.DataFrame]]:
         """Get datasplits for single seed."""
-<<<<<<< HEAD
-        dataset_unique = self.dataset.drop_duplicates(subset=DATASPLIT_COL, keep="first", inplace=False)
-        dataset_unique.reset_index(drop=True, inplace=True)
-
-        kf: KFold | StratifiedKFold
-=======
         groups = self.dataset[DATASPLIT_COL]
         num_groups = groups.nunique()
 
         splitter: GroupKFold | StratifiedGroupKFold
->>>>>>> 1de9f14 (Replace custom datasplit logic by scikit learns built in functions, fixes #84, #384)
         split_method: str
         if self.stratification_col:
             splitter = StratifiedGroupKFold(

--- a/tests/test_datasplit.py
+++ b/tests/test_datasplit.py
@@ -83,6 +83,27 @@ def test_get_inner_splits_keeps_groups_together_and_covers_all_rows_once():
     assert sorted(all_dev_rows) == [10, 11, 20, 30, 31, 40]
 
 
+def test_multiple_seeds_concatenate_seed_results_in_seed_then_fold_order():
+    """With multiple seeds, results are returned seed by seed, then fold by fold."""
+    df = _grouped_df()
+
+    seed_11 = DataSplit(dataset=df.copy(), seeds=[11], num_folds=2).get_outer_splits()
+    seed_22 = DataSplit(dataset=df.copy(), seeds=[22], num_folds=2).get_outer_splits()
+
+    combined = DataSplit(
+        dataset=df.copy(),
+        seeds=[11, 22],
+        num_folds=2,
+    ).get_outer_splits()
+
+    assert len(combined) == 4
+
+    pdt.assert_frame_equal(_norm(combined[0].test), _norm(seed_11[0].test))
+    pdt.assert_frame_equal(_norm(combined[1].test), _norm(seed_11[1].test))
+    pdt.assert_frame_equal(_norm(combined[2].test), _norm(seed_22[0].test))
+    pdt.assert_frame_equal(_norm(combined[3].test), _norm(seed_22[1].test))
+
+
 def test_same_seed_is_deterministic_for_outer_splits():
     """Running the same seed twice should give the exact same partitions."""
     df = _grouped_df()


### PR DESCRIPTION
FIxes #384, #397.

This PR refactors our custom data split logic to use `scikit-learn`’s built-in splitters:

- `GroupKFold` for non-stratified group splits
- `StratifiedGroupKFold` for stratified group splits

Our previous custom approach first reduced each group to one representative row, then stratified on those representatives.
If a group had mixed class labels, that reduction could hide part of the true label mix and produce weak folds (for example, a test fold missing one class).

Using `scikit-learn` splitters directly avoids that issue by handling groups and labels together during splitting.

What this improves:
- More reliable stratified group splits
- Better handling of groups with mixed class labels
- Less custom split logic to maintain
- Behavior aligned with standard `sklearn` APIs
- Validation
- Added/updated tests for group integrity and stratified behavior
- Added a regression test for the mixed-label group case
- Existing datasplit tests pass