### PR TITLE
refactor: rename pool to ensemble in performance/score names, fixes #117

### DIFF
--- a/examples/analyse_study_classification.ipynb
+++ b/examples/analyse_study_classification.ipynb
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "# Display performance (target metric) for all workflow tasks\n",
-    "# Set report_test=True to include test-set columns (test_avg, test_pool)\n",
+    "# Set report_test=True to include test-set columns (test_avg, test_ensemble)\n",
     "performance_tables = show_target_metric_performance(study_info)"
    ]
   },

--- a/octopus/modules/octo/bag.py
+++ b/octopus/modules/octo/bag.py
@@ -413,9 +413,9 @@ class BagBase(BaseEstimator):
 
         # Add ensemble performance with renamed keys
         if "ensemble" in performance:
-            performance_output["train_pool"] = performance["ensemble"]["train"]
-            performance_output["dev_pool"] = performance["ensemble"]["dev"]
-            performance_output["test_pool"] = performance["ensemble"]["test"]
+            performance_output["train_ensemble"] = performance["ensemble"]["train"]
+            performance_output["dev_ensemble"] = performance["ensemble"]["dev"]
+            performance_output["test_ensemble"] = performance["ensemble"]["test"]
 
         return performance_output
 
@@ -436,7 +436,7 @@ class BagBase(BaseEstimator):
         for partition in ["train", "dev", "test"]:
             lst_key = f"{partition}_lst"
             avg_key = f"{partition}_avg"
-            pool_key = f"{partition}_pool"
+            ensemble_key = f"{partition}_ensemble"
 
             if lst_key in perf:
                 for fold_idx, val in enumerate(perf[lst_key]):
@@ -459,14 +459,14 @@ class BagBase(BaseEstimator):
                         "value": perf[avg_key],
                     }
                 )
-            if pool_key in perf:
+            if ensemble_key in perf:
                 rows.append(
                     {
                         "metric": metric,
                         "partition": partition,
-                        "aggregation": "pool",
+                        "aggregation": "ensemble",
                         "fold": None,
-                        "value": perf[pool_key],
+                        "value": perf[ensemble_key],
                     }
                 )
 

--- a/octopus/modules/octo/core.py
+++ b/octopus/modules/octo/core.py
@@ -288,7 +288,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         logger.set_log_group(LogGroup.RESULTS)
         logger.info("Ensemble selection performance")
         logger.info(
-            f"Training: {training_id} {target_metric} (ensemble selection): Dev {ensel_scores['dev_pool']:.3f}, Test {ensel_scores['test_pool']:.3f}"
+            f"Training: {training_id} {target_metric} (ensemble selection): Dev {ensel_scores['dev_ensemble']:.3f}, Test {ensel_scores['test_ensemble']:.3f}"
         )
 
         # calculate feature importances of best bag
@@ -474,8 +474,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             f"Training: {training_id} "
             f"{target_metric} "
             f"(best bag - ensembled): "
-            f"Dev {best_bag_performance['dev_pool']:.3f}, "
-            f"Test {best_bag_performance['test_pool']:.3f}"
+            f"Dev {best_bag_performance['dev_ensemble']:.3f}, "
+            f"Test {best_bag_performance['test_ensemble']:.3f}"
         )
 
         # calculate feature importances of best bag

--- a/octopus/modules/octo/enssel.py
+++ b/octopus/modules/octo/enssel.py
@@ -89,8 +89,8 @@ class EnSel:
         for key, value in self.bags.items():
             s = pd.Series()
             s["id"] = value["id"]
-            s["dev_pool"] = value["performance"]["dev_pool"]  # relevant
-            s["test_pool"] = value["performance"]["test_pool"]
+            s["dev_ensemble"] = value["performance"]["dev_ensemble"]  # relevant
+            s["test_ensemble"] = value["performance"]["test_ensemble"]
             s["dev_avg"] = value["performance"]["dev_avg"]
             s["test_avg"] = value["performance"]["test_avg"]
             s["n_features_used_mean"] = value["n_features_used_mean"]
@@ -103,7 +103,7 @@ class EnSel:
         # (a) direction
         ascending = self.direction != MetricDirection.MAXIMIZE
 
-        self.model_table = self.model_table.sort_values(by="dev_pool", ascending=ascending).reset_index(drop=True)
+        self.model_table = self.model_table.sort_values(by="dev_ensemble", ascending=ascending).reset_index(drop=True)
 
         logger.info("Model Table:")
         logger.info(f"\n{self.model_table.head(20)}")
@@ -155,8 +155,8 @@ class EnSel:
 
         # Add ensemble performance with renamed keys
         if "ensemble" in performance:
-            performance_output["dev_pool"] = performance["ensemble"]["dev"]
-            performance_output["test_pool"] = performance["ensemble"]["test"]
+            performance_output["dev_ensemble"] = performance["ensemble"]["dev"]
+            performance_output["test_ensemble"] = performance["ensemble"]["test"]
 
         return performance_output
 
@@ -165,8 +165,8 @@ class EnSel:
         self.scan_table = pd.DataFrame(
             columns=[
                 "#models",
-                "dev_pool",
-                "test_pool",
+                "dev_ensemble",
+                "test_ensemble",
             ]
         )
 
@@ -175,8 +175,8 @@ class EnSel:
             scores = self._ensemble_models(bag_keys)
             self.scan_table.loc[i] = [
                 i + 1,
-                scores["dev_pool"],
-                scores["test_pool"],
+                scores["dev_ensemble"],
+                scores["test_ensemble"],
             ]
         logger.info("Scan Table:")
         logger.info(f"\n{self.scan_table.head(20)}")
@@ -190,16 +190,16 @@ class EnSel:
         """
         if self.direction == MetricDirection.MAXIMIZE:
             # Get all indices with the max value, then take the last one
-            best_value = self.scan_table["dev_pool"].max()
-            best_idx = self.scan_table[self.scan_table["dev_pool"] == best_value].index[-1]
+            best_value = self.scan_table["dev_ensemble"].max()
+            best_idx = self.scan_table[self.scan_table["dev_ensemble"] == best_value].index[-1]
         else:
             # Get all indices with the min value, then take the last one
-            best_value = self.scan_table["dev_pool"].min()
-            best_idx = self.scan_table[self.scan_table["dev_pool"] == best_value].index[-1]
+            best_value = self.scan_table["dev_ensemble"].min()
+            best_idx = self.scan_table[self.scan_table["dev_ensemble"] == best_value].index[-1]
         start_n = int(self.scan_table.loc[best_idx, "#models"])
         logger.info(f"Ensemble scan, number of included best models: {start_n}")
-        logger.info(f"Ensemble scan, dev_pool value: {self.scan_table.loc[best_idx, 'dev_pool']}")
-        logger.info(f"Ensemble scan, test_pool value: {self.scan_table.loc[best_idx, 'test_pool']}")
+        logger.info(f"Ensemble scan, dev_ensemble value: {self.scan_table.loc[best_idx, 'dev_ensemble']}")
+        logger.info(f"Ensemble scan, test_ensemble value: {self.scan_table.loc[best_idx, 'test_ensemble']}")
 
         # startn_bags dict with path as key and repeats=1 as value
         escan_ensemble: dict[UPath, int] = {}
@@ -210,7 +210,7 @@ class EnSel:
         # we start with the bags found in ensemble scan
         results: list[tuple[str | UPath, float, list[UPath]]] = []
         start_bags = list(escan_ensemble.keys())
-        start_perf = self._ensemble_models(start_bags)["dev_pool"]
+        start_perf = self._ensemble_models(start_bags)["dev_ensemble"]
         logger.info("Ensemble optimization")
         logger.info(f"Start performance: {start_perf}")
         # record start performance
@@ -227,7 +227,7 @@ class EnSel:
                 bags_lst = copy.deepcopy(bags_ensemble)
                 bags_lst.append(model)
                 perf = self._ensemble_models(bags_lst)
-                df.loc[len(df)] = [model, perf["dev_pool"], perf["test_pool"]]
+                df.loc[len(df)] = [model, perf["dev_ensemble"], perf["test_ensemble"]]
 
             if self.direction == MetricDirection.MAXIMIZE:
                 idx_best = df["performance_dev"].idxmax()

--- a/octopus/modules/octo/module.py
+++ b/octopus/modules/octo/module.py
@@ -105,7 +105,7 @@ class Octo(Task):
     """List of feature numbers to be investigated by mrmr."""
 
     optuna_return: OptunaReturnType = field(
-        default=OptunaReturnType.POOL,
+        default=OptunaReturnType.ENSEMBLE,
         converter=OptunaReturnType,
         validator=validators.in_(list(OptunaReturnType)),
     )

--- a/octopus/modules/octo/objective_optuna.py
+++ b/octopus/modules/octo/objective_optuna.py
@@ -179,8 +179,8 @@ class ObjectiveOptuna:
         self._log_trial_scores(bag_performance)
 
         # define optuna target
-        if self.config.optuna_return == OptunaReturnType.POOL:
-            optuna_target: float = bag_performance["dev_pool"]
+        if self.config.optuna_return == OptunaReturnType.ENSEMBLE:
+            optuna_target: float = bag_performance["dev_ensemble"]
         else:
             optuna_target = bag_performance["dev_avg"]
 

--- a/octopus/predict/notebook_utils.py
+++ b/octopus/predict/notebook_utils.py
@@ -288,7 +288,7 @@ def show_target_metric_performance(
         study_info: Dictionary returned by show_study_details().
         details: If True, shows detailed information for each outersplit.
         report_test: If True, includes test-set performance columns
-            (``test_avg``, ``test_pool``) in the output.  Default is False
+            (``test_avg``, ``test_ensemble``) in the output.  Default is False
             to prevent accidental data leakage during model selection.
 
     Returns:
@@ -415,7 +415,7 @@ def show_testset_performance(
         else:
             metrics = []
 
-    print("Performance on test dataset (pooling)")
+    print("Performance on test dataset (ensemble)")
 
     performance_long = predictor.performance(metrics=metrics)
     df = performance_long.pivot(index="outersplit", columns="metric", values="score")

--- a/octopus/predict/study_io.py
+++ b/octopus/predict/study_io.py
@@ -488,7 +488,7 @@ class StudyLoader:
 
                     perf_df = loader.load_scores()
 
-                    # Filter out per_fold rows — only keep avg and pool aggregations
+                    # Filter out per_fold rows — only keep avg and ensemble aggregations
                     if not perf_df.empty and "aggregation" in perf_df.columns:
                         perf_df = perf_df[perf_df["aggregation"] != "per_fold"]
 

--- a/octopus/types.py
+++ b/octopus/types.py
@@ -201,11 +201,11 @@ class OptunaReturnType(StrEnum):
     """Determines which bag performance statistic is used as the Optuna optimisation target.
 
     Used in ``Octo.optuna_return``:
-    - ``POOL``: uses the pooled dev score across all inner folds (dev_pool)
+    - ``ENSEMBLE``: uses the ensembled dev score across all inner folds (dev_ensemble)
     - ``AVERAGE``: uses the average of per-fold dev scores (dev_avg)
     """
 
-    POOL = "pool"
+    ENSEMBLE = "ensemble"
     AVERAGE = "average"
 
 

--- a/tests/modules/octo/test_ensemble_selection.py
+++ b/tests/modules/octo/test_ensemble_selection.py
@@ -252,7 +252,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
     individual_performances = []
     for _model_name, bag in bags.items():
         scores = bag.get_performance(num_assigned_cpus=1)
-        individual_performances.append(scores["dev_pool"])
+        individual_performances.append(scores["dev_ensemble"])
 
     best_individual_mae = min(individual_performances)
 
@@ -273,7 +273,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
     # Calculate ensemble performance
     start_bags = list(start_ensemble.keys())
     start_scores = ensel._ensemble_models(start_bags)
-    ensemble_mae = start_scores["dev_pool"]
+    ensemble_mae = start_scores["dev_ensemble"]
 
     # Calculate true optimal ensemble performance using same bag predictions
     # Sum individual bag dev predictions instead of ensemble selection's averaging

--- a/tests/modules/octo/test_ensemble_selection_unit.py
+++ b/tests/modules/octo/test_ensemble_selection_unit.py
@@ -216,8 +216,8 @@ def test_collect_trials_basic(tmp_path):
         assert set(bag_data.keys()) == expected_keys
         assert isinstance(bag_data["performance"], dict)
         assert isinstance(bag_data["predictions"], dict)
-        assert "dev_pool" in bag_data["performance"]
-        assert "test_pool" in bag_data["performance"]
+        assert "dev_ensemble" in bag_data["performance"]
+        assert "test_ensemble" in bag_data["performance"]
 
 
 # Tests for EnSel._create_model_table() method
@@ -236,11 +236,11 @@ def test_create_model_table_sorting_minimize(tmp_path):
 
     # Verify model table structure
     assert len(ensel.model_table) == 3
-    expected_columns = {"id", "dev_pool", "test_pool", "dev_avg", "test_avg", "n_features_used_mean", "path"}
+    expected_columns = {"id", "dev_ensemble", "test_ensemble", "dev_avg", "test_avg", "n_features_used_mean", "path"}
     assert set(ensel.model_table.columns) == expected_columns
 
     # Verify sorting (ascending for minimize metrics)
-    dev_scores = ensel.model_table["dev_pool"].values
+    dev_scores = ensel.model_table["dev_ensemble"].values
     assert all(dev_scores[i] <= dev_scores[i + 1] for i in range(len(dev_scores) - 1))
 
     # Best model should be first
@@ -256,8 +256,8 @@ def test_create_model_table_identical_performance(tmp_path):
 
     # Should handle identical performance
     assert len(ensel.model_table) == 3
-    # All should have same dev_pool score
-    dev_scores = ensel.model_table["dev_pool"].values
+    # All should have same dev_ensemble score
+    dev_scores = ensel.model_table["dev_ensemble"].values
     assert np.all(dev_scores == 1.5)
 
 
@@ -277,10 +277,10 @@ def test_ensemble_models_single_bag(tmp_path):
 
     # Verify score structure
     assert isinstance(scores, dict)
-    expected_keys = {"dev_pool", "test_pool"}
+    expected_keys = {"dev_ensemble", "test_ensemble"}
     assert expected_keys.issubset(set(scores.keys()))
-    assert isinstance(scores["dev_pool"], (int | float))
-    assert isinstance(scores["test_pool"], (int | float))
+    assert isinstance(scores["dev_ensemble"], (int | float))
+    assert isinstance(scores["test_ensemble"], (int | float))
 
 
 # Tests for EnSel._ensemble_scan() method


### PR DESCRIPTION
Renames `dev_pool`, `test_pool`, `train_pool` to `dev_ensemble`, `test_ensemble`, `train_ensemble` across all performance metric keys, log messages, docstrings, and tests. Also renames `OptunaReturnType.POOL` to `OptunaReturnType.ENSEMBLE` and the `"pool"` aggregation label to `"ensemble"`.

Closes #117.