### PR TITLE
Refactor/402 raise error for single label fold

### DIFF
--- a/octopus/datasplit.py
+++ b/octopus/datasplit.py
@@ -4,6 +4,7 @@ import pandas as pd
 from attrs import Factory, define, field, frozen, validators
 from sklearn.model_selection import GroupKFold, StratifiedGroupKFold
 
+from .exceptions import SingleClassFoldError
 from .logger import get_logger
 from .types import LogGroup
 
@@ -30,6 +31,34 @@ OuterSplits = dict[int, OuterSplit]
 InnerSplits = dict[int, InnerSplit]
 
 DATASPLIT_COL = "datasplit_group"
+
+
+def validate_class_coverage(
+    splits: OuterSplits | InnerSplits,
+    target_col: str,
+) -> None:
+    """Verify no fold partition contains only a single class.
+
+    Raises SingleClassFoldError if any partition has just one unique class,
+    which would cause degenerate model training or undefined metrics.
+    """
+    for fold_id, split in splits.items():
+        if isinstance(split, OuterSplit):
+            partitions = {"traindev": split.traindev, "test": split.test}
+        else:
+            partitions = {"train": split.train, "dev": split.dev}
+
+        for part_name, part_df in partitions.items():
+            unique_classes = part_df[target_col].unique()
+            if len(unique_classes) <= 1:
+                raise SingleClassFoldError(
+                    f"Fold {fold_id} {part_name} partition contains only class(es) "
+                    f"{sorted(unique_classes)}. "
+                    "Try: changing `datasplit_seeds_inner` or `datasplit_seed_outer`, "
+                    "reducing `n_folds_inner` or `n_folds_outer`, "
+                    "or setting `stratification_col` to the target column "
+                    "for balanced splits."
+                )
 
 
 @define

--- a/octopus/exceptions.py
+++ b/octopus/exceptions.py
@@ -11,3 +11,7 @@ class UnknownModelError(Exception):
 
 class UnknownMetricError(Exception):
     """An attempt was made to use an metric that does not exists."""
+
+
+class SingleClassFoldError(ValueError):
+    """A cross-validation fold contains only a single class label."""

--- a/octopus/modules/octo/core.py
+++ b/octopus/modules/octo/core.py
@@ -12,13 +12,13 @@ from attrs import Factory, define, field
 from optuna.trial import TrialState
 from upath import UPath
 
-from octopus.datasplit import DataSplit, InnerSplits
+from octopus.datasplit import DataSplit, InnerSplits, validate_class_coverage
 from octopus.logger import get_logger
 from octopus.metrics import Metrics
 from octopus.models import Models
 from octopus.modules import ModuleExecution, ModuleResult
 from octopus.modules.mrmr.core import _maxrminr, _relevance_fstats
-from octopus.types import CorrelationType, FIComputeMethod, LogGroup, MetricDirection, ResultType
+from octopus.types import CorrelationType, FIComputeMethod, LogGroup, MetricDirection, MLType, ResultType
 from octopus.utils import joblib_load, parquet_save
 
 from .bag import Bag, BagBase
@@ -177,6 +177,11 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             stratification_col=study_context.stratification_col,
             process_id=f"OUTER {outersplit_id} SEQ TBD",
         ).get_inner_splits()
+
+        if study_context.ml_type in (MLType.BINARY, MLType.MULTICLASS):
+            validate_class_coverage(self.data_splits_, list(study_context.target_assignments.values())[0])
+        elif study_context.ml_type == MLType.TIMETOEVENT:
+            validate_class_coverage(self.data_splits_, study_context.target_assignments["event"])
 
         logger.set_log_group(LogGroup.PREPARE_EXECUTION, f"OUTER {outersplit_id} SQE TBD")
 

--- a/octopus/study/core.py
+++ b/octopus/study/core.py
@@ -12,7 +12,7 @@ import pandas as pd
 from attrs import Factory, asdict, define, field, fields, has, validators
 from upath import UPath
 
-from octopus.datasplit import DATASPLIT_COL, DataSplit, OuterSplits
+from octopus.datasplit import DATASPLIT_COL, DataSplit, OuterSplits, validate_class_coverage
 from octopus.logger import get_logger, set_logger_filename
 from octopus.manager.core import OctoManager
 from octopus.metrics import Metrics
@@ -225,7 +225,7 @@ class OctoStudy(ABC):
         )
         return preparator.prepare()
 
-    def _create_datasplits(self, prepared: PreparedData) -> OuterSplits:
+    def _create_datasplits(self, prepared: PreparedData, ml_type: MLType) -> OuterSplits:
         """Create datasplits for outer cross-validation."""
         relevant_cols = list(prepared.feature_cols) + [
             c
@@ -251,6 +251,16 @@ class OctoStudy(ABC):
             num_folds=self.n_folds_outer,
             stratification_col=self.stratification_col,
         ).get_outer_splits()
+
+        if self.run_single_outersplit_num is not None:
+            splits_to_validate = {self.run_single_outersplit_num: outersplits[self.run_single_outersplit_num]}
+        else:
+            splits_to_validate = outersplits
+
+        if ml_type in (MLType.BINARY, MLType.MULTICLASS) and hasattr(self, "target_col"):
+            validate_class_coverage(splits_to_validate, self.target_col)
+        elif ml_type == MLType.TIMETOEVENT and hasattr(self, "event_col"):
+            validate_class_coverage(splits_to_validate, self.event_col)
 
         return outersplits
 
@@ -342,7 +352,7 @@ class OctoStudy(ABC):
         self._initialize_study_outputs(data, prepared, ml_type, positive_class)
         self._run_health_check(prepared, health_check_config)
 
-        outersplit_data = self._create_datasplits(prepared)
+        outersplit_data = self._create_datasplits(prepared, ml_type)
         study_context = self._create_study_context(prepared, ml_type, positive_class)
         manager = OctoManager(
             outersplit_data=outersplit_data,

--- a/tests/test_datasplit.py
+++ b/tests/test_datasplit.py
@@ -7,7 +7,16 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
-from octopus.datasplit import DATASPLIT_COL, DataSplit, InnerSplit, OuterSplit
+from octopus.datasplit import (
+    DATASPLIT_COL,
+    DataSplit,
+    InnerSplit,
+    InnerSplits,
+    OuterSplit,
+    OuterSplits,
+    validate_class_coverage,
+)
+from octopus.exceptions import SingleClassFoldError
 
 
 def _grouped_df() -> pd.DataFrame:
@@ -433,3 +442,49 @@ def test_unequal_group_sizes_balances_group_count_across_folds():
 
     test_group_counts = [len(set(s.test[DATASPLIT_COL])) for s in splits.values()]
     assert test_group_counts == [2, 2]
+
+
+def test_validate_class_coverage_raises_on_single_class_outer_fold():
+    """validate_class_coverage raises SingleClassFoldError when an outer fold has one class."""
+    splits: OuterSplits = {
+        0: OuterSplit(
+            traindev=pd.DataFrame({"target": [0, 0, 1, 1], DATASPLIT_COL: [0, 0, 1, 1]}),
+            test=pd.DataFrame({"target": [1, 1], DATASPLIT_COL: [2, 2]}),
+        ),
+    }
+
+    with pytest.raises(SingleClassFoldError, match=r"Fold 0 test.*only class"):
+        validate_class_coverage(splits, "target")
+
+
+def test_validate_class_coverage_raises_on_single_class_inner_fold():
+    """validate_class_coverage raises SingleClassFoldError for inner splits too."""
+    splits: InnerSplits = {
+        0: InnerSplit(
+            train=pd.DataFrame({"target": [0, 0, 1, 1]}),
+            dev=pd.DataFrame({"target": [0, 1]}),
+        ),
+        1: InnerSplit(
+            train=pd.DataFrame({"target": [0, 0, 0, 0]}),
+            dev=pd.DataFrame({"target": [0, 1]}),
+        ),
+    }
+
+    with pytest.raises(SingleClassFoldError, match=r"Fold 1 train.*only class"):
+        validate_class_coverage(splits, "target")
+
+
+def test_validate_class_coverage_passes_when_all_classes_present():
+    """No error when all classes appear in every partition."""
+    splits: OuterSplits = {
+        0: OuterSplit(
+            traindev=pd.DataFrame({"target": [0, 1], DATASPLIT_COL: [0, 1]}),
+            test=pd.DataFrame({"target": [0, 1], DATASPLIT_COL: [2, 3]}),
+        ),
+        1: OuterSplit(
+            traindev=pd.DataFrame({"target": [0, 1], DATASPLIT_COL: [2, 3]}),
+            test=pd.DataFrame({"target": [0, 1], DATASPLIT_COL: [0, 1]}),
+        ),
+    }
+
+    validate_class_coverage(splits, "target")


### PR DESCRIPTION
Fixes #402 .

**Problem**

Cross-validation can sometimes produce folds where one partition ends up with only a single class. Currently, things go wrong quietly. A model trained on a single-class fold learns nothing useful. Metrics like `AUCROC` become undefined (sklearn either raises `ValueError: y_true contains only one label` only after the `.fit()` call or the metric silently returns a meaningless number.

**Solution**

Check all fold partitions before any model training begins. If a fold's `train`, `dev`, or `test` partition is missing a class, we raise a `SingleClassFoldError`:

```
SingleClassFoldError: Fold 3 test partition contains only class(es) [1]; expected all of [0, 1].
Try: changing `datasplit_seeds_inner` or `datasplit_seed_outer`,
reducing `n_folds_inner` or `n_folds_outer`,
or setting `stratification_col` to the target column for balanced splits.
```

The validation function `validate_class_coverage()` lives in `datasplit.py`, but it's called from the study `study/core.py` for outer splits, `modules/octo/core.py` for inner splits, not from the `DataSplit` class itself, because it doesn't know the `ml_type` context. We need the `ml_type` context to decide whether to validate at all:

- Binary / Multiclass classification: validate against `target_col`
- Time-to-event analysis: validate against `event_col`
- Regression: skip (single-value folds are fine)

For `run_single_outersplit_num=0` we only validate that specific fold.

**What changed**

- `exceptions.py`: new `SingleClassFoldError(ValueError)`exception
- `datasplit.py`: new `validate_class_coverage()]` function that validates every fold
- `study/core.py` calls validation after creating outer splits (uses `ml_type` and `run_single_outersplit_num`)
- `modules/octo/core.py`calls validation after creating inner splits
- `test_datasplit.py`: four new tests covering: single-class outer fold raises, single-class inner fold raises, all-classes-present passes