### PR TITLE
fix: create parent directory before opening log file

### DIFF
--- a/octopus/logger.py
+++ b/octopus/logger.py
@@ -74,6 +74,7 @@ class FSSpecFileHandler(logging.StreamHandler):
             self.encoding = io.text_encoding(encoding)
         self.errors = errors
 
+        self.filename.parent.mkdir(parents=True, exist_ok=True)
         logfile = self.filename.open(self.mode, encoding=encoding, errors=errors)
         logging.StreamHandler.__init__(self, logfile)
 


### PR DESCRIPTION
## Summary
- Fixes #391
- `FSSpecFileHandler` now calls `mkdir(parents=True, exist_ok=True)` on the parent directory before opening the log file, preventing `FileNotFoundError` in Ray workers