### PR TITLE
refactor: simplify user interface, fixes #375

### DIFF
--- a/docs/concepts/feature_importance.md
+++ b/docs/concepts/feature_importance.md
@@ -4,7 +4,7 @@ All modules in Octopus inherit from the `Module` base class, which provides stan
 
 ## Overview
 
-The `Module` base class provides a unified interface for feature importance extraction through the `get_feature_importances()` method. This method supports three different calculation strategies:
+The `Module` base class provides a unified interface for feature importance extraction through the `get_fi()` method. This method supports three different calculation strategies:
 
 1. **Internal** - Uses built-in feature importances from tree-based models
 2. **Permutation** - Calculates permutation importance (works with any model)
@@ -21,12 +21,12 @@ module.fit(
     data_test=test_data,
     feature_cols=feature_cols,
     study=study,
-    outersplit_id=0,
+    outer_split_id=0,
     output_dir=output_dir,
 )
 
 # Get feature importances (default: internal method)
-importance_df = module.get_feature_importances()
+importance_df = module.get_fi()
 print(importance_df)
 ```
 
@@ -52,7 +52,7 @@ Features are sorted by importance in descending order.
 Best for: Random Forest, Gradient Boosting, XGBoost, LightGBM, CatBoost
 
 ```python
-importance_df = module.get_feature_importances(method="internal")
+importance_df = module.get_fi(method="internal")
 ```
 
 This method extracts the built-in `feature_importances_` attribute from tree-based models. It's fast and directly reflects how the model uses features during training.
@@ -82,7 +82,7 @@ octo = Octo(
 octo.fit(...)
 
 # Get internal feature importances
-fi_df = octo.get_feature_importances(method="internal")
+fi_df = octo.get_fi(method="internal")
 ```
 
 ### 2. Permutation Importance (Any Model)
@@ -90,7 +90,7 @@ fi_df = octo.get_feature_importances(method="internal")
 Best for: Any fitted model, especially when internal importances aren't available
 
 ```python
-importance_df = module.get_feature_importances(
+importance_df = module.get_fi(
     method="permutation",
     data=validation_data,
     target=validation_target,
@@ -122,7 +122,7 @@ mrmr = Mrmr(task_id=1, depends_on=0, n_features=50)
 mrmr.fit(...)
 
 # Get permutation importance on test set
-fi_df = mrmr.get_feature_importances(
+fi_df = mrmr.get_fi(
     method="permutation",
     data=test_data,
     target=test_data["target"],
@@ -134,7 +134,7 @@ fi_df = mrmr.get_feature_importances(
 Best for: Logistic Regression, Linear Regression, Ridge, Lasso, ElasticNet
 
 ```python
-importance_df = module.get_feature_importances(method="coefficients")
+importance_df = module.get_fi(method="coefficients")
 ```
 
 This method extracts and ranks features by the absolute magnitude of their coefficients in linear models.
@@ -165,7 +165,7 @@ octo = Octo(
 octo.fit(...)
 
 # Get coefficient-based importances
-fi_df = octo.get_feature_importances(method="coefficients")
+fi_df = octo.get_fi(method="coefficients")
 ```
 
 ## Error Handling
@@ -178,7 +178,7 @@ module = Octo(task_id=0)
 # Forgot to call fit()!
 
 try:
-    importance = module.get_feature_importances()
+    importance = module.get_fi()
 except ValueError as e:
     print(e)  # "Octo must be fitted before getting feature importances"
 ```
@@ -189,7 +189,7 @@ except ValueError as e:
 octo.fit(...)
 
 try:
-    importance = octo.get_feature_importances(method="internal")
+    importance = octo.get_fi(method="internal")
 except ValueError as e:
     print(e)  # "Model LogisticRegression does not have feature_importances_..."
 ```
@@ -197,7 +197,7 @@ except ValueError as e:
 ### Missing Parameters Error
 ```python
 try:
-    importance = module.get_feature_importances(method="permutation")
+    importance = module.get_fi(method="permutation")
     # Forgot to provide data and target!
 except ValueError as e:
     print(e)  # "Permutation importance requires data and target parameters"
@@ -222,15 +222,15 @@ octo.fit(
     data_test=test_data,
     feature_cols=feature_cols,
     study=study,
-    outersplit_id=0,
+    outer_split_id=0,
     output_dir=output_dir,
 )
 
 # Get internal importances (works if best model is tree-based)
-fi_internal = octo.get_feature_importances(method="internal")
+fi_internal = octo.get_fi(method="internal")
 
 # Get permutation importances (works for any best model)
-fi_permutation = octo.get_feature_importances(
+fi_permutation = octo.get_fi(
     method="permutation",
     data=test_data,
     target=test_data["target"],
@@ -244,7 +244,7 @@ from octopus.modules import Roc
 
 roc = Roc(
     task_id=0,
-    threshold=0.8,
+    correlation_threshold=0.8,
     correlation_type=CorrelationType.SPEARMAN,
 )
 
@@ -264,13 +264,13 @@ from octopus.types import ModelName
 boruta = Boruta(
     task_id=0,
     model=ModelName.RandomForestClassifier,
-    perc=100,
+    threshold=100,
 )
 
 boruta.fit(...)
 
 # Boruta uses RandomForest internally
-fi_df = boruta.get_feature_importances(method="internal")
+fi_df = boruta.get_fi(method="internal")
 ```
 
 ## Best Practices
@@ -287,7 +287,7 @@ fi_df = boruta.get_feature_importances(method="internal")
 Always validate feature importances make sense:
 
 ```python
-fi_df = module.get_feature_importances(method="internal")
+fi_df = module.get_fi(method="internal")
 
 # Check that importances sum to ~1.0 for tree models
 total_importance = fi_df["importance"].sum()
@@ -303,8 +303,8 @@ print(f"Top 10 features:\n{top_features}")
 For tree-based models, compare internal and permutation importance:
 
 ```python
-fi_internal = module.get_feature_importances(method="internal")
-fi_permutation = module.get_feature_importances(
+fi_internal = module.get_fi(method="internal")
+fi_permutation = module.get_fi(
     method="permutation",
     data=test_data,
     target=test_data["target"],
@@ -325,7 +325,7 @@ print(comparison)
 
 ```python
 # Get feature importances
-fi_df = module.get_feature_importances(method="internal")
+fi_df = module.get_fi(method="internal")
 
 # Save to disk
 output_path = module.path_results / "feature_importances.parquet"
@@ -353,11 +353,11 @@ workflow = [
 runner = WorkflowTaskRunner(
     study=study,
     workflow=workflow,
-    cpus_per_outersplit=4,
+    cpus_per_outer_split=4,
     log_dir=log_dir,
 )
 
-runner.run(outersplit_id=0, data_train=train_data, data_test=test_data)
+runner.run(outer_split_id=0, data_train=train_data, data_test=test_data)
 
 # After workflow completes, you can load modules and get importances
 from octopus.modules import Octo
@@ -366,7 +366,7 @@ octo_dir = study.output_path / "outersplit0" / "task0" / "module"
 loaded_octo = Octo.load(octo_dir)
 
 # Get importances from loaded module
-fi_df = loaded_octo.get_feature_importances(method="internal")
+fi_df = loaded_octo.get_fi(method="internal")
 ```
 
 ## Advanced Usage
@@ -385,7 +385,7 @@ octo = Octo(task_id=0, models=[ModelName.RandomForestClassifier])
 octo.fit(...)
 
 # This automatically extracts best_estimator_ from GridSearchCV
-fi_df = octo.get_feature_importances(method="internal")
+fi_df = octo.get_fi(method="internal")
 ```
 
 ### Custom Feature Importance
@@ -413,7 +413,7 @@ class CustomModule(Task):
 
 The feature importance functionality in Octopus modules provides:
 
-- **Unified interface** across all modules via `get_feature_importances()`
+- **Unified interface** across all modules via `get_fi()`
 - **Multiple methods** (internal, permutation, coefficients) for different model types
 - **Automatic error handling** with clear, actionable error messages
 - **Standardized output** format (DataFrame with feature/importance columns)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,7 +13,7 @@ Still, proper dtypes are only guaranteed to be reconstructed using `parquet_load
 For details on which dtypes are tested and supported, see [tests/infrastructure/test_file_io.py](https://github.com/emdgroup/octopus/blob/main/tests/infrastructure/test_file_io.py).
 
 
-## How does parallelization work in `octopus`, what are `num_cpus`, `num_workers`,  `num_assigned_cpus`?
+## How does parallelization work in `octopus`, what are `n_cpus`, `n_workers`,  `n_assigned_cpus`?
 
 Octopus uses a layered approach to parallelization.
 Clearly, it is most efficient to distribute the work done for the individual outer splits onto individual CPUs/CPU groups.
@@ -23,26 +23,26 @@ If there are more CPUs available than outer splits to be processed, `octopus` ac
 Take for example a machine with 128 CPUs and a study with 32 outer splits.
 Then, all outer splits are processed in parallel and the workflow tasks (which are always processed sequentially for every split) can parallelize onto 4 CPUs each ("inner parallelization").
 
-The total number of CPUs to be used by `octopus` can be specified via the `num_cpus` attribute of the `OctoStudy`.
+The total number of CPUs to be used by `octopus` can be specified via the `n_cpus` attribute of the `OctoStudy`.
 Its default value 0 uses all available CPUs.
 Positive values specify the total number of CPUs to be used.
-Negative values indicate `abs(num_cpus)` to leave free, e.g. -1 means use all but one CPU.
-Setting `num_cpus` to 1 disables all parallel processing and runs the study sequentially.
+Negative values indicate `abs(n_cpus)` to leave free, e.g. -1 means use all but one CPU.
+Setting `n_cpus` to 1 disables all parallel processing and runs the study sequentially.
 
 Internally, the `ResourceConfig` class is responsible for handling these constraints. Therein, nomenclature is as follows:
 
-* `num_cpus`, `num_cpus_user` is the user-defined number of CPUs to be used as described above.
-* `available_cpus` is the absolute total number of CPUs available for `octopus` (no negative values, zero, None). Deduced from `num_cpus` and the hardware capabilities of the machine.
-* `num_workers` is the number of parallel processes for the outer parallelization, i.e. the number of outer splits to be performed in parallel.
+* `n_cpus`, `n_cpus_user` is the user-defined number of CPUs to be used as described above.
+* `available_cpus` is the absolute total number of CPUs available for `octopus` (no negative values, zero, None). Deduced from `n_cpus` and the hardware capabilities of the machine.
+* `n_workers` is the number of parallel processes for the outer parallelization, i.e. the number of outer splits to be performed in parallel.
 * `cpus_per_worker` is the number of CPUs available for inner parallelization, i.e. within an outer split.
-* `num_assigned_cpus` is identical to `cpus_per_worker` and is being used in `octopus` internal code that should not care about whether it is running inside a dedicated worker or not. So, `num_assigned_cpus` always refers to inner parallelization.
+* `n_assigned_cpus` is identical to `cpus_per_worker` and is being used in `octopus` internal code that should not care about whether it is running inside a dedicated worker or not. So, `n_assigned_cpus` always refers to inner parallelization.
 
-Upon starting the `num_workers` worker processes, each of them can occupy `cpus_per_worker` CPUs without interfering with other workers.
-While `octopus`-internal modules use their `num_assigned_cpus` parameter to adhere to this limit, parallelization in external code is sometimes difficult to control.
+Upon starting the `n_workers` worker processes, each of them can occupy `cpus_per_worker` CPUs without interfering with other workers.
+While `octopus`-internal modules use their `n_assigned_cpus` parameter to adhere to this limit, parallelization in external code is sometimes difficult to control.
 `octopus` does its best to transport the intent by
 
 * Setting the environment variables `OMP_NUM_THREADS`, `OPENBLAS_NUM_THREADS`, `MKL_NUM_THREADS`, `BLIS_NUM_THREADS`, `VECLIB_MAXIMUM_THREADS`,`NUMEXPR_NUM_THREADS` to `cpus_per_worker` and
-* Calling `threadpoolctl.threadpool_limits(limits=num_cpus_per_worker)`
+* Calling `threadpoolctl.threadpool_limits(limits=n_cpus_per_worker)`
 
 for/in every worker process.
 

--- a/docs/userguide/time_to_event.md
+++ b/docs/userguide/time_to_event.md
@@ -52,14 +52,14 @@ from octopus.modules import Octo
 from octopus.types import ModelName
 
 study = OctoTimeToEvent(
-    name="my_survival_study",
+    study_name="my_survival_study",
     target_metric="CI",
     feature_cols=["age", "biomarker"],
     duration_col="duration",
     event_col="event",
     sample_id_col="patient_id",
     metrics=["CI"],
-    path="./results",
+    studies_directory="./results",
     workflow=[
         Octo(
             task_id=0,
@@ -69,7 +69,6 @@ study = OctoTimeToEvent(
             n_trials=20,
             max_features=5,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
         )
     ],
 )
@@ -131,13 +130,12 @@ Octo(
     n_trials=20,
     max_features=5,
     ensemble_selection=True,
-    ensel_n_save_trials=10,
 )
 ```
 
 ## Feature Importance
 
-The following feature importance methods are supported for T2E models via `fi_methods_bestbag`:
+The following feature importance methods are supported for T2E models via `fi_methods`:
 
 - **`permutation`** — Permutation importance using concordance index as scoring
 - **`shap`** — SHAP-based feature importance
@@ -148,6 +146,6 @@ Additionally, tree-based internal feature importances are always computed automa
 ```python
 Octo(
     ...,
-    fi_methods_bestbag=["permutation"],
+    fi_methods=["permutation"],
 )
 ```

--- a/examples/analyse_study_classification.ipynb
+++ b/examples/analyse_study_classification.ipynb
@@ -312,7 +312,7 @@
    "outputs": [],
    "source": [
     "# Access per-split feature importances via the fi_source column\n",
-    "for split_id in task_predictor_test.outersplits:\n",
+    "for split_id in task_predictor_test.outer_splits:\n",
     "    split_fi = fi_table_perm[fi_table_perm[\"fi_source\"] == split_id].copy()\n",
     "    print(f\"\\n=== Outersplit {split_id} ===\")\n",
     "    display_table(split_fi[[\"feature\", \"importance_mean\", \"importance_std\", \"p_value\"]].head(10))"

--- a/examples/basic_classification.py
+++ b/examples/basic_classification.py
@@ -24,8 +24,8 @@ print(f"  Target distribution: {df['target'].value_counts().sort_index().to_dict
 
 ### Create and run OctoClassification
 study = OctoClassification(
-    name="basic_classification",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="basic_classification",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="AUCROC",
     feature_cols=features,
     target_col="target",
@@ -38,7 +38,7 @@ study = OctoClassification(
             depends_on=None,  # First task, depends on input
             models=[ModelName.ExtraTreesClassifier],
             n_trials=100,  # 100 trials for hyperparameter optimization
-            n_folds_inner=5,  # 5 inner folds
+            n_inner_splits=5,  # 5 inner splits
             max_features=30,  # Use all 30 features
             ensemble_selection=True,  # Enable ensemble selection
         ),

--- a/examples/basic_regression.py
+++ b/examples/basic_regression.py
@@ -22,8 +22,8 @@ print(f"  Target distribution: {df['target'].value_counts().sort_index().to_dict
 
 ### Create and run OctoRegression
 study = OctoRegression(
-    name="basic_regression",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="basic_regression",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="MAE",
     feature_cols=features,
     target_col="target",

--- a/examples/diagnostics_octo_classification.ipynb
+++ b/examples/diagnostics_octo_classification.ipynb
@@ -66,7 +66,7 @@
     "diag = StudyDiagnostics(study_path_abs)\n",
     "print(f\"ML type: {diag.ml_type}\")\n",
     "print(f\"Predictions: {len(diag.predictions)} rows\")\n",
-    "print(f\"Feature importances: {len(diag.feature_importances)} rows\")\n",
+    "print(f\"Feature importances: {len(diag.fi)} rows\")\n",
     "print(f\"Optuna trials: {len(diag.optuna_trials)} rows\")"
    ]
   },
@@ -76,7 +76,7 @@
    "source": [
     "## Feature Importance\n",
     "\n",
-    "Interactive bar chart filtered by outersplit, task, training ID, and FI method."
+    "Interactive bar chart filtered by outer split, task, training ID, and FI method."
    ]
   },
   {
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diag.plot_feature_importance()"
+    "diag.plot_fi()"
    ]
   },
   {

--- a/examples/diagnostics_octo_regression.ipynb
+++ b/examples/diagnostics_octo_regression.ipynb
@@ -63,7 +63,7 @@
     "diag = StudyDiagnostics(study_path_abs)\n",
     "print(f\"ML type: {diag.ml_type}\")\n",
     "print(f\"Predictions: {len(diag.predictions)} rows\")\n",
-    "print(f\"Feature importances: {len(diag.feature_importances)} rows\")\n",
+    "print(f\"Feature importances: {len(diag.fi)} rows\")\n",
     "print(f\"Optuna trials: {len(diag.optuna_trials)} rows\")"
    ]
   },
@@ -91,7 +91,7 @@
    "source": [
     "## Feature Importance\n",
     "\n",
-    "Interactive bar chart filtered by outersplit, task, training ID, and FI method.\n"
+    "Interactive bar chart filtered by outer split, task, training ID, and FI method.\n"
    ]
   },
   {
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diag.plot_feature_importance()"
+    "diag.plot_fi()"
    ]
   },
   {

--- a/examples/multi_workflow.py
+++ b/examples/multi_workflow.py
@@ -22,14 +22,13 @@ print(f"  Target distribution: {df['target'].value_counts().sort_index().to_dict
 
 ### Create and run OctoRegression with multi-step workflow
 study = OctoRegression(
-    name="example_multiworkflow",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="example_multiworkflow",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="R2",
     feature_cols=features,
     target_col="target",
     sample_id_col="index",
-    ignore_data_health_warning=True,
-    run_single_outersplit_num=1,
+    single_outer_split=1,
     workflow=[
         Octo(
             description="step1_octofull",

--- a/examples/use_own_hyperparameters.py
+++ b/examples/use_own_hyperparameters.py
@@ -29,14 +29,13 @@ print(f"  Target distribution: {df['target'].value_counts().sort_index().to_dict
 
 ### Create and run OctoRegression with custom hyperparameters
 study = OctoRegression(
-    name="use_own_hyperparameters_example",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="use_own_hyperparameters_example",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="MAE",
     feature_cols=features,
     target_col="target",
     sample_id_col="index",
-    ignore_data_health_warning=True,
-    run_single_outersplit_num=0,
+    single_outer_split=0,
     workflow=[
         Octo(
             task_id=0,

--- a/examples/wf_multiclass_wine.py
+++ b/examples/wf_multiclass_wine.py
@@ -27,31 +27,29 @@ print(f"  Target distribution: {df['target'].value_counts().sort_index().to_dict
 ### Create and run OctoClassification for multiclass classification
 # OctoClassification automatically detects multiclass (>2 classes) from the data
 study = OctoClassification(
-    name="multiclass_wine",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="multiclass_wine",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="AUCROC_MACRO",
     feature_cols=features,
     target_col="target",
     sample_id_col="index",
     stratification_col="target",
-    datasplit_seed_outer=1234,
-    ignore_data_health_warning=True,
-    run_single_outersplit_num=0,  # only process first outersplit, for quick testing
+    outer_split_seed=1234,
+    single_outer_split=0,  # only process first outer split, for quick testing
     workflow=[
         Octo(
             task_id=0,
             depends_on=None,
             description="step_1_octo_multiclass",
-            n_folds_inner=5,
+            n_inner_splits=5,
             models=[
                 ModelName.ExtraTreesClassifier,
                 ModelName.RandomForestClassifier,
                 ModelName.XGBClassifier,
                 ModelName.CatBoostClassifier,
             ],
-            model_seed=0,
-            max_outl=0,
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
+            max_outliers=0,
+            fi_methods=[FIComputeMethod.PERMUTATION],
             n_trials=20,
         ),
     ],

--- a/examples/wf_octo_autogluon.py
+++ b/examples/wf_octo_autogluon.py
@@ -65,15 +65,14 @@ print("=====================================\n")
 ### Create and run OctoClassification with PARALLEL Octo + AutoGluon workflow
 
 study = OctoClassification(
-    name="wf_octo_autogluon_parallel",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="wf_octo_autogluon_parallel",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="AUCROC",  # Area Under ROC Curve for binary classification
     feature_cols=feature_names,
     target_col="target",
     sample_id_col="index",
     stratification_col="target",  # Ensure balanced splits
-    n_folds_outer=5,  # 5-fold outer cross-validation
-    ignore_data_health_warning=True,
+    n_outer_splits=5,  # 5-split outer cross-validation
     workflow=[
         # Step 0: octo
         Octo(
@@ -81,26 +80,24 @@ study = OctoClassification(
             task_id=0,
             depends_on=None,  # No dependency (parallel with AutoGluon)
             # Cross-validation settings
-            n_folds_inner=5,
+            n_inner_splits=5,
             # Model selection - using tree-based models for feature importance
             models=[
                 ModelName.ExtraTreesClassifier,
             ],
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],  # Feature importance method
+            fi_methods=[FIComputeMethod.PERMUTATION],  # Feature importance method
             n_trials=100,  # Number of hyperparameter optimization trials
             # Constrained hyperparameter optimization
             # max_features=60,  # Maximum number of features to select
-            # penalty_factor=1.0,  # Complexity penalty for feature selection
         ),
         # Step 1: AutoGluon
         AutoGluon(
             description="step_1_autogluon",
             task_id=1,
             depends_on=None,  # No dependency (parallel with Octo)
-            verbosity=3,  # Standard logging
             time_limit=600,
             presets=["medium_quality"],  # Balance between speed and accuracy
-            num_bag_folds=5,  # 5-fold bagging for ensemble models
+            n_bag_splits=5,  # 5-split bagging for ensemble models
             included_model_types=[
                 "XT",  # ExtraTrees
             ],

--- a/examples/wf_octo_mrmr_octo.py
+++ b/examples/wf_octo_mrmr_octo.py
@@ -3,7 +3,7 @@
 This example demonstrates a multi-step workflow using:
 - Artificial dataset with 30 features
 - Binary classification problem (not too easy)
-- 5 outer folds, 5 inner folds
+- 5 outer splits, 5 inner splits
 - 100 trials for hyperparameter optimization
 - ExtraTreesClassifier model
 - Sequential tasks: Octo -> Mrmr -> Octo (with reduced features)
@@ -56,14 +56,13 @@ print()
 
 # Create and run OctoClassification with sequential multi-step workflow
 study = OctoClassification(
-    name="wf_octo_mrmr_octo",
+    study_name="wf_octo_mrmr_octo",
     target_metric="ACCBAL",
     feature_cols=feature_names,
     target_col="target",
     sample_id_col="index",
     stratification_col="target",
-    n_folds_outer=5,  # 5 outer folds
-    ignore_data_health_warning=True,
+    n_outer_splits=5,  # 5 outer splits
     workflow=[
         # Task 0: Initial Octo with all features
         Octo(
@@ -72,7 +71,7 @@ study = OctoClassification(
             depends_on=None,  # First task, depends on input
             models=[ModelName.ExtraTreesClassifier],
             n_trials=100,  # 100 trials for hyperparameter optimization
-            n_folds_inner=5,  # 5 inner folds
+            n_inner_splits=5,  # 5 inner splits
             max_features=30,  # Use all 30 features
         ),
         # Task 1: Feature selection using Mrmr
@@ -90,7 +89,7 @@ study = OctoClassification(
             depends_on=1,
             models=[ModelName.ExtraTreesClassifier],
             n_trials=100,
-            n_folds_inner=5,
+            n_inner_splits=5,
             ensemble_selection=True,
         ),
     ],

--- a/examples/wf_roc_octo.py
+++ b/examples/wf_roc_octo.py
@@ -11,7 +11,7 @@ import os
 from octopus.example_data import load_breast_cancer_data
 from octopus.modules import Octo, Roc
 from octopus.study import OctoClassification
-from octopus.types import CorrelationType, FIComputeMethod, ModelName, ROCFilterMethod
+from octopus.types import CorrelationType, FIComputeMethod, ModelName, RelevanceMethod
 
 ### Load and Preprocess Data
 
@@ -30,25 +30,24 @@ print(f"  Target distribution: {df['target'].value_counts().sort_index().to_dict
 ### Create and run OctoClassification with ROC + Octo workflow
 
 study = OctoClassification(
-    name="example_roc_octo",
-    path=os.environ.get("STUDIES_PATH", "./studies"),
+    study_name="example_roc_octo",
+    studies_directory=os.environ.get("STUDIES_PATH", "./studies"),
     target_metric="ACCBAL",  # Balanced accuracy for binary classification
     feature_cols=features,
     target_col="target",
     sample_id_col="index",
     stratification_col="target",
-    datasplit_seed_outer=1234,
-    ignore_data_health_warning=True,
-    run_single_outersplit_num=0,  # Process only first outersplit for quick testing
+    outer_split_seed=1234,
+    single_outer_split=0,  # Process only first outer split for quick testing
     workflow=[
         # Step 0: ROC - Remove highly correlated features and apply statistical filtering
         Roc(
             description="step_0_roc",
             task_id=0,
             depends_on=None,  # First step, no input dependency
-            threshold=0.85,  # Remove features with correlation > 0.85
+            correlation_threshold=0.85,  # Remove features with correlation > 0.85
             correlation_type=CorrelationType.SPEARMAN,  # Use Spearman correlation
-            filter_type=ROCFilterMethod.F_STATISTICS,  # Apply F-statistics filtering
+            relevance_method=RelevanceMethod.F_STATISTICS,  # Apply F-statistics filtering
         ),
         # Step 1: Octo - Train models on filtered features from ROC step
         Octo(
@@ -56,21 +55,18 @@ study = OctoClassification(
             task_id=1,
             depends_on=0,  # Use output from ROC step
             # Cross-validation settings
-            n_folds_inner=5,
+            n_inner_splits=5,
             # Model selection
             models=[
                 ModelName.ExtraTreesClassifier,
                 # ModelName.RandomForestClassifier,
             ],
-            model_seed=0,
-            max_outl=0,  # No outlier removal
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],  # Feature importance method
+            max_outliers=0,  # No outlier removal
+            fi_methods=[FIComputeMethod.PERMUTATION],  # Feature importance method
             # Hyperparameter optimization with Optuna
-            optuna_seed=0,
-            n_optuna_startup_trials=10,
+            n_startup_trials=10,
             n_trials=12,  # Number of hyperparameter optimization trials
             max_features=12,  # Maximum number of features to select
-            penalty_factor=1.0,
         ),
     ],
 )

--- a/octopus/datasplit.py
+++ b/octopus/datasplit.py
@@ -4,7 +4,7 @@ import pandas as pd
 from attrs import Factory, define, field, frozen, validators
 from sklearn.model_selection import GroupKFold, StratifiedGroupKFold
 
-from .exceptions import SingleClassFoldError
+from .exceptions import SingleClassSplitError
 from .logger import get_logger
 from .types import LogGroup
 
@@ -13,7 +13,7 @@ logger = get_logger()
 
 @frozen
 class OuterSplit:
-    """One fold of outer cross-validation: traindev + held-out test."""
+    """One split of outer cross-validation: traindev + held-out test."""
 
     traindev: pd.DataFrame
     test: pd.DataFrame
@@ -21,7 +21,7 @@ class OuterSplit:
 
 @frozen
 class InnerSplit:
-    """One fold of inner cross-validation: train + dev/validation."""
+    """One split of inner cross-validation: train + dev/validation."""
 
     train: pd.DataFrame
     dev: pd.DataFrame
@@ -37,12 +37,12 @@ def validate_class_coverage(
     splits: OuterSplits | InnerSplits,
     target_col: str,
 ) -> None:
-    """Verify no fold partition contains only a single class.
+    """Verify no split partition contains only a single class.
 
-    Raises SingleClassFoldError if any partition has just one unique class,
+    Raises SingleClassSplitError if any partition has just one unique class,
     which would cause degenerate model training or undefined metrics.
     """
-    for fold_id, split in splits.items():
+    for split_id, split in splits.items():
         if isinstance(split, OuterSplit):
             partitions = {"traindev": split.traindev, "test": split.test}
         else:
@@ -51,11 +51,11 @@ def validate_class_coverage(
         for part_name, part_df in partitions.items():
             unique_classes = part_df[target_col].unique()
             if len(unique_classes) <= 1:
-                raise SingleClassFoldError(
-                    f"Fold {fold_id} {part_name} partition contains only class(es) "
+                raise SingleClassSplitError(
+                    f"Split {split_id} {part_name} partition contains only class(es) "
                     f"{sorted(unique_classes)}. "
-                    "Try: changing `datasplit_seeds_inner` or `datasplit_seed_outer`, "
-                    "reducing `n_folds_inner` or `n_folds_outer`, "
+                    "Try: changing `inner_split_seeds` or `outer_split_seed`, "
+                    "reducing `n_inner_splits` or `n_outer_splits`, "
                     "or setting `stratification_col` to the target column "
                     "for balanced splits."
                 )
@@ -80,7 +80,7 @@ class DataSplit:
             iterable_validator=validators.instance_of(list),
         )
     )
-    num_folds: int = field(validator=[validators.instance_of(int)])
+    n_splits: int = field(validator=[validators.instance_of(int)])
     dataset: pd.DataFrame = field(validator=[validators.instance_of(pd.DataFrame)])
     stratification_col: str | None = field(
         default=Factory(lambda: None),
@@ -118,12 +118,12 @@ class DataSplit:
     ) -> dict[int, tuple[pd.DataFrame, pd.DataFrame]]:
         """Get datasplits for single seed."""
         groups = self.dataset[DATASPLIT_COL]
-        num_groups = groups.nunique()
+        n_groups = groups.nunique()
 
         splitter: GroupKFold | StratifiedGroupKFold
         if self.stratification_col is not None:
             splitter = StratifiedGroupKFold(
-                n_splits=self.num_folds,
+                n_splits=self.n_splits,
                 shuffle=True,
                 random_state=datasplit_seed,
             )
@@ -133,22 +133,22 @@ class DataSplit:
             # Runtime sklearn (>=1.6) supports shuffle/random_state on GroupKFold,
             # but currently available sklearn stubs lag behind this signature.
             splitter = GroupKFold(
-                n_splits=self.num_folds,
+                n_splits=self.n_splits,
                 shuffle=True,  # type: ignore[call-arg]  # sklearn stubs lag behind sklearn version (>=1.6)
                 random_state=datasplit_seed,
             )
             split_iterator = splitter.split(self.dataset, groups=groups)
 
         logger.info(
-            f"{len(self.dataset)} rows, {num_groups} groups (column: {DATASPLIT_COL}), "
-            f"{type(splitter).__name__}, {self.num_folds} folds, seed {datasplit_seed}"
+            f"{len(self.dataset)} rows, {n_groups} groups (column: {DATASPLIT_COL}), "
+            f"{type(splitter).__name__}, {self.n_splits} splits, seed {datasplit_seed}"
         )
 
         raw_splits: dict[int, tuple[pd.DataFrame, pd.DataFrame]] = {}
         all_test_indices = []
         all_test_groups = []
 
-        for num_split, (train_ind, test_ind) in enumerate(split_iterator):
+        for split_idx, (train_ind, test_ind) in enumerate(split_iterator):
             partition_train = self.dataset.iloc[train_ind]
             partition_test = self.dataset.iloc[test_ind]
 
@@ -168,22 +168,22 @@ class DataSplit:
             partition_test.reset_index(drop=True, inplace=True)
 
             logger.info(
-                f"{self.process_id} {num_split} created: "
+                f"{self.process_id} {split_idx} created: "
                 f"{name_a} - {len(partition_train)} rows, "
                 f"{len(set(groups_train))} groups | "
                 f"{name_b} - {len(partition_test)} rows, "
                 f"{len(set(groups_test))} groups"
             )
 
-            raw_splits[num_split] = (partition_train, partition_test)
+            raw_splits[split_idx] = (partition_train, partition_test)
 
         if len(all_test_groups) != len(set(all_test_groups)):
-            raise RuntimeError("Duplicate groups across test folds")
+            raise RuntimeError("Duplicate groups across test splits")
         if set(self.dataset[DATASPLIT_COL]).symmetric_difference(set(all_test_groups)):
-            raise RuntimeError("Not all groups covered by test folds")
+            raise RuntimeError("Not all groups covered by test splits")
         if len(all_test_indices) != len(set(all_test_indices)):
-            raise RuntimeError("Duplicate row indices across test folds")
+            raise RuntimeError("Duplicate row indices across test splits")
         if len(self.dataset) != len(all_test_indices):
-            raise RuntimeError(f"Test folds contain {len(all_test_indices)} rows, expected {len(self.dataset)}")
+            raise RuntimeError(f"Test splits contain {len(all_test_indices)} rows, expected {len(self.dataset)}")
 
         return raw_splits

--- a/octopus/diagnostics/__init__.py
+++ b/octopus/diagnostics/__init__.py
@@ -10,7 +10,7 @@ Example::
     from octopus.diagnostics import StudyDiagnostics
 
     diag = StudyDiagnostics("./studies/my_study/")
-    diag.plot_feature_importance()
+    diag.plot_fi()
     diag.plot_optuna_trials()
 """
 

--- a/octopus/diagnostics/_data_loader.py
+++ b/octopus/diagnostics/_data_loader.py
@@ -2,7 +2,7 @@
 
 Replaces DuckDB's ``read_parquet(..., hive_partitioning=true)`` with
 :func:`load_parquet_glob` which iterates directories, reads individual
-parquet files, and extracts outersplit/task IDs from directory names.
+parquet files, and extracts outer_split/task IDs from directory names.
 """
 
 from __future__ import annotations
@@ -37,7 +37,7 @@ def _extract_id_from_dirname(dirname: str, prefix: str) -> int | None:
 def load_parquet_glob(study_path: UPath, pattern: str) -> pd.DataFrame:
     """Load and concatenate parquet files matching a glob pattern.
 
-    Extracts ``outersplit_id`` and ``task_id`` from the directory structure,
+    Extracts ``outer_split_id`` and ``task_id`` from the directory structure,
     equivalent to DuckDB's ``hive_partitioning=true``.
 
     Args:
@@ -46,7 +46,7 @@ def load_parquet_glob(study_path: UPath, pattern: str) -> pd.DataFrame:
             (e.g. ``"outersplit*/task*/scores.parquet"``).
 
     Returns:
-        Concatenated DataFrame with ``outersplit_id`` and ``task_id``
+        Concatenated DataFrame with ``outer_split_id`` and ``task_id``
         columns added from directory names. Empty DataFrame if no
         files match.
     """
@@ -61,8 +61,8 @@ def load_parquet_glob(study_path: UPath, pattern: str) -> pd.DataFrame:
         parts = parquet_file.relative_to(study_path).parts
         for part in parts[:-1]:  # exclude filename
             outer_id = _extract_id_from_dirname(part, "outersplit")
-            if outer_id is not None and "outersplit_id" not in df.columns:
-                df["outersplit_id"] = outer_id
+            if outer_id is not None and "outer_split_id" not in df.columns:
+                df["outer_split_id"] = outer_id
             task_id = _extract_id_from_dirname(part, "task")
             if task_id is not None and "task_id" not in df.columns:
                 df["task_id"] = task_id
@@ -75,7 +75,7 @@ def load_parquet_glob(study_path: UPath, pattern: str) -> pd.DataFrame:
 
 
 def load_predictions(study_path: UPath) -> pd.DataFrame:
-    """Load all predictions parquet files across outersplits and tasks.
+    """Load all predictions parquet files across outer splits and tasks.
 
     Searches in ``outersplit*/task*/results/*/predictions.parquet`` to pick up
     results stored under ``results/best/`` and ``results/ensemble_selection/`` sub-directories.
@@ -89,8 +89,8 @@ def load_predictions(study_path: UPath) -> pd.DataFrame:
     return load_parquet_glob(study_path, "outersplit*/task*/results/*/predictions.parquet")
 
 
-def load_feature_importances(study_path: UPath) -> pd.DataFrame:
-    """Load all feature importance parquet files across outersplits and tasks.
+def load_fi(study_path: UPath) -> pd.DataFrame:
+    """Load all feature importance parquet files across outer splits and tasks.
 
     Searches in ``outersplit*/task*/results/*/feature_importances.parquet`` to pick up
     results stored under ``results/best/`` and ``results/ensemble_selection/`` sub-directories.
@@ -105,7 +105,7 @@ def load_feature_importances(study_path: UPath) -> pd.DataFrame:
 
 
 def load_optuna(study_path: UPath) -> pd.DataFrame:
-    """Load all Optuna parquet files across outersplits and tasks.
+    """Load all Optuna parquet files across outer splits and tasks.
 
     Args:
         study_path: Root path of the study directory.
@@ -117,7 +117,7 @@ def load_optuna(study_path: UPath) -> pd.DataFrame:
 
 
 def load_scores(study_path: UPath) -> pd.DataFrame:
-    """Load all scores parquet files across outersplits and tasks.
+    """Load all scores parquet files across outer splits and tasks.
 
     Searches in ``outersplit*/task*/results/*/scores.parquet`` to pick up
     results stored under ``results/best/`` and ``results/ensemble_selection/`` sub-directories.

--- a/octopus/diagnostics/_plots.py
+++ b/octopus/diagnostics/_plots.py
@@ -10,10 +10,10 @@ from sklearn.metrics import confusion_matrix
 from octopus.types import FIResultLabel, MetricDirection
 
 
-def plot_feature_importance_chart(
+def plot_fi_chart(
     df: pd.DataFrame,
     *,
-    outersplit_id: int | str = 0,
+    outer_split_id: int | str = 0,
     task_id: int | str = 0,
     training_id: str = "",
     fi_method: str | FIResultLabel = "",
@@ -22,8 +22,8 @@ def plot_feature_importance_chart(
 
     Args:
         df: Feature importances DataFrame with columns:
-            feature, importance, fi_method, training_id, outersplit_id, task_id.
-        outersplit_id: Outer split to filter on.
+            feature, importance, fi_method, training_id, outer_split_id, task_id.
+        outer_split_id: Outer split to filter on.
         task_id: Task to filter on.
         training_id: Training ID to filter on. If empty, uses first available.
         fi_method: FI method to filter on. If empty, uses first available.
@@ -31,7 +31,7 @@ def plot_feature_importance_chart(
     Returns:
         Plotly Figure.
     """
-    mask = (df["outersplit_id"] == int(outersplit_id)) & (df["task_id"] == int(task_id))
+    mask = (df["outer_split_id"] == int(outer_split_id)) & (df["task_id"] == int(task_id))
     if training_id:
         mask &= df["training_id"] == training_id
     if fi_method:
@@ -67,7 +67,7 @@ def plot_feature_importance_chart(
 def plot_confusion_matrix_chart(
     df_predictions: pd.DataFrame,
     *,
-    outersplit_id: int | str = 0,
+    outer_split_id: int | str = 0,
     task_id: int | str = 0,
     training_id: str = "",
 ) -> go.Figure:
@@ -75,8 +75,8 @@ def plot_confusion_matrix_chart(
 
     Args:
         df_predictions: Predictions DataFrame with columns:
-            prediction, target, partition, outersplit_id, task_id, inner_split_id.
-        outersplit_id: Outer split to filter on.
+            prediction, target, partition, outer_split_id, task_id, inner_split_id.
+        outer_split_id: Outer split to filter on.
         task_id: Task to filter on.
         training_id: Training ID / inner_split_id to filter on.
 
@@ -84,7 +84,7 @@ def plot_confusion_matrix_chart(
         Plotly Figure with absolute and relative confusion matrices.
     """
     mask = (
-        (df_predictions["outersplit_id"] == int(outersplit_id))
+        (df_predictions["outer_split_id"] == int(outer_split_id))
         & (df_predictions["task_id"] == int(task_id))
         & (df_predictions["partition"] == "test")
     )
@@ -157,7 +157,7 @@ def plot_confusion_matrix_chart(
     fig.update_yaxes(title_text="True Label", row=1, col=2, autorange="reversed")
 
     fig.update_layout(
-        title_text=f"Confusion Matrix — outersplit {outersplit_id}, task {task_id}",
+        title_text=f"Confusion Matrix — outer split {outer_split_id}, task {task_id}",
         width=900,
         height=420,
         showlegend=False,
@@ -168,7 +168,7 @@ def plot_confusion_matrix_chart(
 def plot_predictions_vs_truth_chart(
     df_predictions: pd.DataFrame,
     *,
-    outersplit_id: int | str = 0,
+    outer_split_id: int | str = 0,
     task_id: int | str = 0,
     training_id: str = "",
 ) -> go.Figure:
@@ -176,14 +176,14 @@ def plot_predictions_vs_truth_chart(
 
     Args:
         df_predictions: Predictions DataFrame.
-        outersplit_id: Outer split to filter on.
+        outer_split_id: Outer split to filter on.
         task_id: Task to filter on.
         training_id: Training ID / inner_split_id to filter on.
 
     Returns:
         Plotly Figure.
     """
-    mask = (df_predictions["outersplit_id"] == int(outersplit_id)) & (df_predictions["task_id"] == int(task_id))
+    mask = (df_predictions["outer_split_id"] == int(outer_split_id)) & (df_predictions["task_id"] == int(task_id))
     if training_id and "inner_split_id" in df_predictions.columns:
         mask &= df_predictions["inner_split_id"].astype(str) == str(training_id)
 
@@ -226,7 +226,7 @@ def plot_predictions_vs_truth_chart(
     )
 
     fig.update_layout(
-        title=f"Prediction vs Ground Truth — outersplit {outersplit_id}, task {task_id}",
+        title=f"Prediction vs Ground Truth — outer split {outer_split_id}, task {task_id}",
         xaxis_title="Ground Truth",
         yaxis_title="Prediction",
         width=650,
@@ -250,17 +250,19 @@ def plot_optuna_trial_counts_chart(df_optuna: pd.DataFrame) -> go.Figure:
         return fig
 
     grouped = (
-        df_optuna.groupby(["outersplit_id", "task_id", "model_type"])["trial"].nunique().reset_index(name="trial_count")
+        df_optuna.groupby(["outer_split_id", "task_id", "model_type"])["trial"]
+        .nunique()
+        .reset_index(name="trial_count")
     )
 
-    # Create subplots: one row per task_id, one col per outersplit_id
+    # Create subplots: one row per task_id, one col per outer_split_id
     task_ids = sorted(grouped["task_id"].unique())
-    outer_ids = sorted(grouped["outersplit_id"].unique())
+    outer_ids = sorted(grouped["outer_split_id"].unique())
 
     fig = make_subplots(
         rows=len(task_ids),
         cols=len(outer_ids),
-        subplot_titles=[f"task {t}, outersplit {o}" for t in task_ids for o in outer_ids],
+        subplot_titles=[f"task {t}, outer split {o}" for t in task_ids for o in outer_ids],
         vertical_spacing=0.12,
         horizontal_spacing=0.08,
     )
@@ -279,7 +281,7 @@ def plot_optuna_trial_counts_chart(df_optuna: pd.DataFrame) -> go.Figure:
 
     for row_i, task in enumerate(task_ids, 1):
         for col_i, outer in enumerate(outer_ids, 1):
-            sub = grouped[(grouped["task_id"] == task) & (grouped["outersplit_id"] == outer)]
+            sub = grouped[(grouped["task_id"] == task) & (grouped["outer_split_id"] == outer)]
             for m_i, model in enumerate(model_types):
                 model_data = sub[sub["model_type"] == model]
                 fig.add_trace(
@@ -306,7 +308,7 @@ def plot_optuna_trial_counts_chart(df_optuna: pd.DataFrame) -> go.Figure:
 def plot_optuna_trials_chart(
     df_optuna: pd.DataFrame,
     *,
-    outersplit_id: int | str = 0,
+    outer_split_id: int | str = 0,
     task_id: int | str = 0,
     direction: MetricDirection = MetricDirection.MINIMIZE,
 ) -> go.Figure:
@@ -314,14 +316,14 @@ def plot_optuna_trials_chart(
 
     Args:
         df_optuna: Optuna results DataFrame.
-        outersplit_id: Outer split to filter on.
+        outer_split_id: Outer split to filter on.
         task_id: Task to filter on.
         direction: Optimization direction ('minimize' or 'maximize').
 
     Returns:
         Plotly Figure.
     """
-    mask = (df_optuna["outersplit_id"] == int(outersplit_id)) & (df_optuna["task_id"] == int(task_id))
+    mask = (df_optuna["outer_split_id"] == int(outer_split_id)) & (df_optuna["task_id"] == int(task_id))
     filtered = df_optuna[mask]
     if filtered.empty:
         fig = go.Figure()
@@ -380,7 +382,7 @@ def plot_optuna_trials_chart(
     )
 
     fig.update_layout(
-        title=f"Optuna Trials — outersplit {outersplit_id}, task {task_id}",
+        title=f"Optuna Trials — outer split {outer_split_id}, task {task_id}",
         xaxis_title="Trial",
         yaxis_title="Objective Value",
         yaxis_type="log",
@@ -393,7 +395,7 @@ def plot_optuna_trials_chart(
 def plot_optuna_hyperparameters_chart(
     df_optuna: pd.DataFrame,
     *,
-    outersplit_id: int | str = 0,
+    outer_split_id: int | str = 0,
     task_id: int | str = 0,
     model_type: str = "",
 ) -> go.Figure:
@@ -401,14 +403,14 @@ def plot_optuna_hyperparameters_chart(
 
     Args:
         df_optuna: Optuna results DataFrame.
-        outersplit_id: Outer split to filter on.
+        outer_split_id: Outer split to filter on.
         task_id: Task to filter on.
         model_type: Model type to filter on.
 
     Returns:
         Plotly Figure with subplots per hyperparameter.
     """
-    mask = (df_optuna["outersplit_id"] == int(outersplit_id)) & (df_optuna["task_id"] == int(task_id))
+    mask = (df_optuna["outer_split_id"] == int(outer_split_id)) & (df_optuna["task_id"] == int(task_id))
     if model_type:
         mask &= df_optuna["model_type"] == model_type
 
@@ -461,7 +463,7 @@ def plot_optuna_hyperparameters_chart(
         fig.update_yaxes(title_text="Target Metric", row=row, col=col)
 
     fig.update_layout(
-        title=f"Optuna Hyperparameters — outersplit {outersplit_id}, task {task_id}"
+        title=f"Optuna Hyperparameters — outer split {outer_split_id}, task {task_id}"
         + (f", {model_type}" if model_type else ""),
         height=300 * max(rows, 1),
         width=700,

--- a/octopus/diagnostics/core.py
+++ b/octopus/diagnostics/core.py
@@ -17,14 +17,14 @@ from typing import Any
 import pandas as pd
 
 from octopus.diagnostics._data_loader import (
-    load_feature_importances,
+    load_fi,
     load_optuna,
     load_predictions,
     load_scores,
 )
 from octopus.diagnostics._plots import (
     plot_confusion_matrix_chart,
-    plot_feature_importance_chart,
+    plot_fi_chart,
     plot_optuna_hyperparameters_chart,
     plot_optuna_trial_counts_chart,
     plot_optuna_trials_chart,
@@ -65,7 +65,7 @@ class StudyDiagnostics:
         from octopus.diagnostics import StudyDiagnostics
 
         diag = StudyDiagnostics("./studies/my_study/")
-        diag.plot_feature_importance()
+        diag.plot_fi()
         diag.plot_optuna_trials()
     """
 
@@ -84,7 +84,7 @@ class StudyDiagnostics:
 
         # Lazy-loaded DataFrames
         self._predictions: pd.DataFrame | None = None
-        self._feature_importances: pd.DataFrame | None = None
+        self._fi: pd.DataFrame | None = None
         self._optuna: pd.DataFrame | None = None
         self._scores: pd.DataFrame | None = None
 
@@ -107,28 +107,28 @@ class StudyDiagnostics:
 
     @property
     def predictions(self) -> pd.DataFrame:
-        """All predictions across outersplits and tasks (lazy-loaded)."""
+        """All predictions across outer splits and tasks (lazy-loaded)."""
         if self._predictions is None:
             self._predictions = load_predictions(self._study_path)
         return self._predictions
 
     @property
-    def feature_importances(self) -> pd.DataFrame:
-        """All feature importances across outersplits and tasks (lazy-loaded)."""
-        if self._feature_importances is None:
-            self._feature_importances = load_feature_importances(self._study_path)
-        return self._feature_importances
+    def fi(self) -> pd.DataFrame:
+        """All feature importances across outer splits and tasks (lazy-loaded)."""
+        if self._fi is None:
+            self._fi = load_fi(self._study_path)
+        return self._fi
 
     @property
     def optuna_trials(self) -> pd.DataFrame:
-        """All Optuna trial results across outersplits and tasks (lazy-loaded)."""
+        """All Optuna trial results across outer splits and tasks (lazy-loaded)."""
         if self._optuna is None:
             self._optuna = load_optuna(self._study_path)
         return self._optuna
 
     @property
     def scores(self) -> pd.DataFrame:
-        """All scores across outersplits and tasks (lazy-loaded)."""
+        """All scores across outer splits and tasks (lazy-loaded)."""
         if self._scores is None:
             self._scores = load_scores(self._study_path)
         return self._scores
@@ -149,9 +149,9 @@ class StudyDiagnostics:
 
     # ── Interactive Plots ───────────────────────────────────────
 
-    def plot_feature_importance(
+    def plot_fi(
         self,
-        outersplit_id: int | None = None,
+        outer_split_id: int | None = None,
         task_id: int | None = None,
         training_id: str | None = None,
         fi_method: str | FIResultLabel | None = None,
@@ -162,36 +162,36 @@ class StudyDiagnostics:
         dropdowns. Otherwise uses provided values or defaults.
 
         Args:
-            outersplit_id: Outer split to filter on.
+            outer_split_id: Outer split to filter on.
             task_id: Task to filter on.
             training_id: Training ID to filter on.
             fi_method: FI method to filter on.
         """
-        df = self.feature_importances
+        df = self.fi
         if df.empty:
             print("No feature importance data found.")
             return
 
-        if _has_ipywidgets() and outersplit_id is None:
+        if _has_ipywidgets() and outer_split_id is None:
             from ipywidgets import Dropdown, interact  # noqa: PLC0415
 
-            opts = self._get_filter_options(df, ["outersplit_id", "task_id", "training_id", "fi_method"])
+            opts = self._get_filter_options(df, ["outer_split_id", "task_id", "training_id", "fi_method"])
 
             @interact(
-                outersplit_id=Dropdown(options=opts.get("outersplit_id", ["0"]), description="Outersplit:"),
+                outer_split_id=Dropdown(options=opts.get("outer_split_id", ["0"]), description="Outer Split:"),
                 task_id=Dropdown(options=opts.get("task_id", ["0"]), description="Task:"),
                 training_id=Dropdown(options=opts.get("training_id", [""]), description="Training:"),
                 fi_method=Dropdown(options=opts.get("fi_method", [""]), description="FI Method:"),
             )
-            def _plot(outersplit_id: str, task_id: str, training_id: str, fi_method: str) -> None:
-                fig = plot_feature_importance_chart(
-                    df, outersplit_id=outersplit_id, task_id=task_id, training_id=training_id, fi_method=fi_method
+            def _plot(outer_split_id: str, task_id: str, training_id: str, fi_method: str) -> None:
+                fig = plot_fi_chart(
+                    df, outer_split_id=outer_split_id, task_id=task_id, training_id=training_id, fi_method=fi_method
                 )
                 fig.show()
         else:
-            fig = plot_feature_importance_chart(
+            fig = plot_fi_chart(
                 df,
-                outersplit_id=outersplit_id or 0,
+                outer_split_id=outer_split_id or 0,
                 task_id=task_id or 0,
                 training_id=training_id or "",
                 fi_method=fi_method or "",
@@ -200,14 +200,14 @@ class StudyDiagnostics:
 
     def plot_confusion_matrix(
         self,
-        outersplit_id: int | None = None,
+        outer_split_id: int | None = None,
         task_id: int | None = None,
         training_id: str | None = None,
     ) -> None:
         """Plot confusion matrix heatmap (classification only).
 
         Args:
-            outersplit_id: Outer split to filter on.
+            outer_split_id: Outer split to filter on.
             task_id: Task to filter on.
             training_id: Inner split / training ID to filter on.
         """
@@ -216,25 +216,25 @@ class StudyDiagnostics:
             print("No prediction data found.")
             return
 
-        if _has_ipywidgets() and outersplit_id is None:
+        if _has_ipywidgets() and outer_split_id is None:
             from ipywidgets import Dropdown, interact  # noqa: PLC0415
 
-            opts = self._get_filter_options(df, ["outersplit_id", "task_id", "inner_split_id"])
+            opts = self._get_filter_options(df, ["outer_split_id", "task_id", "inner_split_id"])
 
             @interact(
-                outersplit_id=Dropdown(options=opts.get("outersplit_id", ["0"]), description="Outersplit:"),
+                outer_split_id=Dropdown(options=opts.get("outer_split_id", ["0"]), description="Outer Split:"),
                 task_id=Dropdown(options=opts.get("task_id", ["0"]), description="Task:"),
                 training_id=Dropdown(options=opts.get("inner_split_id", [""]), description="Training:"),
             )
-            def _plot(outersplit_id: str, task_id: str, training_id: str) -> None:
+            def _plot(outer_split_id: str, task_id: str, training_id: str) -> None:
                 fig = plot_confusion_matrix_chart(
-                    df, outersplit_id=outersplit_id, task_id=task_id, training_id=training_id
+                    df, outer_split_id=outer_split_id, task_id=task_id, training_id=training_id
                 )
                 fig.show()
         else:
             fig = plot_confusion_matrix_chart(
                 df,
-                outersplit_id=outersplit_id or 0,
+                outer_split_id=outer_split_id or 0,
                 task_id=task_id or 0,
                 training_id=training_id or "",
             )
@@ -242,14 +242,14 @@ class StudyDiagnostics:
 
     def plot_predictions_vs_truth(
         self,
-        outersplit_id: int | None = None,
+        outer_split_id: int | None = None,
         task_id: int | None = None,
         training_id: str | None = None,
     ) -> None:
         """Plot prediction vs ground truth scatter (regression only).
 
         Args:
-            outersplit_id: Outer split to filter on.
+            outer_split_id: Outer split to filter on.
             task_id: Task to filter on.
             training_id: Inner split / training ID to filter on.
         """
@@ -258,25 +258,25 @@ class StudyDiagnostics:
             print("No prediction data found.")
             return
 
-        if _has_ipywidgets() and outersplit_id is None:
+        if _has_ipywidgets() and outer_split_id is None:
             from ipywidgets import Dropdown, interact  # noqa: PLC0415
 
-            opts = self._get_filter_options(df, ["outersplit_id", "task_id", "inner_split_id"])
+            opts = self._get_filter_options(df, ["outer_split_id", "task_id", "inner_split_id"])
 
             @interact(
-                outersplit_id=Dropdown(options=opts.get("outersplit_id", ["0"]), description="Outersplit:"),
+                outer_split_id=Dropdown(options=opts.get("outer_split_id", ["0"]), description="Outer Split:"),
                 task_id=Dropdown(options=opts.get("task_id", ["0"]), description="Task:"),
                 training_id=Dropdown(options=opts.get("inner_split_id", [""]), description="Training:"),
             )
-            def _plot(outersplit_id: str, task_id: str, training_id: str) -> None:
+            def _plot(outer_split_id: str, task_id: str, training_id: str) -> None:
                 fig = plot_predictions_vs_truth_chart(
-                    df, outersplit_id=outersplit_id, task_id=task_id, training_id=training_id
+                    df, outer_split_id=outer_split_id, task_id=task_id, training_id=training_id
                 )
                 fig.show()
         else:
             fig = plot_predictions_vs_truth_chart(
                 df,
-                outersplit_id=outersplit_id or 0,
+                outer_split_id=outer_split_id or 0,
                 task_id=task_id or 0,
                 training_id=training_id or "",
             )
@@ -293,14 +293,14 @@ class StudyDiagnostics:
 
     def plot_optuna_trials(
         self,
-        outersplit_id: int | None = None,
+        outer_split_id: int | None = None,
         task_id: int | None = None,
         direction: MetricDirection = MetricDirection.MINIMIZE,
     ) -> None:
         """Plot Optuna trial scatter + cumulative best line.
 
         Args:
-            outersplit_id: Outer split to filter on.
+            outer_split_id: Outer split to filter on.
             task_id: Task to filter on.
             direction: Optimization direction ('minimize' or 'maximize').
         """
@@ -309,22 +309,22 @@ class StudyDiagnostics:
             print("No Optuna data found.")
             return
 
-        if _has_ipywidgets() and outersplit_id is None:
+        if _has_ipywidgets() and outer_split_id is None:
             from ipywidgets import Dropdown, interact  # noqa: PLC0415
 
-            opts = self._get_filter_options(df, ["outersplit_id", "task_id"])
+            opts = self._get_filter_options(df, ["outer_split_id", "task_id"])
 
             @interact(
-                outersplit_id=Dropdown(options=opts.get("outersplit_id", ["0"]), description="Outersplit:"),
+                outer_split_id=Dropdown(options=opts.get("outer_split_id", ["0"]), description="Outer Split:"),
                 task_id=Dropdown(options=opts.get("task_id", ["0"]), description="Task:"),
             )
-            def _plot(outersplit_id: str, task_id: str) -> None:
-                fig = plot_optuna_trials_chart(df, outersplit_id=outersplit_id, task_id=task_id, direction=direction)
+            def _plot(outer_split_id: str, task_id: str) -> None:
+                fig = plot_optuna_trials_chart(df, outer_split_id=outer_split_id, task_id=task_id, direction=direction)
                 fig.show()
         else:
             fig = plot_optuna_trials_chart(
                 df,
-                outersplit_id=outersplit_id or 0,
+                outer_split_id=outer_split_id or 0,
                 task_id=task_id or 0,
                 direction=direction,
             )
@@ -332,14 +332,14 @@ class StudyDiagnostics:
 
     def plot_optuna_hyperparameters(
         self,
-        outersplit_id: int | None = None,
+        outer_split_id: int | None = None,
         task_id: int | None = None,
         model_type: str | None = None,
     ) -> None:
         """Plot Optuna hyperparameter scatter plots.
 
         Args:
-            outersplit_id: Outer split to filter on.
+            outer_split_id: Outer split to filter on.
             task_id: Task to filter on.
             model_type: Model type to filter on.
         """
@@ -348,25 +348,25 @@ class StudyDiagnostics:
             print("No Optuna data found.")
             return
 
-        if _has_ipywidgets() and outersplit_id is None:
+        if _has_ipywidgets() and outer_split_id is None:
             from ipywidgets import Dropdown, interact  # noqa: PLC0415
 
-            opts = self._get_filter_options(df, ["outersplit_id", "task_id", "model_type"])
+            opts = self._get_filter_options(df, ["outer_split_id", "task_id", "model_type"])
 
             @interact(
-                outersplit_id=Dropdown(options=opts.get("outersplit_id", ["0"]), description="Outersplit:"),
+                outer_split_id=Dropdown(options=opts.get("outer_split_id", ["0"]), description="Outer Split:"),
                 task_id=Dropdown(options=opts.get("task_id", ["0"]), description="Task:"),
                 model_type=Dropdown(options=opts.get("model_type", [""]), description="Model:"),
             )
-            def _plot(outersplit_id: str, task_id: str, model_type: str) -> None:
+            def _plot(outer_split_id: str, task_id: str, model_type: str) -> None:
                 fig = plot_optuna_hyperparameters_chart(
-                    df, outersplit_id=outersplit_id, task_id=task_id, model_type=model_type
+                    df, outer_split_id=outer_split_id, task_id=task_id, model_type=model_type
                 )
                 fig.show()
         else:
             fig = plot_optuna_hyperparameters_chart(
                 df,
-                outersplit_id=outersplit_id or 0,
+                outer_split_id=outer_split_id or 0,
                 task_id=task_id or 0,
                 model_type=model_type or "",
             )

--- a/octopus/exceptions.py
+++ b/octopus/exceptions.py
@@ -13,5 +13,5 @@ class UnknownMetricError(Exception):
     """An attempt was made to use an metric that does not exists."""
 
 
-class SingleClassFoldError(ValueError):
-    """A cross-validation fold contains only a single class label."""
+class SingleClassSplitError(ValueError):
+    """A cross-validation split contains only a single class label."""

--- a/octopus/logger.py
+++ b/octopus/logger.py
@@ -24,15 +24,15 @@ class ContextualFilter(logging.Filter):
         return True
 
 
-class OptunaHandler(logging.Handler):
-    """Optuna handler."""
+class ExternalHandler(logging.Handler):
+    """Handler that forwards external library logs to the Octopus logger."""
 
     def __init__(self, logger):
         super().__init__()
         self.logger = logger
 
     def emit(self, record):
-        """Forward the Optuna log to our custom logger."""
+        """Forward the log record to the Octopus logger."""
         self.logger.log(record.levelno, record.getMessage())
 
 
@@ -132,12 +132,20 @@ def setup_logger(name="OctoManager", log_file: UPath | None = None, level=loggin
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
 
-    # Set up Optuna logging
+    # Route external library logs through the Octopus logger
+    external_handler = ExternalHandler(logger)
+
     optuna_logger = logging.getLogger("optuna")
+    optuna_logger.handlers.clear()
     optuna_logger.setLevel(level)
     optuna_logger.propagate = False
-    optuna_handler = OptunaHandler(logger)
-    optuna_logger.addHandler(optuna_handler)
+    optuna_logger.addHandler(external_handler)
+
+    autogluon_logger = logging.getLogger("autogluon")
+    autogluon_logger.handlers.clear()
+    autogluon_logger.setLevel(level)
+    autogluon_logger.propagate = False
+    autogluon_logger.addHandler(external_handler)
 
     # Override the default log level colors
     def colorize_log(record):
@@ -194,15 +202,6 @@ def set_logger_filename(logger: logging.Logger | None = None, log_file: UPath | 
         file_handler.setLevel(level if level is not None else logger.level)
         file_handler.setFormatter(file_formatter)
         logger.addHandler(file_handler)
-
-
-def set_optuna_log_group(logger):
-    """Set optuna log group."""
-
-    def optuna_log_group_setter(study, trial):
-        logger.set_log_group(LogGroup.OPTUNA)
-
-    return optuna_log_group_setter
 
 
 # Create a single instance of the logger

--- a/octopus/manager/__init__.py
+++ b/octopus/manager/__init__.py
@@ -5,7 +5,7 @@ from octopus.manager.execution import (
     ExecutionStrategy,
     ParallelRayStrategy,
     SequentialStrategy,
-    SingleOutersplitStrategy,
+    SingleOuterSplitStrategy,
 )
 from octopus.manager.workflow_runner import WorkflowTaskRunner
 
@@ -14,6 +14,6 @@ __all__ = [
     "OctoManager",
     "ParallelRayStrategy",
     "SequentialStrategy",
-    "SingleOutersplitStrategy",
+    "SingleOuterSplitStrategy",
     "WorkflowTaskRunner",
 ]

--- a/octopus/manager/core.py
+++ b/octopus/manager/core.py
@@ -11,7 +11,7 @@ from octopus.manager.execution import (
     ExecutionStrategy,
     ParallelRayStrategy,
     SequentialStrategy,
-    SingleOutersplitStrategy,
+    SingleOuterSplitStrategy,
 )
 from octopus.manager.workflow_runner import WorkflowTaskRunner
 from octopus.modules import StudyContext, Task
@@ -21,10 +21,10 @@ logger = get_logger()
 
 @define
 class OctoManager:
-    """Orchestrates the execution of outersplits."""
+    """Orchestrates the execution of outer splits."""
 
-    outersplit_data: OuterSplits = field(validator=[validators.instance_of(dict)])
-    """Preprocessed data for each outersplit, keyed by outersplit identifier."""
+    outer_split_data: OuterSplits = field(validator=[validators.instance_of(dict)])
+    """Preprocessed data for each outer split, keyed by outer split identifier."""
 
     study_context: StudyContext = field(validator=[validators.instance_of(StudyContext)])
     """Frozen runtime context containing study configuration."""
@@ -32,26 +32,25 @@ class OctoManager:
     workflow: Sequence[Task] = field(validator=[validators.instance_of(list)])
     """Workflow tasks to execute."""
 
-    num_cpus: int = field(validator=validators.instance_of(int))
-    """Number of CPUs to use for parallel processing. num_cpus=0 uses all available CPUs.
-       Negative values indicate abs(num_cpus) to leave free, e.g. -1 means use all but one CPU.
+    n_cpus: int = field(validator=validators.instance_of(int))
+    """Number of CPUs to use for parallel processing. n_cpus=0 uses all available CPUs.
+       Negative values indicate abs(n_cpus) to leave free, e.g. -1 means use all but one CPU.
        Set to 1 to disable all parallel processing and run sequentially."""
 
-    run_single_outersplit_num: int | None = field(
-        validator=validators.optional([validators.instance_of(int), validators.ge(0)])
+    single_outer_split: int | None = field(
+        validator=validators.optional(validators.and_(validators.instance_of(int), validators.ge(0)))
     )
-    """Index of single outersplit to run (None for all)."""
+    """Index of single outer split to run (None for all)."""
 
-    def run_outersplits(self) -> None:
-        """Run all outersplits."""
-        if not self.outersplit_data:
-            raise ValueError("No outersplit data defined")
+    def run_outer_splits(self) -> None:
+        """Run all outer splits."""
+        if not self.outer_split_data:
+            raise ValueError("No outer split data defined")
 
-        if self.run_single_outersplit_num is not None and not (
-            0 <= self.run_single_outersplit_num < len(self.outersplit_data)
-        ):
+        if self.single_outer_split is not None and not (0 <= self.single_outer_split < len(self.outer_split_data)):
             raise ValueError(
-                f"run_single_outersplit_num must be between 0 and num_outersplits-1 ({len(self.outersplit_data) - 1}), got {self.run_single_outersplit_num}"
+                f"single_outer_split must be between 0 and n_outer_splits-1"
+                f" ({len(self.outer_split_data) - 1}), got {self.single_outer_split}"
             )
 
         # Initialize Ray upfront to ensure worker setup hooks are registered before any workflows execute.
@@ -61,9 +60,9 @@ class OctoManager:
         # 2. Lifecycle clarity: Explicit init → run → shutdown at the manager level makes the
         #    Ray lifecycle predictable and easier to reason about
         resources = ray_parallel.init(
-            num_cpus_user=self.num_cpus,
-            num_outersplits=len(self.outersplit_data),
-            run_single_outersplit=self.run_single_outersplit_num is not None,
+            n_cpus_user=self.n_cpus,
+            n_outer_splits=len(self.outer_split_data),
+            run_single_outer_split=self.single_outer_split is not None,
             namespace=f"octopus_study_{self.study_context.output_path}",
         )
 
@@ -75,7 +74,7 @@ class OctoManager:
                 workflow=self.workflow,
             )
             strategy = self._select_strategy(resources)
-            strategy.execute(self.outersplit_data, runner.run)
+            strategy.execute(self.outer_split_data, runner.run)
         finally:
             ray_parallel.shutdown()
 
@@ -88,17 +87,17 @@ class OctoManager:
         Returns:
             Appropriate execution strategy based on configuration.
         """
-        if self.run_single_outersplit_num is not None:
-            return SingleOutersplitStrategy(
-                outersplit_index=self.run_single_outersplit_num,
-                num_cpus=resources.cpus_per_worker,
+        if self.single_outer_split is not None:
+            return SingleOuterSplitStrategy(
+                outer_split_index=self.single_outer_split,
+                n_cpus=resources.cpus_per_worker,
             )
-        elif resources.num_workers > 1:
+        elif resources.n_workers > 1:
             return ParallelRayStrategy(
-                num_cpus_per_worker=resources.cpus_per_worker,
+                n_cpus_per_worker=resources.cpus_per_worker,
                 log_dir=self.study_context.log_dir,
             )
         else:
             return SequentialStrategy(
-                num_cpus=resources.cpus_per_worker,
+                n_cpus=resources.cpus_per_worker,
             )

--- a/octopus/manager/execution.py
+++ b/octopus/manager/execution.py
@@ -1,4 +1,4 @@
-"""Execution strategies for running outersplits."""
+"""Execution strategies for running outer splits."""
 
 from typing import TYPE_CHECKING, Protocol
 
@@ -17,89 +17,89 @@ logger = get_logger()
 
 
 class ExecutionStrategy(Protocol):
-    """Protocol for outersplit execution strategies."""
+    """Protocol for outer split execution strategies."""
 
     def execute(
         self,
-        outersplit_data: OuterSplits,
+        outer_split_data: OuterSplits,
         run_fn: "Callable[[int, OuterSplit, int], None]",
     ) -> None:
-        """Execute outersplits using this strategy."""
+        """Execute outer splits using this strategy."""
         ...
 
 
 @define
-class SingleOutersplitStrategy(ExecutionStrategy):
-    """Run a single outersplit by index."""
+class SingleOuterSplitStrategy(ExecutionStrategy):
+    """Run a single outer split by index."""
 
-    outersplit_index: int = field(validator=[validators.instance_of(int), validators.ge(0)])
-    num_cpus: int = field(validator=[validators.instance_of(int), validators.ge(1)])
-    """Number of CPUs to use for parallel processing within the single outersplit."""
+    outer_split_index: int = field(validator=[validators.instance_of(int), validators.ge(0)])
+    n_cpus: int = field(validator=[validators.instance_of(int), validators.ge(1)])
+    """Number of CPUs to use for parallel processing within the single outer split."""
 
     def execute(
         self,
-        outersplit_data: OuterSplits,
+        outer_split_data: OuterSplits,
         run_fn: "Callable[[int, OuterSplit, int], None]",
     ) -> None:
-        """Execute only the outersplit at outersplit_index."""
+        """Execute only the outer split at outer_split_index."""
         logger.set_log_group(LogGroup.PROCESSING)
-        logger.info(f"Running single outersplit: {self.outersplit_index}")
-        outersplit_id = self.outersplit_index
-        run_fn(outersplit_id, outersplit_data[outersplit_id], self.num_cpus)
+        logger.info(f"Running single outer split: {self.outer_split_index}")
+        outer_split_id = self.outer_split_index
+        run_fn(outer_split_id, outer_split_data[outer_split_id], self.n_cpus)
 
 
 @define
 class SequentialStrategy(ExecutionStrategy):
-    """Run outersplits one after another."""
+    """Run outer splits one after another."""
 
-    num_cpus: int = field(validator=[validators.instance_of(int), validators.ge(1)])
+    n_cpus: int = field(validator=[validators.instance_of(int), validators.ge(1)])
     """Number of CPUs to use for parallel processing in each sequential step."""
 
     def execute(
         self,
-        outersplit_data: OuterSplits,
+        outer_split_data: OuterSplits,
         run_fn: "Callable[[int, OuterSplit, int], None]",
     ) -> None:
-        """Execute all outersplits sequentially."""
+        """Execute all outer splits sequentially."""
         logger.set_log_group(LogGroup.PROCESSING)
-        for outersplit_id in outersplit_data:
-            logger.info(f"Running outer split: {outersplit_id}")
-            run_fn(outersplit_id, outersplit_data[outersplit_id], self.num_cpus)
+        for outer_split_id in outer_split_data:
+            logger.info(f"Running outer split: {outer_split_id}")
+            run_fn(outer_split_id, outer_split_data[outer_split_id], self.n_cpus)
 
 
 @define
 class ParallelRayStrategy(ExecutionStrategy):
-    """Run outersplits in parallel using Ray.
+    """Run outer splits in parallel using Ray.
 
     This strategy starts as many parallel workers as allowed by the resource
     configuration set up in ray_parallel.init() and executes one outer split per worker.
     """
 
-    num_cpus_per_worker: int = field(validator=[validators.instance_of(int), validators.ge(1)])
+    n_cpus_per_worker: int = field(validator=[validators.instance_of(int), validators.ge(1)])
     """Number of CPUs to use for parallel processing within each parallel worker."""
     log_dir: UPath = field(validator=validators.instance_of(UPath))
 
     def execute(
         self,
-        outersplit_data: OuterSplits,
+        outer_split_data: OuterSplits,
         run_fn: "Callable[[int, OuterSplit, int], None]",
     ) -> None:
         """Execute all outer splits in parallel using Ray."""
 
-        def wrapped_run(outersplit_id: int, outersplit: OuterSplit, num_cpus_per_worker: int) -> None:
-            logger.set_log_group(LogGroup.PROCESSING, f"OUTER {outersplit_id}")
-            logger.info(f"Starting execution for outer split {outersplit_id}")
+        def wrapped_run(outer_split_id: int, outer_split: OuterSplit, n_cpus_per_worker: int) -> None:
+            logger.set_log_group(LogGroup.PROCESSING, f"OUTER {outer_split_id}")
+            logger.info(f"Starting execution for outer split {outer_split_id}")
             try:
-                run_fn(outersplit_id, outersplit, num_cpus_per_worker)
-                logger.set_log_group(LogGroup.PREPARE_EXECUTION, f"OUTER {outersplit_id}")
-                logger.info(f"Completed successfully for outer split {outersplit_id}")
+                run_fn(outer_split_id, outer_split, n_cpus_per_worker)
+                logger.set_log_group(LogGroup.PREPARE_EXECUTION, f"OUTER {outer_split_id}")
+                logger.info(f"Completed successfully for outer split {outer_split_id}")
             except Exception as e:
-                logger.exception(f"Exception in task {outersplit_id}: {e!s}")
+                logger.exception(f"Exception in task {outer_split_id}: {e!s}")
                 raise e
 
         ray_parallel.run_parallel_outer(
-            outersplit_data=outersplit_data,
+            outer_split_data=outer_split_data,
             run_fn=wrapped_run,
             log_dir=self.log_dir,
-            num_cpus_per_worker=self.num_cpus_per_worker,
+            n_cpus_per_worker=self.n_cpus_per_worker,
         )

--- a/octopus/manager/ray_parallel.py
+++ b/octopus/manager/ray_parallel.py
@@ -2,7 +2,7 @@
 
 import os
 from collections.abc import Callable, Sequence
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import ray
 import threadpoolctl
@@ -12,8 +12,10 @@ from upath import UPath
 
 from octopus.datasplit import OuterSplit, OuterSplits
 from octopus.logger import get_logger, set_logger_filename
-from octopus.modules.octo.bag import FeatureImportanceWithLogging, TrainingWithLogging
 from octopus.modules.octo.training import Training
+
+if TYPE_CHECKING:
+    from octopus.modules.octo.bag import FIWithLogging, TrainingWithLogging
 
 logger = get_logger()
 
@@ -67,34 +69,34 @@ class ResourceConfig:
     available_cpus: int = field(validator=validators.instance_of(int))
     """Total number of CPUs available for parallel processing (inner * outer parallelization)."""
 
-    num_workers: int = field(validator=validators.instance_of(int))
+    n_workers: int = field(validator=validators.instance_of(int))
     """Number of parallel outer workers."""
 
     cpus_per_worker: int = field(validator=validators.instance_of(int))
     """CPUs allocated to each worker for inner parallelization."""
 
     ray_nodes: dict[str, _NodeResources] = field(validator=validators.instance_of(dict))
-    """Dictionary of Ray nodes and their resources, used for calculating available_cpus and num_workers."""
+    """Dictionary of Ray nodes and their resources, used for calculating available_cpus and n_workers."""
 
-    num_outersplits: int = field(validator=validators.instance_of(int))
-    """Total number of outersplits in the study."""
+    n_outer_splits: int = field(validator=validators.instance_of(int))
+    """Total number of outer splits in the study."""
 
-    run_single_outersplit: bool = field(validator=validators.instance_of(bool))
-    """Whether to run a single outer split instead of all . This is mainly used for testing and debugging."""
+    run_single_outer_split: bool = field(validator=validators.instance_of(bool))
+    """Whether to run a single outer split instead of all. This is mainly used for testing and debugging."""
 
     @classmethod
     def create(
         cls,
         ray_nodes: dict[str, _NodeResources],
-        num_outersplits: int,
-        run_single_outersplit: bool,
+        n_outer_splits: int,
+        run_single_outer_split: bool,
     ) -> "ResourceConfig":
         """Create ResourceConfig with computed values.
 
         Args:
             ray_nodes: Dictionary of Ray nodes and their available CPU resources.
-            num_outersplits: Total number of outersplits in the study.
-            run_single_outersplit: Whether to run a single outer split instead of all.
+            n_outer_splits: Total number of outer splits in the study.
+            run_single_outer_split: Whether to run a single outer split instead of all.
               This is mainly used for testing and debugging.
 
         Returns:
@@ -103,29 +105,31 @@ class ResourceConfig:
         Raises:
             ValueError: If any input parameter is invalid.
         """
-        if num_outersplits <= 0:
-            raise ValueError(f"num_outersplits must be positive, got {num_outersplits}")
+        if n_outer_splits <= 0:
+            raise ValueError(f"n_outer_splits must be positive, got {n_outer_splits}")
 
-        # Calculate effective number of outersplits for resource allocation
-        effective_num_outersplits = 1 if run_single_outersplit else num_outersplits
+        # Calculate effective number of outer splits for resource allocation
+        effective_n_outer_splits = 1 if run_single_outer_split else n_outer_splits
 
-        # TODO: instead of summing all CPUs we should properly use the node/resource architecture, i.e. num_workers should be a multiple of len(nodes)
+        # TODO: instead of summing all CPUs we should properly use the node/resource architecture, i.e. n_workers should be a multiple of len(nodes)
         available_cpus = sum(int(node["CPU"]) for node in ray_nodes.values())
 
         # Calculate resource allocation
-        num_workers = min(effective_num_outersplits, available_cpus)
-        if num_workers == 0:
+        n_workers = min(effective_n_outer_splits, available_cpus)
+        if n_workers == 0:
             raise ValueError(
-                f"Cannot allocate resources: num_workers computed as 0 (effective_num_outersplits={effective_num_outersplits}, available_cpus={available_cpus})"
+                f"Cannot allocate resources: n_workers computed as 0 "
+                f"(effective_n_outer_splits={effective_n_outer_splits}, "
+                f"available_cpus={available_cpus})"
             )
 
         return cls(
             available_cpus=available_cpus,
-            num_workers=num_workers,
-            cpus_per_worker=max(1, available_cpus // num_workers),
+            n_workers=n_workers,
+            cpus_per_worker=max(1, available_cpus // n_workers),
             ray_nodes=ray_nodes,
-            num_outersplits=num_outersplits,
-            run_single_outersplit=run_single_outersplit,
+            n_outer_splits=n_outer_splits,
+            run_single_outer_split=run_single_outer_split,
         )
 
     def __str__(self) -> str:
@@ -133,19 +137,19 @@ class ResourceConfig:
         nodes = "\n\t".join(f"Node {node}:  {res['CPU']} CPUs" for node, res in self.ray_nodes.items())
 
         return (
-            f"\nSingle outersplit: {self.run_single_outersplit}"
-            f"\nOutersplits:       {self.num_outersplits}"
+            f"\nSingle outer split: {self.run_single_outer_split}"
+            f"\nOuter splits:      {self.n_outer_splits}"
             f"\nAvailable CPUs:    {self.available_cpus}"
-            f"\nWorkers:           {self.num_workers}"
-            f"\nCPUs/outersplit:   {self.cpus_per_worker}"
+            f"\nWorkers:           {self.n_workers}"
+            f"\nCPUs/outer split:  {self.cpus_per_worker}"
             f"\nRay Nodes:\n\t{nodes}"
         )
 
 
 def init(
-    num_cpus_user: int,
-    num_outersplits: int,
-    run_single_outersplit: bool,
+    n_cpus_user: int,
+    n_outer_splits: int,
+    run_single_outer_split: bool,
     address: str | None = None,
     namespace: str | None = None,
 ):
@@ -161,11 +165,11 @@ def init(
     cause resource conflicts.
 
     Args:
-        num_cpus_user: Number of CPUs requested by the user. for parallel processing. num_cpus=0 uses all available CPUs.
-          Negative values indicate abs(num_cpus) to leave free, e.g. -1 means use all but one CPU.
+        n_cpus_user: Number of CPUs requested by the user. for parallel processing. n_cpus=0 uses all available CPUs.
+          Negative values indicate abs(n_cpus) to leave free, e.g. -1 means use all but one CPU.
           Set to 1 to disable all parallel processing and run sequentially.
-        num_outersplits: Total number of outersplits in the study.
-        run_single_outersplit: Whether to run a single outer split instead of all. This is mainly used for testing and debugging.
+        n_outer_splits: Total number of outer splits in the study.
+        run_single_outer_split: Whether to run a single outer split instead of all. This is mainly used for testing and debugging.
         address: Ray head address (e.g., "auto", "127.0.0.1:6379", "local"). If None, uses
             env vars RAY_ADDRESS or RAY_HEAD_ADDRESS if set.
         namespace: Ray namespace to use for all operations. If None, uses the default namespace.
@@ -174,7 +178,7 @@ def init(
         ResourceConfig with details about the initialized Ray cluster and resource allocation.
 
     Raises:
-        ValueError: If num_cpus_user is set to a value that leaves no CPUs available in case of starting a local ray instance.
+        ValueError: If n_cpus_user is set to a value that leaves no CPUs available in case of starting a local ray instance.
     """
     if ray.is_initialized():
         logger.info("Ray is already initialized. Skipping initialization.")
@@ -189,31 +193,31 @@ def init(
     else:
         total_cpus_local = _get_locally_available_cpus()
 
-        if num_cpus_user == 0:
-            num_cpus = total_cpus_local
-        elif num_cpus_user < 0:
-            num_cpus = total_cpus_local + num_cpus_user  # Negative means leave some CPUs free
-            if num_cpus <= 0:
+        if n_cpus_user == 0:
+            n_cpus = total_cpus_local
+        elif n_cpus_user < 0:
+            n_cpus = total_cpus_local + n_cpus_user  # Negative means leave some CPUs free
+            if n_cpus <= 0:
                 raise ValueError(
-                    f"num_cpus is set to {num_cpus_user}, which leaves no CPUs available (total_cpus={total_cpus_local})."
+                    f"n_cpus is set to {n_cpus_user}, which leaves no CPUs available (total_cpus={total_cpus_local})."
                 )
-        elif num_cpus_user > total_cpus_local:
+        elif n_cpus_user > total_cpus_local:
             raise ValueError(
-                f"Requested num_cpus={num_cpus_user} exceeds total locally available CPUs ({total_cpus_local}). This may "
-                "lead to oversubscription and degraded performance. Reduce num_cpus or set it to 0 to use all available CPUs. "
+                f"Requested n_cpus={n_cpus_user} exceeds total locally available CPUs ({total_cpus_local}). This may "
+                "lead to oversubscription and degraded performance. Reduce n_cpus or set it to 0 to use all available CPUs. "
             )
         else:
-            num_cpus = num_cpus_user
+            n_cpus = n_cpus_user
 
-        logger.info(f"Creating a local ray instance with {num_cpus} CPUs.")
-        ray.init(address="local", num_cpus=num_cpus, namespace=namespace)
+        logger.info(f"Creating a local ray instance with {n_cpus} CPUs.")
+        ray.init(address="local", num_cpus=n_cpus, namespace=namespace)
 
     ray_nodes = _get_ray_nodes()
 
     resource_config = ResourceConfig.create(
         ray_nodes=ray_nodes,
-        num_outersplits=num_outersplits,
-        run_single_outersplit=run_single_outersplit,
+        n_outer_splits=n_outer_splits,
+        run_single_outer_split=run_single_outer_split,
     )
 
     if ray_address := ray.get_runtime_context().gcs_address:
@@ -245,25 +249,25 @@ def _setup_worker_logging(log_dir: UPath):
 
 
 def run_parallel_outer(
-    outersplit_data: OuterSplits,
+    outer_split_data: OuterSplits,
     run_fn: Callable[[int, OuterSplit, int], None],
     log_dir: UPath,
-    num_cpus_per_worker: int,
+    n_cpus_per_worker: int,
 ) -> None:
-    """Execute run_fn(outersplit_id, outersplit, num_cpus_per_worker) in parallel using Ray.
+    """Execute run_fn(outer_split_id, outer_split, n_cpus_per_worker) in parallel using Ray.
 
     Preserves input order. Essentially, one Ray actor is created per outer task, and each
-    actor executes run_fn for its assigned outersplit_id. The runtime environment of the
+    actor executes run_fn for its assigned outer_split_id. The runtime environment of the
     subprocesses is configured to allow inner parallelism (e.g. by AutoGluon)
     without oversubscribing CPUs through setting environment variables that many
     libraries respect (e.g. OpenBLAS, MKL, NumExpr, etc.) to
-    num_cpus_per_worker and via a threadpoolctl limit.
+    n_cpus_per_worker and via a threadpoolctl limit.
 
     Args:
-        outersplit_data: Dictionary mapping outersplit_id to OuterSplit(traindev, test).
-        run_fn: Function called as run_fn(outersplit_id, outersplit, num_cpus_per_worker).
+        outer_split_data: Dictionary mapping outer_split_id to OuterSplit(traindev, test).
+        run_fn: Function called as run_fn(outer_split_id, outer_split, n_cpus_per_worker).
         log_dir: Directory to store individual Ray worker logs.
-        num_cpus_per_worker: CPUs used for each outer task to prevent
+        n_cpus_per_worker: CPUs used for each outer task to prevent
           oversubscription during inner parallel work. Outer workers do not reserve these
           CPUs by themselves but set them in the environment for libraries to respect and
           enforce via threadpoolctl in inner parallel code. This allows inner parallelism
@@ -273,41 +277,41 @@ def run_parallel_outer(
         raise RuntimeError("Ray is not initialized. Call ray_parallel.init() first.")
 
     class OuterTask:
-        def __init__(self, outersplit_id: int, outersplit: OuterSplit, log_dir: UPath, num_cpus: int):
+        def __init__(self, outer_split_id: int, outer_split: OuterSplit, log_dir: UPath, n_cpus: int):
             _setup_worker_logging(log_dir)
-            self.outersplit_id = outersplit_id
-            self.outersplit = outersplit
-            self.num_cpus = num_cpus
+            self.outer_split_id = outer_split_id
+            self.outer_split = outer_split
+            self.n_cpus = n_cpus
 
         @ray.method
         def run(self):
-            with threadpoolctl.threadpool_limits(limits=self.num_cpus):
-                run_fn(self.outersplit_id, self.outersplit, self.num_cpus)
-            return self.outersplit_id
+            with threadpoolctl.threadpool_limits(limits=self.n_cpus):
+                run_fn(self.outer_split_id, self.outer_split, self.n_cpus)
+            return self.outer_split_id
 
     OuterTaskActor = ray.remote(OuterTask)
 
     # do our best to prevent oversubscription of CPUs by setting environment variables that many libraries respect (e.g. OpenBLAS, MKL, NumExpr, etc.)
-    runtime_env = RuntimeEnv(env_vars={var: str(num_cpus_per_worker) for var in _PARALLELIZATION_ENV_VARS})
+    runtime_env = RuntimeEnv(env_vars={var: str(n_cpus_per_worker) for var in _PARALLELIZATION_ENV_VARS})
 
     futures = [
         OuterTaskActor.options(
-            name=f"outer_task_{outersplit_id}",
-            num_cpus=num_cpus_per_worker,  # Outer task reserves all CPUs required for individual inner parallelization
+            name=f"outer_task_{outer_split_id}",
+            num_cpus=n_cpus_per_worker,  # Outer task reserves all CPUs required for individual inner parallelization
             runtime_env=runtime_env,
         )
-        .remote(outersplit_id, outersplit, log_dir, num_cpus_per_worker)
+        .remote(outer_split_id, outer_split, log_dir, n_cpus_per_worker)
         .run.remote()
-        for outersplit_id, outersplit in outersplit_data.items()
+        for outer_split_id, outer_split in outer_split_data.items()
     ]
     ray.get(futures)
 
 
 def run_parallel_inner(
     bag_id: str,
-    trainings: Sequence[TrainingWithLogging | FeatureImportanceWithLogging],
+    trainings: "Sequence[TrainingWithLogging | FIWithLogging]",
     log_dir: UPath,
-    num_assigned_cpus: int,
+    n_assigned_cpus: int,
 ) -> list[Training]:
     """Run training.fit() for each item inside trainings in parallel.
 
@@ -315,7 +319,7 @@ def run_parallel_inner(
         bag_id: Identifier for the bag.
         trainings: Objects with fit() method.
         log_dir: Directory to store individual Ray worker logs.
-        num_assigned_cpus: CPUs for parallel execution of the fit() methods.
+        n_assigned_cpus: CPUs for parallel execution of the fit() methods.
 
     Returns:
         Results from each training.fit() in input order.
@@ -329,21 +333,21 @@ def run_parallel_inner(
     # do our best to prevent oversubscription of CPUs by setting environment variables that many libraries respect (e.g. OpenBLAS, MKL, NumExpr, etc.)
     runtime_env = RuntimeEnv(env_vars=dict.fromkeys(_PARALLELIZATION_ENV_VARS, "1"))
 
-    # num_assigned_cpus inner tasks will run in parallel (See below), each task only gets one CPU
+    # n_assigned_cpus inner tasks will run in parallel (See below), each task only gets one CPU
     @ray.remote
     def execute_training(training: Any, idx: int, log_dir: UPath) -> tuple[int, Training]:
         _setup_worker_logging(log_dir)
         with threadpoolctl.threadpool_limits(limits=1):
             return idx, training.fit()
 
-    # Fill task queue and limit concurrency to num_assigned_cpus to avoid oversubscription.
+    # Fill task queue and limit concurrency to n_assigned_cpus to avoid oversubscription.
     # Approach from https://docs.ray.io/en/latest/ray-core/patterns/limit-pending-tasks.html
 
     results: list[Training] = [None] * len(trainings)  # type: ignore[list-item]
 
     inflight_refs: list[ray.ObjectRef] = []
     for training_idx, training in enumerate(trainings):
-        if len(inflight_refs) >= num_assigned_cpus:
+        if len(inflight_refs) >= n_assigned_cpus:
             # wait for at least one task to complete before launching more to limit resource usage
             ready_refs, inflight_refs = ray.wait(inflight_refs, num_returns=1)
 

--- a/octopus/manager/workflow_runner.py
+++ b/octopus/manager/workflow_runner.py
@@ -38,22 +38,22 @@ class WorkflowTaskRunner:
     study_context: StudyContext = field(validator=[validators.instance_of(StudyContext)])
     workflow: Sequence[Task] = field(validator=[validators.instance_of(list)])
 
-    def run(self, outersplit_id: int, outersplit: OuterSplit, num_assigned_cpus: int) -> None:
+    def run(self, outer_split_id: int, outer_split: OuterSplit, n_assigned_cpus: int) -> None:
         """Process all workflow tasks for a single outer split.
 
         Args:
-            outersplit_id: Current outer split ID
-            outersplit: OuterSplit containing traindev and test DataFrames
-            num_assigned_cpus: Number of CPUs assigned to this outer split for inner parallel processing
+            outer_split_id: Current outer split ID
+            outer_split: OuterSplit containing traindev and test DataFrames
+            n_assigned_cpus: Number of CPUs assigned to this outer split for inner parallel processing
         """
         # Save split row IDs (not full datasets) for reproducibility
-        outer_split_dir = self.study_context.output_path / f"outersplit{outersplit_id}"
+        outer_split_dir = self.study_context.output_path / f"outersplit{outer_split_id}"
         outer_split_dir.mkdir(parents=True, exist_ok=True)
         row_id_col = self.study_context.row_id_col
         split_ids = {
             "row_id_col": row_id_col,
-            "traindev_row_ids": outersplit.traindev[row_id_col].tolist(),
-            "test_row_ids": outersplit.test[row_id_col].tolist(),
+            "traindev_row_ids": outer_split.traindev[row_id_col].tolist(),
+            "test_row_ids": outer_split.test[row_id_col].tolist(),
         }
         with (outer_split_dir / "split_row_ids.json").open("w") as f:
             json.dump(split_ids, f)
@@ -63,25 +63,25 @@ class WorkflowTaskRunner:
 
         for task in self.workflow:
             self._log_task_info(task)
-            result = self._run_task(outersplit_id, outersplit, task, num_assigned_cpus, task_results, outer_split_dir)
+            result = self._run_task(outer_split_id, outer_split, task, n_assigned_cpus, task_results, outer_split_dir)
             task_results[task.task_id] = result
 
     def _run_task(
         self,
-        outersplit_id: int,
-        outersplit: OuterSplit,
+        outer_split_id: int,
+        outer_split: OuterSplit,
         task: Task,
-        num_assigned_cpus: int,
+        n_assigned_cpus: int,
         task_results: dict[int, dict[ResultType, ModuleResult]],
         outer_split_dir: UPath,
     ) -> dict[ResultType, ModuleResult]:
         """Run a single workflow task.
 
         Args:
-            outersplit_id: Current outer split ID
-            outersplit: OuterSplit containing traindev and test DataFrames
+            outer_split_id: Current outer split ID
+            outer_split: OuterSplit containing traindev and test DataFrames
             task: Task to run
-            num_assigned_cpus: Number of CPUs assigned to this outer split for inner parallel processing
+            n_assigned_cpus: Number of CPUs assigned to this outer split for inner parallel processing
             task_results: Dictionary of results from previous tasks
             outer_split_dir: directory where all data/results relevant for this outer
               split reside / should be saved to
@@ -100,22 +100,22 @@ class WorkflowTaskRunner:
             feature_cols = upstream_results[ResultType.BEST].selected_features
             # Build prior_results by concatenating DataFrames from all upstream ModuleResult values
             prior_results: dict[str, pd.DataFrame] = {}
-            for df_name in ["scores", "predictions", "feature_importances"]:
+            for attr_name, key in [("scores", "scores"), ("predictions", "predictions"), ("fi", "fi")]:
                 dfs = []
                 for module_result in upstream_results.values():
-                    df = getattr(module_result, df_name)
+                    df = getattr(module_result, attr_name)
                     if isinstance(df, pd.DataFrame) and not df.empty:
                         out = df.copy()
                         out["module"] = module_result.module
                         dfs.append(out)
-                prior_results[df_name] = pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
+                prior_results[key] = pd.concat(dfs, ignore_index=True) if dfs else pd.DataFrame()
             logger.info(f"Prior results keys: {prior_results.keys()}")
         else:
             feature_cols = self.study_context.feature_cols
             prior_results = {}
 
         # Calculate feature groups
-        feature_groups = calculate_feature_groups(outersplit.traindev, feature_cols)
+        feature_groups = calculate_feature_groups(outer_split.traindev, feature_cols)
 
         # Create output directory
         module_output_dir = outer_split_dir / f"task{task.task_id}"
@@ -125,19 +125,19 @@ class WorkflowTaskRunner:
         module_scratch_dir = module_output_dir / "scratch"
         module_scratch_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Running task {task.task_id} for outer split {outersplit_id}")
+        logger.info(f"Running task {task.task_id} for outer split {outer_split_id}")
 
         # Create execution module from config and run fit()
         module = task.create_module()
         results = module.fit(
-            data_traindev=outersplit.traindev,
-            data_test=outersplit.test,
+            data_traindev=outer_split.traindev,
+            data_test=outer_split.test,
             feature_cols=feature_cols,
             study_context=self.study_context,
-            outersplit_id=outersplit_id,
+            outer_split_id=outer_split_id,
             results_dir=module_results_dir,
             scratch_dir=module_scratch_dir,
-            num_assigned_cpus=num_assigned_cpus,
+            n_assigned_cpus=n_assigned_cpus,
             feature_groups=feature_groups,
             prior_results=prior_results,
         )

--- a/octopus/models/classification_models.py
+++ b/octopus/models/classification_models.py
@@ -24,7 +24,7 @@ def extra_trees_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=ExtraTreesClassifier,  # type: ignore[arg-type]
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=True,
@@ -51,7 +51,7 @@ def hist_gradient_boosting_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=HistGradientBoostingClassifier,  # type: ignore[arg-type]
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -78,7 +78,7 @@ def gradient_boosting_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=GradientBoostingClassifier,  # type: ignore[arg-type]
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=True,
@@ -103,7 +103,7 @@ def random_forest_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=RandomForestClassifier,  # type: ignore[arg-type]
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=True,  # maybe: False - check!
@@ -128,7 +128,7 @@ def xgb_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=XGBClassifier,
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -154,7 +154,7 @@ def catboost_classifier() -> ModelConfig:
         model_class=CatBoostClassifier,
         # Multiclass excluded: SHAP explainers segfault on CatBoost multiclass models.
         ml_types=[MLType.BINARY],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -184,7 +184,7 @@ def logistic_regression_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=LogisticRegression,  # type: ignore[arg-type]
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.PERMUTATION,
+        fi_method=FIComputeMethod.PERMUTATION,
         n_repeats=2,
         chpo_compatible=True,
         scaler="StandardScaler",
@@ -211,7 +211,7 @@ def gaussian_process_classifier() -> ModelConfig:
     return ModelConfig(
         model_class=GPClassifierWrapper,  # type: ignore[arg-type]
         ml_types=[MLType.BINARY, MLType.MULTICLASS],
-        feature_method=FIComputeMethod.PERMUTATION,
+        fi_method=FIComputeMethod.PERMUTATION,
         n_repeats=2,
         chpo_compatible=False,
         scaler="StandardScaler",

--- a/octopus/models/config.py
+++ b/octopus/models/config.py
@@ -61,7 +61,7 @@ class ModelConfig:
     """Create model config."""
 
     model_class: type[BaseModel]
-    feature_method: FIComputeMethod = field(converter=FIComputeMethod)
+    fi_method: FIComputeMethod = field(converter=FIComputeMethod)
     ml_types: frozenset[MLType] = field(converter=to_ml_types_frozenset, validator=validate_ml_types)
     hyperparameters: list[Hyperparameter] = field(validator=validate_hyperparameters)
     n_repeats: None | int = field(factory=lambda: None)

--- a/octopus/models/regression_models.py
+++ b/octopus/models/regression_models.py
@@ -25,7 +25,7 @@ def ard_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=ARDRegression,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.PERMUTATION,
+        fi_method=FIComputeMethod.PERMUTATION,
         n_repeats=2,
         chpo_compatible=False,
         scaler="StandardScaler",
@@ -51,7 +51,7 @@ def catboost_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=CatBoostRegressor,
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -80,7 +80,7 @@ def elastic_net_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=ElasticNet,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.SHAP,
+        fi_method=FIComputeMethod.SHAP,
         chpo_compatible=True,
         scaler="StandardScaler",
         imputation_required=True,
@@ -105,7 +105,7 @@ def extra_trees_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=ExtraTreesRegressor,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=True,
@@ -129,7 +129,7 @@ def gaussian_process_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=GPRegressorWrapper,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.PERMUTATION,
+        fi_method=FIComputeMethod.PERMUTATION,
         n_repeats=2,
         chpo_compatible=False,
         scaler="StandardScaler",
@@ -154,7 +154,7 @@ def gradient_boosting_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=GradientBoostingRegressor,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=True,
@@ -179,7 +179,7 @@ def random_forest_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=RandomForestRegressor,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=True,  # maybe: False -- check!
@@ -203,7 +203,7 @@ def ridge_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=Ridge,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.SHAP,
+        fi_method=FIComputeMethod.SHAP,
         chpo_compatible=False,
         scaler="StandardScaler",
         imputation_required=True,
@@ -224,7 +224,7 @@ def svr_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=SVR,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.PERMUTATION,
+        fi_method=FIComputeMethod.PERMUTATION,
         n_repeats=2,
         chpo_compatible=False,
         scaler="StandardScaler",
@@ -246,7 +246,7 @@ def xgb_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=XGBRegressor,
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -272,7 +272,7 @@ def hist_gradient_boosting_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=HistGradientBoostingRegressor,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -300,7 +300,7 @@ def tabular_nn_regressor() -> ModelConfig:
     return ModelConfig(
         model_class=TabularNNRegressor,  # type: ignore[arg-type]
         ml_types=[MLType.REGRESSION],
-        feature_method=FIComputeMethod.PERMUTATION,
+        fi_method=FIComputeMethod.PERMUTATION,
         n_repeats=2,
         chpo_compatible=False,
         scaler="StandardScaler",

--- a/octopus/models/time_to_event_models.py
+++ b/octopus/models/time_to_event_models.py
@@ -15,7 +15,7 @@ def catboost_cox_survival() -> ModelConfig:
     return ModelConfig(
         model_class=CatBoostCoxSurvival,  # type: ignore[arg-type]
         ml_types=[MLType.TIMETOEVENT],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,
@@ -43,7 +43,7 @@ def xgboost_cox_survival() -> ModelConfig:
     return ModelConfig(
         model_class=XGBoostCoxSurvival,  # type: ignore[arg-type]
         ml_types=[MLType.TIMETOEVENT],
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         chpo_compatible=True,
         scaler=None,
         imputation_required=False,

--- a/octopus/models/wrapper_models/TabularNNClassifier.py
+++ b/octopus/models/wrapper_models/TabularNNClassifier.py
@@ -33,7 +33,7 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
         activation: Activation function ('relu' or 'elu'). Defaults to 'relu'.
         optimizer: Optimizer type ('adam' or 'adamw'). Defaults to 'adam'.
         random_state: Random seed. Defaults to None.
-        num_threads: Number of threads for PyTorch. Defaults to 1 (set to >1 with caution
+        n_threads: Number of threads for PyTorch. Defaults to 1 (set to >1 with caution
             due to potential deadlocks). If set to 0, number of PyTorch threads will not be limited.
     """
 
@@ -50,7 +50,7 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
         activation: str = "relu",
         optimizer: str = "adam",
         random_state: int | None = None,
-        num_threads: int = 1,
+        n_threads: int = 1,
     ) -> None:
         self.hidden_sizes = hidden_sizes if hidden_sizes is not None else [200, 100]
         self.dropout = dropout
@@ -61,18 +61,18 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
         self.activation = activation
         self.optimizer = optimizer
         self.random_state = random_state
-        self.num_threads = num_threads
+        self.n_threads = n_threads
 
-        if self.num_threads < 0:
-            raise ValueError(f"num_threads must be non-negative, got {self.num_threads}.")
-        elif self.num_threads > 0:
-            if self.num_threads > 1:
+        if self.n_threads < 0:
+            raise ValueError(f"n_threads must be non-negative, got {self.n_threads}.")
+        elif self.n_threads > 0:
+            if self.n_threads > 1:
                 logger.warning(
-                    f"Using {self.num_threads} threads for PyTorch. This may lead to deadlocks in some environments, "
+                    f"Using {self.n_threads} threads for PyTorch. This may lead to deadlocks in some environments, "
                     "see https://github.com/pytorch/pytorch/issues/91547#issuecomment-1370011188."
                 )
 
-            torch.set_num_threads(self.num_threads)
+            torch.set_num_threads(self.n_threads)
 
     def _detect_categorical_columns(self, X: Any) -> tuple[list[str], list[str] | list[int]]:
         """Detect categorical columns from DataFrame.
@@ -86,8 +86,8 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
         if isinstance(X, pd.DataFrame):
             # Use pandas dtypes to detect categorical columns
             cat_cols = X.select_dtypes(include=["object", "category"]).columns.tolist()
-            num_cols = X.select_dtypes(include=[np.number]).columns.tolist()
-            return cat_cols, num_cols
+            numerical_cols = X.select_dtypes(include=[np.number]).columns.tolist()
+            return cat_cols, numerical_cols
         else:
             # If numpy array, no categorical columns
             return [], list(range(X.shape[1]))
@@ -130,7 +130,7 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
         self.n_features_in_ = len(self.feature_names_in_)
 
         # Detect categorical and numerical columns
-        self.cat_cols_, self.num_cols_ = self._detect_categorical_columns(X)
+        self.cat_cols_, self.numerical_cols_ = self._detect_categorical_columns(X)
 
         # Encode categorical features
         self.label_encoders_: dict[str, LabelEncoder] = {}
@@ -152,28 +152,30 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
             X_cat_encoded.append(encoded)
 
         # Enhanced missing value handling for numerical features
-        self.num_medians_ = {}
+        self.numerical_medians_ = {}
         self.missing_indicators_ = []
 
-        X_num_list = []
-        for num_col in self.num_cols_:
-            col_data = X[num_col]
+        X_numerical_list = []
+        for numerical_col in self.numerical_cols_:
+            col_data = X[numerical_col]
             is_missing = col_data.isna()
 
             # Store median for this column
             median_val = col_data.median()
-            self.num_medians_[num_col] = median_val if not pd.isna(median_val) else 0.0
+            self.numerical_medians_[numerical_col] = median_val if not pd.isna(median_val) else 0.0
 
             # Fill missing with median
-            filled_data = col_data.fillna(self.num_medians_[num_col])
-            X_num_list.append(filled_data.to_numpy())
+            filled_data = col_data.fillna(self.numerical_medians_[numerical_col])
+            X_numerical_list.append(filled_data.to_numpy())
 
             # Add missing indicator if there are any missing values
             if is_missing.any():
-                self.missing_indicators_.append(num_col)
-                X_num_list.append(is_missing.astype(np.float32).to_numpy())
+                self.missing_indicators_.append(numerical_col)
+                X_numerical_list.append(is_missing.astype(np.float32).to_numpy())
 
-        X_num = np.column_stack(X_num_list).astype(np.float32) if X_num_list else np.zeros((len(X), 0))
+        X_numerical = (
+            np.column_stack(X_numerical_list).astype(np.float32) if X_numerical_list else np.zeros((len(X), 0))
+        )
         X_cat = np.column_stack(X_cat_encoded) if X_cat_encoded else np.zeros((len(X), 0), dtype=np.int64)
 
         # Build model
@@ -181,7 +183,7 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
 
         # Convert to tensors
         X_cat_tensor = torch.LongTensor(X_cat)
-        X_num_tensor = torch.FloatTensor(X_num)
+        X_numerical_tensor = torch.FloatTensor(X_numerical)
 
         criterion: nn.BCEWithLogitsLoss | nn.CrossEntropyLoss
         if self.is_binary_:
@@ -194,7 +196,7 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
             criterion = nn.CrossEntropyLoss()
 
         # Training
-        dataset = TensorDataset(X_cat_tensor, X_num_tensor, y_tensor)
+        dataset = TensorDataset(X_cat_tensor, X_numerical_tensor, y_tensor)
 
         # Use generator for reproducible shuffling if random_state is set
         if self.random_state is not None:
@@ -221,9 +223,9 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
         self.model_.train()
         for _epoch in range(self.epochs):
             epoch_loss = 0.0
-            for X_cat_batch, X_num_batch, y_batch in dataloader:
+            for X_cat_batch, X_numerical_batch, y_batch in dataloader:
                 optimizer.zero_grad()
-                outputs = self.model_(X_cat_batch, X_num_batch)
+                outputs = self.model_(X_cat_batch, X_numerical_batch)
                 loss = criterion(outputs, y_batch)
                 loss.backward()
 
@@ -260,37 +262,39 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
 
         # Encode categorical features
         X_cat_encoded = []
-        for num_col in self.cat_cols_:
-            le = self.label_encoders_[num_col]
-            X_col = X[num_col].fillna("__NAN__")
+        for cat_col in self.cat_cols_:
+            le = self.label_encoders_[cat_col]
+            X_col = X[cat_col].fillna("__NAN__")
             # Handle unseen categories
             encoded = np.array([le.transform([val])[0] if val in le.classes_ else 0 for val in X_col])  # type: ignore[index]
             X_cat_encoded.append(encoded)
 
         # Prepare numerical features with same missing value handling as fit
-        X_num_list = []
-        for cat_col in self.num_cols_:
-            col_data = X[cat_col]
+        X_numerical_list = []
+        for numerical_col in self.numerical_cols_:
+            col_data = X[numerical_col]
             is_missing = col_data.isna()
 
             # Fill missing with stored median
-            filled_data = col_data.fillna(self.num_medians_[cat_col])
-            X_num_list.append(filled_data.values)
+            filled_data = col_data.fillna(self.numerical_medians_[numerical_col])
+            X_numerical_list.append(filled_data.values)
 
             # Add missing indicator if this column had missing values during training
-            if cat_col in self.missing_indicators_:
-                X_num_list.append(is_missing.astype(np.float32).values)
+            if numerical_col in self.missing_indicators_:
+                X_numerical_list.append(is_missing.astype(np.float32).values)
 
-        X_num = np.column_stack(X_num_list).astype(np.float32) if X_num_list else np.zeros((len(X), 0))
+        X_numerical = (
+            np.column_stack(X_numerical_list).astype(np.float32) if X_numerical_list else np.zeros((len(X), 0))
+        )
         X_cat = np.column_stack(X_cat_encoded) if X_cat_encoded else np.zeros((len(X), 0), dtype=np.int64)
 
         # Convert to tensors and predict
         X_cat_tensor = torch.LongTensor(X_cat)
-        X_num_tensor = torch.FloatTensor(X_num)
+        X_numerical_tensor = torch.FloatTensor(X_numerical)
 
         self.model_.eval()
         with torch.no_grad():
-            logits = self.model_(X_cat_tensor, X_num_tensor)
+            logits = self.model_(X_cat_tensor, X_numerical_tensor)
 
             if self.is_binary_:
                 probs_class1 = torch.sigmoid(logits).numpy().flatten()
@@ -324,7 +328,7 @@ class TabularNNClassifier(ClassifierMixin, BaseEstimator):
             The constructed PyTorch model.
         """
         # Calculate actual number of numerical features (including missing indicators)
-        n_num_features = len(self.num_cols_) + len(self.missing_indicators_)
+        n_num_features = len(self.numerical_cols_) + len(self.missing_indicators_)
 
         # Determine output size: 1 for binary, n_classes for multiclass
         output_size = 1 if self.is_binary_ else self.n_classes_
@@ -383,12 +387,12 @@ class TabularNNClassificationModel(nn.Module):
 
         self.network = nn.Sequential(*layers)
 
-    def forward(self, X_cat: torch.Tensor, X_num: torch.Tensor) -> torch.Tensor:
+    def forward(self, X_cat: torch.Tensor, X_numerical: torch.Tensor) -> torch.Tensor:
         """Forward pass.
 
         Args:
             X_cat: Categorical features.
-            X_num: Numerical features.
+            X_numerical: Numerical features.
 
         Returns:
             Model output.
@@ -401,6 +405,6 @@ class TabularNNClassificationModel(nn.Module):
             cat_features = torch.empty(X_cat.shape[0], 0)
 
         # Concatenate with numerical features
-        x = torch.cat([cat_features, X_num], dim=1)
+        x = torch.cat([cat_features, X_numerical], dim=1)
 
         return self.network(x)

--- a/octopus/models/wrapper_models/TabularNNRegressor.py
+++ b/octopus/models/wrapper_models/TabularNNRegressor.py
@@ -30,7 +30,7 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
         activation: Activation function ('relu' or 'elu'). Defaults to 'relu'.
         optimizer: Optimizer type ('adam' or 'adamw'). Defaults to 'adam'.
         random_state: Random seed. Defaults to None.
-        num_threads: Number of threads for PyTorch. Defaults to 1 (set to >1 with caution
+        n_threads: Number of threads for PyTorch. Defaults to 1 (set to >1 with caution
             due to potential deadlocks). If set to 0, number of PyTorch threads will not be limited.
     """
 
@@ -47,7 +47,7 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
         activation: str = "relu",
         optimizer: str = "adam",
         random_state: int | None = None,
-        num_threads: int = 1,
+        n_threads: int = 1,
     ) -> None:
         self.hidden_sizes = hidden_sizes if hidden_sizes is not None else [200, 100]
         self.dropout = dropout
@@ -58,18 +58,18 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
         self.activation = activation
         self.optimizer = optimizer
         self.random_state = random_state
-        self.num_threads = num_threads
+        self.n_threads = n_threads
 
-        if self.num_threads < 0:
-            raise ValueError(f"num_threads must be non-negative, got {self.num_threads}.")
-        elif self.num_threads > 0:
-            if self.num_threads > 1:
+        if self.n_threads < 0:
+            raise ValueError(f"n_threads must be non-negative, got {self.n_threads}.")
+        elif self.n_threads > 0:
+            if self.n_threads > 1:
                 logger.warning(
-                    f"Using {self.num_threads} threads for PyTorch. This may lead to deadlocks in some environments, "
+                    f"Using {self.n_threads} threads for PyTorch. This may lead to deadlocks in some environments, "
                     "see https://github.com/pytorch/pytorch/issues/91547#issuecomment-1370011188."
                 )
 
-            torch.set_num_threads(num_threads)
+            torch.set_num_threads(n_threads)
 
     def _detect_categorical_columns(self, X: Any) -> tuple[list[str], list[str] | list[int]]:
         """Detect categorical columns from DataFrame.
@@ -83,8 +83,8 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
         if isinstance(X, pd.DataFrame):
             # Use pandas dtypes to detect categorical columns
             cat_cols = X.select_dtypes(include=["object", "category"]).columns.tolist()
-            num_cols = X.select_dtypes(include=[np.number]).columns.tolist()
-            return cat_cols, num_cols
+            numerical_cols = X.select_dtypes(include=[np.number]).columns.tolist()
+            return cat_cols, numerical_cols
         else:
             # If numpy array, no categorical columns
             return [], list(range(X.shape[1]))
@@ -112,7 +112,7 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
         self.n_features_in_ = len(self.feature_names_in_)
 
         # Detect categorical and numerical columns
-        self.cat_cols_, self.num_cols_ = self._detect_categorical_columns(X)
+        self.cat_cols_, self.numerical_cols_ = self._detect_categorical_columns(X)
 
         # Encode categorical features
         self.label_encoders_: dict[str, LabelEncoder] = {}
@@ -134,28 +134,30 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
             X_cat_encoded.append(encoded)
 
         # Enhanced missing value handling for numerical features
-        self.num_medians_ = {}
+        self.numerical_medians_ = {}
         self.missing_indicators_ = []
 
-        X_num_list = []
-        for num_col in self.num_cols_:
-            col_data = X[num_col]
+        X_numerical_list = []
+        for numerical_col in self.numerical_cols_:
+            col_data = X[numerical_col]
             is_missing = col_data.isna()
 
             # Store median for this column
             median_val = col_data.median()
-            self.num_medians_[num_col] = median_val if not pd.isna(median_val) else 0.0
+            self.numerical_medians_[numerical_col] = median_val if not pd.isna(median_val) else 0.0
 
             # Fill missing with median
-            filled_data = col_data.fillna(self.num_medians_[num_col])
-            X_num_list.append(filled_data.to_numpy())
+            filled_data = col_data.fillna(self.numerical_medians_[numerical_col])
+            X_numerical_list.append(filled_data.to_numpy())
 
             # Add missing indicator if there are any missing values
             if is_missing.any():
-                self.missing_indicators_.append(num_col)
-                X_num_list.append(is_missing.astype(np.float32).to_numpy())
+                self.missing_indicators_.append(numerical_col)
+                X_numerical_list.append(is_missing.astype(np.float32).to_numpy())
 
-        X_num = np.column_stack(X_num_list).astype(np.float32) if X_num_list else np.zeros((len(X), 0))
+        X_numerical = (
+            np.column_stack(X_numerical_list).astype(np.float32) if X_numerical_list else np.zeros((len(X), 0))
+        )
         X_cat = np.column_stack(X_cat_encoded) if X_cat_encoded else np.zeros((len(X), 0), dtype=np.int64)
 
         # Build model
@@ -163,11 +165,11 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
 
         # Convert to tensors
         X_cat_tensor = torch.LongTensor(X_cat)
-        X_num_tensor = torch.FloatTensor(X_num)
+        X_numerical_tensor = torch.FloatTensor(X_numerical)
         y_tensor = torch.FloatTensor(y.values if isinstance(y, pd.Series) else y).unsqueeze(1)
 
         # Training
-        dataset = TensorDataset(X_cat_tensor, X_num_tensor, y_tensor)
+        dataset = TensorDataset(X_cat_tensor, X_numerical_tensor, y_tensor)
 
         # Use generator for reproducible shuffling if random_state is set
         if self.random_state is not None:
@@ -196,9 +198,9 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
         self.model_.train()
         for _epoch in range(self.epochs):
             epoch_loss = 0.0
-            for X_cat_batch, X_num_batch, y_batch in dataloader:
+            for X_cat_batch, X_numerical_batch, y_batch in dataloader:
                 optimizer.zero_grad()
-                outputs = self.model_(X_cat_batch, X_num_batch)
+                outputs = self.model_(X_cat_batch, X_numerical_batch)
                 loss = criterion(outputs, y_batch)
                 loss.backward()
 
@@ -243,29 +245,31 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
             X_cat_encoded.append(encoded)
 
         # Prepare numerical features with same missing value handling as fit
-        X_num_list = []
-        for num_col in self.num_cols_:
-            col_data = X[num_col]
+        X_numerical_list = []
+        for numerical_col in self.numerical_cols_:
+            col_data = X[numerical_col]
             is_missing = col_data.isna()
 
             # Fill missing with stored median
-            filled_data = col_data.fillna(self.num_medians_[num_col])
-            X_num_list.append(filled_data.values)
+            filled_data = col_data.fillna(self.numerical_medians_[numerical_col])
+            X_numerical_list.append(filled_data.values)
 
             # Add missing indicator if this column had missing values during training
-            if num_col in self.missing_indicators_:
-                X_num_list.append(is_missing.astype(np.float32).values)
+            if numerical_col in self.missing_indicators_:
+                X_numerical_list.append(is_missing.astype(np.float32).values)
 
-        X_num = np.column_stack(X_num_list).astype(np.float32) if X_num_list else np.zeros((len(X), 0))
+        X_numerical = (
+            np.column_stack(X_numerical_list).astype(np.float32) if X_numerical_list else np.zeros((len(X), 0))
+        )
         X_cat = np.column_stack(X_cat_encoded) if X_cat_encoded else np.zeros((len(X), 0), dtype=np.int64)
 
         # Convert to tensors and predict
         X_cat_tensor = torch.LongTensor(X_cat)
-        X_num_tensor = torch.FloatTensor(X_num)
+        X_numerical_tensor = torch.FloatTensor(X_numerical)
 
         self.model_.eval()
         with torch.no_grad():
-            predictions = self.model_(X_cat_tensor, X_num_tensor)
+            predictions = self.model_(X_cat_tensor, X_numerical_tensor)
 
         return predictions.numpy().flatten()  # type: ignore[no-any-return]
 
@@ -276,7 +280,7 @@ class TabularNNRegressor(RegressorMixin, BaseEstimator):
             The constructed PyTorch model.
         """
         # Calculate actual number of numerical features (including missing indicators)
-        n_num_features = len(self.num_cols_) + len(self.missing_indicators_)
+        n_num_features = len(self.numerical_cols_) + len(self.missing_indicators_)
 
         return TabularNNModel(
             cat_cols=self.cat_cols_,
@@ -329,12 +333,12 @@ class TabularNNModel(nn.Module):
 
         self.network = nn.Sequential(*layers)
 
-    def forward(self, X_cat: torch.Tensor, X_num: torch.Tensor) -> torch.Tensor:
+    def forward(self, X_cat: torch.Tensor, X_numerical: torch.Tensor) -> torch.Tensor:
         """Forward pass.
 
         Args:
             X_cat: Categorical features.
-            X_num: Numerical features.
+            X_numerical: Numerical features.
 
         Returns:
             Model output.
@@ -347,6 +351,6 @@ class TabularNNModel(nn.Module):
             cat_features = torch.empty(X_cat.shape[0], 0)
 
         # Concatenate with numerical features
-        x = torch.cat([cat_features, X_num], dim=1)
+        x = torch.cat([cat_features, X_numerical], dim=1)
 
         return self.network(x)

--- a/octopus/modules/autogluon/core.py
+++ b/octopus/modules/autogluon/core.py
@@ -116,9 +116,9 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         data_test: pd.DataFrame,
         feature_cols: list[str],
         study_context: StudyContext,
-        outersplit_id: int,
+        outer_split_id: int,
         results_dir: UPath,
-        num_assigned_cpus: int,
+        n_assigned_cpus: int,
         feature_groups: dict[str, list[str]],
         **kwargs,
     ) -> dict[ResultType, ModuleResult]:
@@ -137,7 +137,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         ag_test_data = pd.concat([x_test, y_test], axis=1)
 
         # Set up logging and resources
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outersplit_id}")
+        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
 
         # Get target column
         if len(study_context.target_assignments) == 1:
@@ -155,8 +155,16 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         predictor = TabularPredictor(
             label=target,
             eval_metric=scoring_type,
-            verbosity=self.config.verbosity,
+            verbosity=0,
             log_to_file=False,
+        )
+
+        # Log configuration summary
+        logger.info(
+            "Starting fit: presets=%s, time_limit=%s, model_types=%s",
+            self.config.presets,
+            self.config.time_limit,
+            self.config.included_model_types or "all",
         )
 
         # Fit predictor
@@ -166,28 +174,33 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             infer_limit=self.config.infer_limit,
             memory_limit=self.config.memory_limit,
             presets=self.config.presets,
-            fit_strategy=self.config.fit_strategy,
-            num_bag_folds=self.config.num_bag_folds,
+            fit_strategy="sequential",
+            num_bag_folds=self.config.n_bag_splits,
             included_model_types=self.config.included_model_types,
-            num_cpus=num_assigned_cpus,
+            num_cpus=n_assigned_cpus,
         )
 
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outersplit_id}")
+        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
         logger.info("Fitting completed")
+
+        # Log best model summary
+        leaderboard_summary = predictor.leaderboard(silent=True)
+        best = leaderboard_summary.iloc[0]
+        logger.info("Best model: %s (score_val=%.4f)", best["model"], best["score_val"])
 
         # Save failure info
         with (results_dir / "autogluon_debug_info.txt").open("w", encoding="utf-8") as text_file:
             print(predictor.model_failures(), file=text_file)
 
         # Save leaderboard and model info
-        self._save_leaderboard_info(predictor, ag_test_data, outersplit_id, results_dir)
+        self._save_leaderboard_info(predictor, ag_test_data, outer_split_id, results_dir)
 
         # Get raw results
         raw_scores = self._get_scores(predictor, study_context, ag_train_data, ag_test_data, feature_cols, results_dir)
         raw_predictions = self._get_predictions(
-            predictor, study_context, ag_test_data, row_test, row_traindev, outersplit_id
+            predictor, study_context, ag_test_data, row_test, row_traindev, outer_split_id
         )
-        raw_fi = self._get_feature_importances(predictor, ag_test_data, outersplit_id, feature_groups, results_dir)
+        raw_fi = self._get_fi(predictor, ag_test_data, outer_split_id, feature_groups, results_dir)
 
         # Build flat scores DataFrame
         scores_rows = []
@@ -199,7 +212,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
                         "metric": key,
                         "partition": "combined",
                         "aggregation": "single",
-                        "fold": None,
+                        "split": None,
                         "value": value,
                     }
                 )
@@ -214,7 +227,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
                 pred_dfs.append(temp)
         predictions = pd.concat(pred_dfs, ignore_index=True) if pred_dfs else pd.DataFrame()
 
-        # Build flat feature_importances DataFrame
+        # Build flat feature importance DataFrame
         fi_dfs = []
         for _fi_key, fi_df in raw_fi.items():
             if isinstance(fi_df, pd.DataFrame) and not fi_df.empty:
@@ -232,7 +245,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
                 temp["training_id"] = "autogluon"
                 temp["result_type"] = ResultType.BEST
                 fi_dfs.append(temp)
-        feature_importances = pd.concat(fi_dfs, ignore_index=True) if fi_dfs else pd.DataFrame()
+        fi_df = pd.concat(fi_dfs, ignore_index=True) if fi_dfs else pd.DataFrame()
 
         return {
             ResultType.BEST: ModuleResult(
@@ -241,7 +254,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
                 selected_features=feature_cols,  # AutoGluon doesn't do feature selection, so return all features
                 scores=scores,
                 predictions=predictions,
-                feature_importances=feature_importances,
+                fi=fi_df,
                 model=self._get_sklearn_model(predictor, study_context),
             )
         }
@@ -255,16 +268,16 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         else:
             raise ValueError(f"ML type {study_context.ml_type} not supported")
 
-    def _get_feature_importances(
+    def _get_fi(
         self,
         model: TabularPredictor,
         ag_test_data: pd.DataFrame,
-        outersplit_id: int,
+        outer_split_id: int,
         feature_groups: dict[str, list[str]],
         results_dir: UPath,
     ) -> dict[str, pd.DataFrame]:
         """Calculate feature importances using AutoGluon's permutation importance."""
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outersplit_id}")
+        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
         logger.info("Calculating test permutation feature importances...")
 
         fi: dict[str, pd.DataFrame] = {}
@@ -298,14 +311,14 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
                 group_importances[group_name] = group_importance
 
             # Combine feature and group importances
-            combined_feature_importances = [fi["autogluon_permutation_test"]]
+            combined_fi = [fi["autogluon_permutation_test"]]
 
             for group_name, importance in group_importances.items():
                 group_row = importance.copy()
                 group_row.index = [f"{group_name}"] * len(group_row)
-                combined_feature_importances.append(group_row)
+                combined_fi.append(group_row)
 
-            fi["autogluon_permutation_test"] = pd.concat(combined_feature_importances)
+            fi["autogluon_permutation_test"] = pd.concat(combined_fi)
 
         fi["autogluon_permutation_test"] = fi["autogluon_permutation_test"].sort_values(
             by="importance", ascending=False
@@ -385,12 +398,12 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         self,
         model: TabularPredictor,
         ag_test_data: pd.DataFrame,
-        outersplit_id: int,
+        outer_split_id: int,
         results_dir: UPath,
     ) -> None:
         """Save AutoGluon leaderboard and model information."""
         # Save leaderboard
-        leaderboard = model.leaderboard(ag_test_data, extra_info=True)
+        leaderboard = model.leaderboard(ag_test_data, extra_info=True, silent=True)
         leaderboard_path = results_dir / "leaderboard.csv"
         csv_save(leaderboard, leaderboard_path)
 
@@ -406,7 +419,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             json.dump(model_info, f, default=str, indent=4)
 
         # Save fit summary
-        fit_summary = model.fit_summary()
+        fit_summary = model.fit_summary(verbosity=0)
         with (results_dir / "model_stats.txt").open("w", encoding="utf-8") as text_file:
             print(fit_summary, file=text_file)
 
@@ -417,9 +430,9 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         ag_test_data: pd.DataFrame,
         row_test: pd.Series,
         row_traindev: pd.Series,
-        outersplit_id: int,
+        outer_split_id: int,
     ) -> dict[str, pd.DataFrame]:
-        """Get out-of-fold and test predictions with metadata."""
+        """Get out-of-split and test predictions with metadata."""
         predictions = {}
         best_model_name = model.model_best
         problem_type = model.problem_type
@@ -448,13 +461,13 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             axis=1,
         )
         # Add metadata
-        test_df["outersplit_id"] = outersplit_id
+        test_df["outer_split_id"] = outer_split_id
         test_df["inner_split_id"] = inner_split_id
         test_df["partition"] = "test"
         test_df["task_id"] = task_id
         predictions["test"] = test_df
 
-        # Out-of-fold validation predictions
+        # Out-of-split validation predictions
         rowid_dev = pd.DataFrame({row_column: row_traindev})
 
         if problem_type == "regression":
@@ -473,7 +486,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             axis=1,
         )
         # Add metadata
-        dev_df["outersplit_id"] = outersplit_id
+        dev_df["outer_split_id"] = outer_split_id
         dev_df["inner_split_id"] = inner_split_id
         dev_df["partition"] = "dev"
         dev_df["task_id"] = task_id

--- a/octopus/modules/autogluon/module.py
+++ b/octopus/modules/autogluon/module.py
@@ -6,8 +6,6 @@ from typing import Literal
 
 from attrs import define, field, validators
 
-from octopus.types import AutoGluonFitStrategy
-
 from ..base import ModuleExecution, Task
 
 
@@ -20,9 +18,6 @@ class AutoGluon(Task):
     engineering, hyperparameter optimization, and model selection.
     """
 
-    verbosity: int = field(default=2, validator=validators.instance_of(int))
-    """Verbosity level (0=exceptions, 1=warnings, 2=standard, 3=verbose, 4=max)."""
-
     time_limit: int | None = field(default=None, validator=validators.optional(validators.instance_of(int)))
     """Training time limit in seconds."""
 
@@ -33,13 +28,6 @@ class AutoGluon(Task):
         default="auto", validator=validators.or_(validators.instance_of(float), validators.in_(["auto"]))
     )
     """Memory limit in GB."""
-
-    fit_strategy: AutoGluonFitStrategy = field(
-        default=AutoGluonFitStrategy.SEQUENTIAL,
-        converter=AutoGluonFitStrategy,
-        validator=validators.in_(list(AutoGluonFitStrategy)),
-    )
-    """Model fitting strategy: Sequential or parallel fitting."""
 
     presets: list[str] = field(
         default=["medium_quality"],
@@ -64,8 +52,8 @@ class AutoGluon(Task):
     )
     """AutoGluon quality presets."""
 
-    num_bag_folds: int = field(default=5, validator=[validators.instance_of(int), validators.gt(1)])
-    """Number of bagging/cross-validation folds."""
+    n_bag_splits: int = field(default=5, validator=[validators.instance_of(int), validators.gt(1)])
+    """Number of bagging/cross-validation splits (passed as num_bag_folds to AutoGluon)."""
 
     included_model_types: list[str] | None = field(
         default=None,

--- a/octopus/modules/base.py
+++ b/octopus/modules/base.py
@@ -46,10 +46,10 @@ class ModuleExecution[T: Task](ABC):
         data_test: pd.DataFrame,
         feature_cols: list[str],
         study_context: StudyContext,
-        outersplit_id: int,
+        outer_split_id: int,
         results_dir: UPath,
         scratch_dir: UPath,
-        num_assigned_cpus: int,
+        n_assigned_cpus: int,
         feature_groups: dict[str, list[str]],
         prior_results: dict[str, pd.DataFrame],
     ) -> dict[ResultType, ModuleResult]:

--- a/octopus/modules/boruta/core.py
+++ b/octopus/modules/boruta/core.py
@@ -88,7 +88,7 @@ class BorutaModule(ModuleExecution["Boruta"]):
         else:
             raise ValueError(f"{study_context.ml_type} not supported")
 
-        model_type = ModelName(self.config.model) if self.config.model else default_model
+        model_type = self.config.model if self.config.model is not None else default_model
 
         if model_type not in supported_models:
             raise ValueError(f"{model_type} not supported")
@@ -105,9 +105,9 @@ class BorutaModule(ModuleExecution["Boruta"]):
 
         cv: int | StratifiedKFold
         if study_context.stratification_col:
-            cv = StratifiedKFold(n_splits=self.config.cv, shuffle=True, random_state=42)
+            cv = StratifiedKFold(n_splits=self.config.n_inner_splits, shuffle=True, random_state=42)
         else:
-            cv = self.config.cv
+            cv = self.config.n_inner_splits
 
         # Hyperparameter optimization
         grid_search = GridSearchCV(
@@ -133,7 +133,7 @@ class BorutaModule(ModuleExecution["Boruta"]):
         boruta = BorutaPy(
             estimator=model,
             n_estimators="auto",
-            perc=self.config.perc,
+            perc=self.config.threshold,
             alpha=self.config.alpha,
             random_state=42,
             verbose=0,
@@ -205,7 +205,7 @@ class BorutaModule(ModuleExecution["Boruta"]):
                     "metric": study_context.target_metric,
                     "partition": "dev",
                     "aggregation": "avg",
-                    "fold": None,
+                    "split": None,
                     "value": dev_score_cv,
                 },
                 {
@@ -213,7 +213,7 @@ class BorutaModule(ModuleExecution["Boruta"]):
                     "metric": study_context.target_metric,
                     "partition": "test",
                     "aggregation": "refit",
-                    "fold": None,
+                    "split": None,
                     "value": test_score_refit,
                 },
                 {
@@ -221,18 +221,18 @@ class BorutaModule(ModuleExecution["Boruta"]):
                     "metric": study_context.target_metric,
                     "partition": "test",
                     "aggregation": "gsrefit",
-                    "fold": None,
+                    "split": None,
                     "value": test_score_gsrefit,
                 },
             ]
         )
 
-        # Build standard feature_importances DataFrame
-        feature_importances = fi_df[["feature", "importance"]].copy()
-        feature_importances["fi_method"] = FIResultLabel.INTERNAL
-        feature_importances["fi_dataset"] = DataPartition.TRAIN
-        feature_importances["training_id"] = "boruta"
-        feature_importances["result_type"] = ResultType.BEST
+        # Build standard feature importance DataFrame
+        fi_df_out = fi_df[["feature", "importance"]].copy()
+        fi_df_out["fi_method"] = FIResultLabel.INTERNAL
+        fi_df_out["fi_dataset"] = DataPartition.TRAIN
+        fi_df_out["training_id"] = "boruta"
+        fi_df_out["result_type"] = ResultType.BEST
 
         # Save results to JSON
         results = {
@@ -254,6 +254,6 @@ class BorutaModule(ModuleExecution["Boruta"]):
                 module=self.config.module,
                 selected_features=selected_features,
                 scores=scores,
-                feature_importances=feature_importances,
+                fi=fi_df_out,
             )
         }

--- a/octopus/modules/boruta/module.py
+++ b/octopus/modules/boruta/module.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from attrs import define, field, validators
 
+from octopus.types import ModelName
+
 from ..base import ModuleExecution, Task
 
 
@@ -16,22 +18,28 @@ class Boruta(Task):
 
     Configuration:
         model: Model to use for Boruta (defaults based on ml_type)
-        cv: Number of CV folds
-        perc: Percentile threshold for shadow feature comparison
-        alpha: Significance level for p-values
+        n_inner_splits: Number of CV folds
+        threshold: Percentile threshold for shadow feature comparison (0-100)
+        alpha: Significance level for p-values (0-1)
     """
 
-    model: str = field(validator=[validators.instance_of(str)], default="")
-    """Model used by Boruta."""
+    model: ModelName | None = field(default=None, converter=lambda v: ModelName(v) if v is not None else None)
+    """Model used by Boruta. If None, defaults are resolved at fit time based on ml_type."""
 
-    cv: int = field(validator=[validators.instance_of(int)], default=5)
-    """Number of folds for CV."""
+    n_inner_splits: int = field(validator=[validators.instance_of(int)], default=5)
+    """Number of inner folds."""
 
-    perc: int = field(validator=[validators.instance_of(int)], default=100)
-    """Percentile (threshold) for comparison between shadow and real features."""
+    threshold: int = field(
+        default=100,
+        validator=[validators.instance_of(int), validators.ge(0), validators.le(100)],
+    )
+    """Percentile threshold for comparison between shadow and real features (0-100)."""
 
-    alpha: float = field(validator=[validators.instance_of(float)], default=0.05)
-    """Level at which the corrected p-values will get rejected."""
+    alpha: float = field(
+        default=0.05,
+        validator=[validators.instance_of(float), validators.gt(0), validators.lt(1)],
+    )
+    """Significance level at which the corrected p-values will get rejected (0-1)."""
 
     def create_module(self) -> ModuleExecution:
         """Create BorutaModule execution instance."""

--- a/octopus/modules/mrmr/core.py
+++ b/octopus/modules/mrmr/core.py
@@ -12,7 +12,7 @@ from sklearn.feature_selection import f_classif, f_regression
 from octopus.logger import get_logger
 from octopus.modules import ModuleExecution, ModuleResult
 from octopus.modules.utils import rdc_correlation_matrix
-from octopus.types import CorrelationType, FIResultLabel, LogGroup, MLType, MRMRRelevance, ResultType
+from octopus.types import CorrelationType, FIResultLabel, LogGroup, MLType, RelevanceMethod, ResultType
 
 if TYPE_CHECKING:
     from octopus.modules import StudyContext
@@ -31,14 +31,14 @@ class MrmrModule(ModuleExecution["Mrmr"]):
         data_traindev: pd.DataFrame,
         feature_cols: list[str],
         study_context: StudyContext,
-        outersplit_id: int,
+        outer_split_id: int,
         prior_results: dict[str, pd.DataFrame],
         **kwargs,
     ) -> dict[ResultType, ModuleResult]:
         """Fit MRMR module by selecting features with maximum relevance and minimum redundancy."""
         logger.set_log_group(LogGroup.PROCESSING, "MRMR")
         self._validate_configuration(prior_results)
-        self._log_outersplit_info(outersplit_id, prior_results)
+        self._log_outer_split_info(outer_split_id, prior_results)
 
         # Extract feature matrices (local variables, not stored)
         target_cols = list(study_context.target_assignments.values())
@@ -78,34 +78,33 @@ class MrmrModule(ModuleExecution["Mrmr"]):
 
     def _get_fi_method(self) -> FIResultLabel:
         """Get FIResultLabel for the configured feature importance method."""
-        return FIResultLabel(self.config.feature_importance_method)
+        return FIResultLabel(self.config.fi_method)
 
     def _validate_configuration(self, prior_results: dict) -> None:
         """Validate MRMR configuration."""
-        if self.config.relevance_type == MRMRRelevance.PERMUTATION:
+        if self.config.relevance_method == RelevanceMethod.PERMUTATION:
             if self.config.task_id == 0:
                 raise ValueError("MRMR module should not be the first workflow task.")
-            fi_df = prior_results.get("feature_importances", pd.DataFrame())
+            fi_df = prior_results.get("fi", pd.DataFrame())
             if fi_df.empty:
                 raise ValueError("No feature importances available from prior results.")
 
             fi_method = self._get_fi_method()
-            subset = fi_df[(fi_df["module"] == self.config.results_module) & (fi_df["fi_method"] == fi_method)]
+            subset = fi_df[fi_df["fi_method"] == fi_method]
             if subset.empty:
-                available_types = fi_df[["module", "fi_method"]].drop_duplicates().to_dict("records")
+                available_methods = fi_df["fi_method"].unique().tolist()
                 raise ValueError(
-                    f"No feature importances for module={self.config.results_module}, fi_method={fi_method}. Available: {available_types}"
+                    f"No feature importances for fi_method={fi_method}. Available methods: {available_methods}"
                 )
 
-    def _log_outersplit_info(self, outersplit_id: int, prior_results: dict) -> None:
+    def _log_outer_split_info(self, outer_split_id: int, prior_results: dict) -> None:
         """Log basic MRMR info."""
         logger.info("MRMR-Module")
-        logger.info(f"Outersplit: {outersplit_id}")
+        logger.info(f"Outer Split: {outer_split_id}")
         logger.info(f"Workflow task: {self.config.task_id}")
         logger.info(f"Number of features selected by MRMR: {self.config.n_features}")
         logger.info(f"Correlation type used by MRMR: {self.config.correlation_type}")
-        logger.info(f"Relevance type used by MRMR: {self.config.relevance_type}")
-        logger.info(f"Specified results module: {self.config.results_module}")
+        logger.info(f"Relevance method used by MRMR: {self.config.relevance_method}")
 
     def _get_relevance_data(
         self,
@@ -115,22 +114,22 @@ class MrmrModule(ModuleExecution["Mrmr"]):
         ml_type: MLType,
         prior_results: dict,
     ) -> pd.DataFrame:
-        """Get relevance data based on relevance type."""
-        if self.config.relevance_type == MRMRRelevance.PERMUTATION:
+        """Get relevance data based on relevance method."""
+        if self.config.relevance_method == RelevanceMethod.PERMUTATION:
             return self._get_permutation_relevance(feature_cols, prior_results)
-        elif self.config.relevance_type == MRMRRelevance.F_STATISTICS:
+        elif self.config.relevance_method == RelevanceMethod.F_STATISTICS:
             return self._get_fstats_relevance(x_traindev, y_traindev, feature_cols, ml_type)
         else:
-            raise ValueError(f"Relevance type {self.config.relevance_type} not supported for MRMR.")
+            raise ValueError(f"Relevance method {self.config.relevance_method} not supported for MRMR.")
 
     def _get_permutation_relevance(
         self, feature_cols: list[str], prior_results: dict[str, pd.DataFrame]
     ) -> pd.DataFrame:
         """Get permutation relevance from prior module results (flat DataFrame)."""
-        fi_df = prior_results.get("feature_importances", pd.DataFrame())
+        fi_df = prior_results.get("fi", pd.DataFrame())
         fi_method = self._get_fi_method()
 
-        subset = fi_df[(fi_df["module"] == self.config.results_module) & (fi_df["fi_method"] == fi_method)]
+        subset = fi_df[fi_df["fi_method"] == fi_method]
         n = subset["training_id"].nunique()
         re_df = (subset.groupby("feature")["importance"].sum() / n).sort_values(ascending=False).reset_index()
 

--- a/octopus/modules/mrmr/module.py
+++ b/octopus/modules/mrmr/module.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from attrs import Factory, define, field, validators
 
-from octopus.types import CorrelationType, FIComputeMethod, MRMRFIAggregation, MRMRRelevance
+from octopus.types import CorrelationType, FIComputeMethod, RelevanceMethod
 
 from ..base import ModuleExecution, Task
 
@@ -20,10 +20,8 @@ class Mrmr(Task):
     Configuration:
         n_features: Number of features to select
         correlation_type: Type of correlation to measure redundancy
-        relevance_type: Method to calculate relevance (MRMRRelevance.PERMUTATION or MRMRRelevance.INTERNAL)
-        results_module: Module name to filter prior results' feature importances (for permutation relevance)
-        feature_importance_type: Type of FI aggregation (MRMRFIAggregation.MEAN or MRMRFIAggregation.COUNT)
-        feature_importance_method: FI calculation method (FIComputeMethod.PERMUTATION, FIComputeMethod.SHAP, FIComputeMethod.INTERNAL, FIComputeMethod.LOFO)
+        relevance_method: Method to calculate relevance (RelevanceMethod.PERMUTATION or RelevanceMethod.F_STATISTICS)
+        fi_method: FI calculation method, only used when relevance_method is PERMUTATION
     """
 
     n_features: int = field(validator=[validators.instance_of(int)], default=Factory(lambda: 30))
@@ -36,30 +34,21 @@ class Mrmr(Task):
     )
     """Selection of correlation type."""
 
-    relevance_type: MRMRRelevance = field(
-        converter=MRMRRelevance, validator=validators.in_(list(MRMRRelevance)), default=MRMRRelevance.PERMUTATION
+    relevance_method: RelevanceMethod = field(
+        converter=RelevanceMethod,
+        validator=validators.in_([RelevanceMethod.F_STATISTICS, RelevanceMethod.PERMUTATION]),
+        default=RelevanceMethod.PERMUTATION,
     )
-    """Selection of relevance measure."""
+    """Method to calculate relevance (permutation or f-statistics)."""
 
-    results_module: str = field(
-        validator=validators.instance_of(str),
-        default="octo",
-    )
-    """Module name from which feature importances were created."""
-
-    feature_importance_type: MRMRFIAggregation = field(
-        converter=MRMRFIAggregation, validator=validators.in_(list(MRMRFIAggregation)), default=MRMRFIAggregation.MEAN
-    )
-    """Selection of feature importance type."""
-
-    feature_importance_method: FIComputeMethod = field(
+    fi_method: FIComputeMethod = field(
         converter=FIComputeMethod,
         validator=validators.in_(
             [FIComputeMethod.PERMUTATION, FIComputeMethod.SHAP, FIComputeMethod.INTERNAL, FIComputeMethod.LOFO]
         ),
         default=FIComputeMethod.PERMUTATION,
     )
-    """Selection of feature importance method."""
+    """FI method to use from prior results. Only relevant when relevance_method is PERMUTATION."""
 
     def create_module(self) -> ModuleExecution:
         """Create MrmrModule execution instance."""

--- a/octopus/modules/octo/bag.py
+++ b/octopus/modules/octo/bag.py
@@ -48,7 +48,7 @@ class TrainingWithLogging:
             raise e
 
 
-class FeatureImportanceWithLogging:
+class FIWithLogging:
     """Logging wrapper for feature importance calculations."""
 
     def __init__(self, training: Training, idx, fi_type, partition, logger, log_group_cls, log_prefix="FI"):
@@ -101,9 +101,7 @@ class BagBase(BaseEstimator):
     train_status: bool = field(default=False)
 
     # bag training outputs, initialized in post_init
-    feature_importances: dict[str, pd.DataFrame | dict[str, pd.DataFrame]] = field(
-        init=False, validator=[validators.instance_of(dict)]
-    )
+    fi: dict[str, pd.DataFrame | dict[str, pd.DataFrame]] = field(init=False, validator=[validators.instance_of(dict)])
     n_features_used_mean: float = field(init=False, validator=[validators.instance_of(float)])
 
     @property
@@ -202,7 +200,7 @@ class BagBase(BaseEstimator):
 
     def __attrs_post_init__(self):
         # initialization here due to "Python immutable default"
-        self.feature_importances = {}
+        self.fi = {}
         self.n_features_used_mean = 0.0
         self._positive_class = None  # Will be inferred when needed
 
@@ -232,7 +230,7 @@ class BagBase(BaseEstimator):
             },
         }
 
-    def _train_parallel(self, num_assigned_cpus: int):
+    def _train_parallel(self, n_assigned_cpus: int):
         """Run trainings in parallel using Ray (delegated to ray_parallel)."""
         # Orchestrate with Ray; exceptions propagate only if your wrapper re-raises.
         self.trainings = ray_parallel.run_parallel_inner(
@@ -248,7 +246,7 @@ class BagBase(BaseEstimator):
                 for idx, t in enumerate(self.trainings)
             ],
             log_dir=self.log_dir,
-            num_assigned_cpus=num_assigned_cpus,
+            n_assigned_cpus=n_assigned_cpus,
         )
 
     def _train_sequential(self):
@@ -286,10 +284,10 @@ class BagBase(BaseEstimator):
 
         self.trainings = successful_trainings
 
-    def fit(self, num_assigned_cpus: int):
+    def fit(self, n_assigned_cpus: int):
         """Run all available trainings."""
-        if num_assigned_cpus > 1:
-            self._train_parallel(num_assigned_cpus)
+        if n_assigned_cpus > 1:
+            self._train_parallel(n_assigned_cpus)
         else:
             self._train_sequential()
 
@@ -305,11 +303,11 @@ class BagBase(BaseEstimator):
 
         self.n_features_used_mean = mean(n_feat_lst)
 
-    def get_predictions(self, num_assigned_cpus: int):
+    def get_predictions(self, n_assigned_cpus: int):
         """Extract bag predictions for train, dev, and test.
 
         Args:
-            num_assigned_cpus: Number of CPUs to use for parallel processing.
+            n_assigned_cpus: Number of CPUs to use for parallel processing.
 
         Returns:
             dict: Dictionary containing predictions for each training and ensemble.
@@ -318,7 +316,7 @@ class BagBase(BaseEstimator):
         if not self.train_status:
             logger.set_log_group(LogGroup.TRAINING)
             logger.info("Running trainings first to be able to get scores")
-            self.fit(num_assigned_cpus)
+            self.fit(n_assigned_cpus)
 
         predictions = {}
         pool: dict[str, list[pd.DataFrame]] = {key: [] for key in ["train", "dev", "test"]}
@@ -365,11 +363,11 @@ class BagBase(BaseEstimator):
 
         return predictions
 
-    def get_performance(self, num_assigned_cpus: int, metric: str | None = None):
+    def get_performance(self, n_assigned_cpus: int, metric: str | None = None):
         """Get performance using get_performance_from_predictions utility.
 
         Args:
-            num_assigned_cpus: Number of CPUs to use for parallel processing when getting predictions.
+            n_assigned_cpus: Number of CPUs to use for parallel processing when getting predictions.
             metric: The metric to evaluate. Defaults to self.target_metric when None.
 
         Returns:
@@ -379,7 +377,7 @@ class BagBase(BaseEstimator):
             metric = self.target_metric
 
         # Get predictions from the bag
-        predictions = self.get_predictions(num_assigned_cpus=num_assigned_cpus)
+        predictions = self.get_predictions(n_assigned_cpus=n_assigned_cpus)
 
         # Calculate performance using the utility function
         performance = get_performance_from_predictions(
@@ -419,33 +417,33 @@ class BagBase(BaseEstimator):
 
         return performance_output
 
-    def get_performance_df(self, num_assigned_cpus: int, metric: str) -> pd.DataFrame:
+    def get_performance_df(self, n_assigned_cpus: int, metric: str) -> pd.DataFrame:
         """Convert get_performance() dict to standard scores DataFrame.
 
         Args:
-            num_assigned_cpus: Number of CPUs to use for parallel processing.
+            n_assigned_cpus: Number of CPUs to use for parallel processing.
             metric: The metric name (e.g. "MAE", "accuracy").
 
         Returns:
-            DataFrame with columns: metric, partition, aggregation, fold, value
+            DataFrame with columns: metric, partition, aggregation, split, value
         """
-        perf = self.get_performance(num_assigned_cpus=num_assigned_cpus, metric=metric)
+        perf = self.get_performance(n_assigned_cpus=n_assigned_cpus, metric=metric)
         rows = []
 
-        # Per-fold scores
+        # Per-split scores
         for partition in ["train", "dev", "test"]:
             lst_key = f"{partition}_lst"
             avg_key = f"{partition}_avg"
             ensemble_key = f"{partition}_ensemble"
 
             if lst_key in perf:
-                for fold_idx, val in enumerate(perf[lst_key]):
+                for split_idx, val in enumerate(perf[lst_key]):
                     rows.append(
                         {
                             "metric": metric,
                             "partition": partition,
-                            "aggregation": "per_fold",
-                            "fold": fold_idx,
+                            "aggregation": "per_split",
+                            "split": split_idx,
                             "value": val,
                         }
                     )
@@ -455,7 +453,7 @@ class BagBase(BaseEstimator):
                         "metric": metric,
                         "partition": partition,
                         "aggregation": "avg",
-                        "fold": None,
+                        "split": None,
                         "value": perf[avg_key],
                     }
                 )
@@ -465,23 +463,23 @@ class BagBase(BaseEstimator):
                         "metric": metric,
                         "partition": partition,
                         "aggregation": "ensemble",
-                        "fold": None,
+                        "split": None,
                         "value": perf[ensemble_key],
                     }
                 )
 
         return pd.DataFrame(rows)
 
-    def get_predictions_df(self, num_assigned_cpus: int) -> pd.DataFrame:
+    def get_predictions_df(self, n_assigned_cpus: int) -> pd.DataFrame:
         """Concat all training predictions into a single DataFrame.
 
         Args:
-            num_assigned_cpus: Number of CPUs to use for parallel processing.
+            n_assigned_cpus: Number of CPUs to use for parallel processing.
 
         Returns:
             DataFrame with all predictions from get_predictions().
         """
-        predictions = self.get_predictions(num_assigned_cpus=num_assigned_cpus)
+        predictions = self.get_predictions(n_assigned_cpus=n_assigned_cpus)
         all_dfs = []
         for _split_id, partitions in predictions.items():
             if isinstance(partitions, dict):
@@ -493,14 +491,14 @@ class BagBase(BaseEstimator):
             return pd.concat(all_dfs, ignore_index=True)
         return pd.DataFrame()
 
-    def get_feature_importances_df(self) -> pd.DataFrame:
-        """Concat per-training FI into a single DataFrame with fi_method, fi_dataset, and training_id columns.
+    def get_fi_df(self) -> pd.DataFrame:
+        """Concat per-training feature importances into a single DataFrame with fi_method, fi_dataset, and training_id columns.
 
         Returns:
             DataFrame with columns: feature, importance, fi_method, fi_dataset, training_id
         """
         all_dfs: list[pd.DataFrame] = []
-        for key, value in self.feature_importances.items():
+        for key, value in self.fi.items():
             # Skip aggregated keys like "internal_mean", "permutation_dev_count", etc.
             if key.endswith("_mean") or key.endswith("_count"):
                 continue
@@ -519,14 +517,14 @@ class BagBase(BaseEstimator):
             return pd.concat(all_dfs, ignore_index=True)
         return pd.DataFrame()
 
-    def _calculate_fi_parallel(self, fi_type: FIComputeMethod, partition: str, num_assigned_cpus: int):
+    def _calculate_fi_parallel(self, fi_type: FIComputeMethod, partition: str, n_assigned_cpus: int):
         """Calculate feature importance in parallel using Ray."""
         # Execute feature importance calculations in parallel
         # Use the same pattern as training execution
         results = ray_parallel.run_parallel_inner(
             bag_id=self.bag_id,
             trainings=[
-                FeatureImportanceWithLogging(
+                FIWithLogging(
                     training=t,
                     idx=idx,
                     fi_type=fi_type,
@@ -538,7 +536,7 @@ class BagBase(BaseEstimator):
                 for idx, t in enumerate(self.trainings)
             ],
             log_dir=self.log_dir,
-            num_assigned_cpus=num_assigned_cpus,
+            n_assigned_cpus=n_assigned_cpus,
         )
 
         # Update trainings with results (should be the same objects with FI calculated)
@@ -582,10 +580,10 @@ class BagBase(BaseEstimator):
 
         self.trainings = successful_calculations
 
-    def _calculate_fi(self, fi_type: FIComputeMethod, num_assigned_cpus: int, partition=DataPartition.DEV):
+    def _calculate_fi(self, fi_type: FIComputeMethod, n_assigned_cpus: int, partition=DataPartition.DEV):
         """Calculate feature importance using parallel or sequential execution."""
-        if num_assigned_cpus > 1:
-            self._calculate_fi_parallel(fi_type=fi_type, partition=partition, num_assigned_cpus=num_assigned_cpus)
+        if n_assigned_cpus > 1:
+            self._calculate_fi_parallel(fi_type=fi_type, partition=partition, n_assigned_cpus=n_assigned_cpus)
         else:
             self._calculate_fi_sequential(fi_type=fi_type, partition=partition)
 
@@ -597,18 +595,18 @@ class BagBase(BaseEstimator):
         with the following ranking: (1) permutation (2) shap (3) internal,
         (4) constant.
         """
-        # we assume that feature_importances were previously calculated
+        # we assume that feature importances were previously calculated
         if fi_methods is None:
             fi_methods = []
 
         if FIComputeMethod.PERMUTATION in fi_methods:
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.PERMUTATION, "dev", "mean")]
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.PERMUTATION, "dev", "mean")]
         elif FIComputeMethod.SHAP in fi_methods:
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.SHAP, "dev", "mean")]
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.SHAP, "dev", "mean")]
         elif FIComputeMethod.INTERNAL in fi_methods:
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.INTERNAL, stat="mean")]
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.INTERNAL, stat="mean")]
         elif FIComputeMethod.CONSTANT in fi_methods:
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.CONSTANT, stat="mean")]
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.CONSTANT, stat="mean")]
         else:
             logger.set_log_group(LogGroup.RESULTS)
             logger.info("No features selected, return empty list")
@@ -633,9 +631,9 @@ class BagBase(BaseEstimator):
             features = self.feature_groups.get(key, [])
             if features and not any(feature in feat_single for feature in features):
                 # Find the feature with the highest importance in fi_df
-                feature_importances = fi_df[fi_df["feature"].isin(features)]
-                if not feature_importances.empty:
-                    best_feature = feature_importances.loc[feature_importances["importance"].idxmax(), "feature"]
+                fi_filtered = fi_df[fi_df["feature"].isin(features)]
+                if not fi_filtered.empty:
+                    best_feature = fi_filtered.loc[fi_filtered["importance"].idxmax(), "feature"]
                     feat_additional.append(best_feature)
 
         # Add the additional features to feat_single and remove duplicates
@@ -648,11 +646,11 @@ class BagBase(BaseEstimator):
 
         return sorted(feat_all, key=lambda x: (len(x), sorted(x)))
 
-    def calculate_feature_importances(
+    def calculate_fi(
         self,
         fi_methods: list[FIComputeMethod] | None,
         partitions: list[DataPartition | str] | None,
-        num_assigned_cpus: int,
+        n_assigned_cpus: int,
     ):
         """Extract feature importances of all models in bag."""
         # we always extract internal feature importances, if available
@@ -661,22 +659,22 @@ class BagBase(BaseEstimator):
         if partitions is None:
             partitions = [DataPartition.DEV, DataPartition.TEST]
 
-        self._calculate_fi(fi_type=FIComputeMethod.INTERNAL, num_assigned_cpus=num_assigned_cpus)
+        self._calculate_fi(fi_type=FIComputeMethod.INTERNAL, n_assigned_cpus=n_assigned_cpus)
 
         for method in fi_methods:
             if method == FIComputeMethod.INTERNAL:
                 continue  # already done
             elif method in (FIComputeMethod.SHAP, FIComputeMethod.PERMUTATION):
                 for partition in partitions:
-                    self._calculate_fi(fi_type=method, partition=partition, num_assigned_cpus=num_assigned_cpus)
+                    self._calculate_fi(fi_type=method, partition=partition, n_assigned_cpus=n_assigned_cpus)
             elif method in (FIComputeMethod.LOFO, FIComputeMethod.CONSTANT):
-                self._calculate_fi(fi_type=method, num_assigned_cpus=num_assigned_cpus)
+                self._calculate_fi(fi_type=method, n_assigned_cpus=n_assigned_cpus)
             else:
                 raise ValueError(f"Feature importance method {method} not supported.")
 
         # save feature importances for every training in bag
         for training in self.trainings:
-            self.feature_importances[training.training_id] = training.feature_importances
+            self.fi[training.training_id] = training.fi
 
         # summary feature importances for all trainings (mean + count)
         # Aggregate all computed partitions dynamically (not just "dev")
@@ -689,7 +687,7 @@ class BagBase(BaseEstimator):
             for method_key in keys_to_aggregate:
                 fi_pool = []
                 for training in self.trainings:
-                    fi_df = training.feature_importances.get(method_key)
+                    fi_df = training.fi.get(method_key)
                     if fi_df is not None and not fi_df.empty:
                         fi_pool.append(fi_df)
 
@@ -701,7 +699,7 @@ class BagBase(BaseEstimator):
 
                 # calculate mean feature importances, keep zero entries
                 mean_key = method_key + "_mean"
-                self.feature_importances[mean_key] = (
+                self.fi[mean_key] = (
                     fi[["feature", "importance"]]
                     .groupby(by="feature")
                     .sum()
@@ -723,11 +721,9 @@ class BagBase(BaseEstimator):
                 all_features = all_features.reset_index()
                 # Sort and reset index
                 count_key = method_key + "_count"
-                self.feature_importances[count_key] = all_features.sort_values(
-                    by="importance", ascending=False
-                ).reset_index(drop=True)
+                self.fi[count_key] = all_features.sort_values(by="importance", ascending=False).reset_index(drop=True)
 
-        return self.feature_importances
+        return self.fi
 
     def predict(self, x):
         """Predict with sklearn compatibility."""

--- a/octopus/modules/octo/core.py
+++ b/octopus/modules/octo/core.py
@@ -53,10 +53,10 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         data_test: pd.DataFrame,
         feature_cols: list[str],
         study_context: StudyContext,
-        outersplit_id: int,
+        outer_split_id: int,
         results_dir: UPath,
         scratch_dir: UPath,
-        num_assigned_cpus: int,
+        n_assigned_cpus: int,
         feature_groups: dict[str, list[str]],
         **kwargs,
     ) -> dict[ResultType, ModuleResult]:
@@ -71,7 +71,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             x_traindev,
             y_traindev,
             feature_cols,
-            outersplit_id,
+            outer_split_id,
             scratch_dir,
             results_dir,
         )
@@ -85,8 +85,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             data_test=data_test,
             feature_cols=feature_cols,
             feature_groups=feature_groups,
-            outersplit_id=outersplit_id,
-            num_assigned_cpus=num_assigned_cpus,
+            outer_split_id=outer_split_id,
+            n_assigned_cpus=n_assigned_cpus,
             results_dir=results_dir,
             results=results,
         )
@@ -95,7 +95,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         best_bag: BagBase = results["best"]["_bag"]
         all_metrics = Metrics.get_by_type(study_context.ml_type)
         best_scores = pd.concat(
-            [best_bag.get_performance_df(metric=m, num_assigned_cpus=num_assigned_cpus) for m in all_metrics],
+            [best_bag.get_performance_df(metric=m, n_assigned_cpus=n_assigned_cpus) for m in all_metrics],
             ignore_index=True,
         )
         best_result = ModuleResult(
@@ -103,8 +103,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             module=self.config.module,
             selected_features=best_selected_features,
             scores=best_scores,
-            predictions=best_bag.get_predictions_df(num_assigned_cpus=num_assigned_cpus),
-            feature_importances=best_bag.get_feature_importances_df(),
+            predictions=best_bag.get_predictions_df(n_assigned_cpus=n_assigned_cpus),
+            fi=best_bag.get_fi_df(),
             model=best_bag,
         )
 
@@ -114,8 +114,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         if self.config.ensemble_selection:
             ensel_selected_features = self._run_ensemble_selection(
                 study_context=study_context,
-                outersplit_id=outersplit_id,
-                num_assigned_cpus=num_assigned_cpus,
+                outer_split_id=outer_split_id,
+                n_assigned_cpus=n_assigned_cpus,
                 scratch_dir=scratch_dir,
                 results=results,
             )
@@ -124,7 +124,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             if "ensel" in results:
                 ensel_bag: BagBase = results["ensel"]["_bag"]
                 ensel_scores = pd.concat(
-                    [ensel_bag.get_performance_df(metric=m, num_assigned_cpus=num_assigned_cpus) for m in all_metrics],
+                    [ensel_bag.get_performance_df(metric=m, n_assigned_cpus=n_assigned_cpus) for m in all_metrics],
                     ignore_index=True,
                 )
                 ensel_result = ModuleResult(
@@ -132,8 +132,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
                     module=self.config.module,
                     selected_features=ensel_selected_features or best_selected_features,
                     scores=ensel_scores,
-                    predictions=ensel_bag.get_predictions_df(num_assigned_cpus=num_assigned_cpus),
-                    feature_importances=ensel_bag.get_feature_importances_df(),
+                    predictions=ensel_bag.get_predictions_df(n_assigned_cpus=n_assigned_cpus),
+                    fi=ensel_bag.get_fi_df(),
                     model=ensel_bag,
                 )
                 module_results[ResultType.ENSEMBLE_SELECTION] = ensel_result
@@ -147,7 +147,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         x_traindev: pd.DataFrame,
         y_traindev: pd.DataFrame,
         feature_cols: list[str],
-        outersplit_id: int,
+        outer_split_id: int,
         scratch_dir: UPath,
         results_dir: UPath,
     ):
@@ -172,10 +172,10 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         # create datasplit during init
         self.data_splits_ = DataSplit(
             dataset=data_traindev,
-            seeds=self.config.datasplit_seeds_inner,
-            num_folds=self.config.n_folds_inner,
+            seeds=self.config.inner_split_seeds,
+            n_splits=self.config.n_inner_splits,
             stratification_col=study_context.stratification_col,
-            process_id=f"OUTER {outersplit_id} SEQ TBD",
+            process_id=f"OUTER {outer_split_id} SEQ TBD",
         ).get_inner_splits()
 
         if study_context.ml_type in (MLType.BINARY, MLType.MULTICLASS):
@@ -183,7 +183,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         elif study_context.ml_type == MLType.TIMETOEVENT:
             validate_class_coverage(self.data_splits_, study_context.target_assignments["event"])
 
-        logger.set_log_group(LogGroup.PREPARE_EXECUTION, f"OUTER {outersplit_id} SQE TBD")
+        logger.set_log_group(LogGroup.PREPARE_EXECUTION, f"OUTER {outer_split_id} SQE TBD")
 
         # Create MRMR feature lists
         self._create_mrmr_features(study_context, x_traindev, y_traindev, feature_cols)
@@ -198,15 +198,13 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         """Calculate feature lists for all provided features numbers."""
         logger.info("Calculating MRMR feature sets...")
         # remove duplicates and cap max number
-        feature_numbers = list(set(self.config.mrmr_feature_numbers))
+        feature_numbers = list(set(self.config.n_mrmr_features))
         feature_numbers = [x for x in feature_numbers if isinstance(x, int) and x <= len(feature_cols)]
         # if no mrmr features are requested, only add original features
         if not feature_numbers:
             # add original features
             self.mrmr_features_[len(feature_cols)] = feature_cols
             return
-
-        # prepare inputs
 
         # create relevance information
         re_df = _relevance_fstats(
@@ -227,7 +225,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         self.mrmr_features_[len(feature_cols)] = feature_cols
 
     def _run_ensemble_selection(
-        self, study_context: StudyContext, outersplit_id: int, num_assigned_cpus: int, scratch_dir: UPath, results: dict
+        self, study_context: StudyContext, outer_split_id: int, n_assigned_cpus: int, scratch_dir: UPath, results: dict
     ) -> list[str]:
         """Run ensemble selection."""
         ensel = EnSel(
@@ -237,16 +235,16 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             row_id_col=study_context.row_id_col,
             target_assignments=study_context.target_assignments,
             positive_class=study_context.positive_class,
-            num_assigned_cpus=num_assigned_cpus,
+            n_assigned_cpus=n_assigned_cpus,
         )
         ensemble_paths_dict = ensel.start_ensemble
-        return self._create_ensemble_bag(study_context, outersplit_id, num_assigned_cpus, ensemble_paths_dict, results)
+        return self._create_ensemble_bag(study_context, outer_split_id, n_assigned_cpus, ensemble_paths_dict, results)
 
     def _create_ensemble_bag(
         self,
         study_context: StudyContext,
-        outersplit_id: int,
-        num_assigned_cpus: int,
+        outer_split_id: int,
+        n_assigned_cpus: int,
         ensemble_paths_dict: dict,
         results: dict,
     ) -> list[str]:
@@ -254,8 +252,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         if len(ensemble_paths_dict) == 0:
             raise ValueError("Valid ensemble information need to be provided")
 
-        # Compute outersplit_task_id from outersplit_id and task_id
-        training_id = f"{outersplit_id}_{self.config.task_id}"
+        # Compute outer_split_task_id from outer_split_id and task_id
+        training_id = f"{outer_split_id}_{self.config.task_id}"
 
         # extract trainings
         trainings = []
@@ -282,7 +280,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             log_dir=study_context.log_dir,
         )
         # save performance values of best bag
-        ensel_scores = ensel_bag.get_performance(num_assigned_cpus=num_assigned_cpus)
+        ensel_scores = ensel_bag.get_performance(n_assigned_cpus=n_assigned_cpus)
         target_metric = study_context.target_metric
         # show and save test results
         logger.set_log_group(LogGroup.RESULTS)
@@ -293,8 +291,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
 
         # calculate feature importances of best bag
         fi_methods: list[FIComputeMethod] = []  # disable calculation of pfi for ensel_bag
-        ensel_bag_fi = ensel_bag.calculate_feature_importances(
-            fi_methods=fi_methods, partitions=["dev"], num_assigned_cpus=num_assigned_cpus
+        ensel_bag_fi = ensel_bag.calculate_fi(
+            fi_methods=fi_methods, partitions=["dev"], n_assigned_cpus=n_assigned_cpus
         )
 
         # calculate selected features
@@ -303,8 +301,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         # save best bag and results to local dict
         results["ensel"] = {
             "scores": ensel_scores,
-            "predictions": ensel_bag.get_predictions(num_assigned_cpus=num_assigned_cpus),
-            "feature_importances": ensel_bag_fi,
+            "predictions": ensel_bag.get_predictions(n_assigned_cpus=n_assigned_cpus),
+            "fi": ensel_bag_fi,
             "_bag": ensel_bag,
         }
 
@@ -316,24 +314,34 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         data_test: pd.DataFrame,
         feature_cols: list[str],
         feature_groups: dict,
-        outersplit_id: int,
-        num_assigned_cpus: int,
+        outer_split_id: int,
+        n_assigned_cpus: int,
         results_dir: UPath,
         results: dict[str, dict],
     ) -> list[str]:
-        """Optimization run with a global HP set over all inner folds."""
+        """Optimization run with a global HP set over all inner splits."""
         logger.info("Running Optuna Optimization with a global HP set")
 
         # Optimize splits.
         splits = self.data_splits_
-        study_name = f"optuna_{outersplit_id}_{self.config.task_id}"
-        outersplit_task_id = f"{outersplit_id}_{self.config.task_id}"
-        task_path = f"outersplit{outersplit_id}/task{self.config.task_id}"
+        study_name = f"optuna_{outer_split_id}_{self.config.task_id}"
+        outer_split_task_id = f"{outer_split_id}_{self.config.task_id}"
+        task_path = f"outersplit{outer_split_id}/task{self.config.task_id}"
+
+        # Warn when the penalty_factor may not match the metric's scale
+        if self.config.max_features > 0 and study_context.target_metric in {"MAE", "MSE", "RMSE"}:
+            logger.warning(
+                "penalty_factor=%.2f is used with metric '%s' whose values are not "
+                "in the 0..1 range. Make sure penalty_factor is scaled to the "
+                "metric's magnitude for the feature constraint to be effective.",
+                self.config.penalty_factor,
+                study_context.target_metric,
+            )
 
         # set up Optuna study
         objective = ObjectiveOptuna(
-            outersplit_task_id=outersplit_task_id,
-            outersplit_id=outersplit_id,
+            outer_split_task_id=outer_split_task_id,
+            outer_split_id=outer_split_id,
             ml_type=study_context.ml_type,
             target_assignments=study_context.target_assignments,
             feature_cols=feature_cols,
@@ -350,7 +358,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
             top_trials=self.top_trials_,
             mrmr_features=self.mrmr_features_,
             log_dir=study_context.log_dir,
-            num_assigned_cpus=num_assigned_cpus,
+            n_assigned_cpus=n_assigned_cpus,
         )
 
         # multivariate sampler with group option
@@ -361,8 +369,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
                 multivariate=True,
                 group=True,
                 constant_liar=True,
-                seed=self.config.optuna_seed,
-                n_startup_trials=self.config.n_optuna_startup_trials,
+                seed=0,
+                n_startup_trials=self.config.n_startup_trials,
             )
 
         # create study with in-memory storage
@@ -401,7 +409,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
 
                 dict_optuna.append(
                     {
-                        "outersplit_id": outersplit_id,
+                        "outer_split_id": outer_split_id,
                         "task_id": self.config.task_id,
                         "trial": trial.number,
                         "value": trial.value,
@@ -414,7 +422,7 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         parquet_save(pd.DataFrame(dict_optuna), dict_optuna_path)
 
         # display results
-        logger.set_log_group(LogGroup.SCORES, f"OUTER {outersplit_id} SQE TBD")
+        logger.set_log_group(LogGroup.SCORES, f"OUTER {outer_split_id} SQE TBD")
         logger.info("Optimization results: ")
         logger.info(f"Best trial number {study.best_trial.number}")
         logger.info(f"Best target value {study.best_value}")
@@ -427,8 +435,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         n_input_features = user_attrs["config_training"]["n_input_features"]
         best_bag_feature_cols = self.mrmr_features_[n_input_features]
 
-        # Compute outersplit_task_id from outersplit_id and task_id
-        training_id = f"{outersplit_id}_{self.config.task_id}"
+        # Compute outer_split_task_id from outer_split_id and task_id
+        training_id = f"{outer_split_id}_{self.config.task_id}"
 
         # create best bag from optuna info
         best_trainings = []
@@ -461,10 +469,10 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         )
 
         # train all models in best_bag
-        best_bag.fit(num_assigned_cpus=num_assigned_cpus)
+        best_bag.fit(n_assigned_cpus=n_assigned_cpus)
 
         # save performance values of best bag
-        best_bag_performance = best_bag.get_performance(num_assigned_cpus=num_assigned_cpus)
+        best_bag_performance = best_bag.get_performance(n_assigned_cpus=n_assigned_cpus)
         logger.info(f"Best bag performance {best_bag_performance}")
         target_metric = study_context.target_metric
 
@@ -479,10 +487,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         )
 
         # calculate feature importances of best bag
-        fi_methods = self.config.fi_methods_bestbag
-        best_bag_fi = best_bag.calculate_feature_importances(
-            fi_methods, partitions=["dev"], num_assigned_cpus=num_assigned_cpus
-        )
+        fi_methods = self.config.fi_methods
+        best_bag_fi = best_bag.calculate_fi(fi_methods, partitions=["dev"], n_assigned_cpus=n_assigned_cpus)
 
         # calculate selected features
         selected_features = best_bag.get_selected_features(fi_methods)
@@ -490,8 +496,8 @@ class OctoModuleTemplate[T: Octo](ModuleExecution[T]):
         # save best bag and results to local dict
         results["best"] = {
             "scores": best_bag_performance,
-            "predictions": best_bag.get_predictions(num_assigned_cpus=num_assigned_cpus),
-            "feature_importances": best_bag_fi,
+            "predictions": best_bag.get_predictions(n_assigned_cpus=n_assigned_cpus),
+            "fi": best_bag_fi,
             "_bag": best_bag,
         }
 

--- a/octopus/modules/octo/enssel.py
+++ b/octopus/modules/octo/enssel.py
@@ -36,7 +36,7 @@ class EnSel:
     path_trials: UPath = field(validator=[validators.instance_of(UPath)])
     max_n_iterations: int = field(validator=[validators.instance_of(int)])
     row_id_col: str = field(validator=[validators.instance_of(str)])
-    num_assigned_cpus: int = field(validator=[validators.instance_of(int)])
+    n_assigned_cpus: int = field(validator=[validators.instance_of(int)])
     positive_class = field(default=None)
     model_table: pd.DataFrame = field(
         init=False,
@@ -78,8 +78,8 @@ class EnSel:
             bag: BagBase = joblib_load(file)
             self.bags[file] = {
                 "id": bag.bag_id,
-                "performance": bag.get_performance(num_assigned_cpus=self.num_assigned_cpus),
-                "predictions": bag.get_predictions(num_assigned_cpus=self.num_assigned_cpus),
+                "performance": bag.get_performance(n_assigned_cpus=self.n_assigned_cpus),
+                "predictions": bag.get_predictions(n_assigned_cpus=self.n_assigned_cpus),
                 "n_features_used_mean": bag.n_features_used_mean,
             }
 
@@ -110,7 +110,7 @@ class EnSel:
 
     def _ensemble_models(self, bag_keys):
         """Esemble using all bags and their corresponding models provided by input."""
-        # collect all predictions over inner folds and bags
+        # collect all predictions over inner splits and bags
         predictions: dict[str, dict[str, pd.DataFrame]] = {}
         performance_output = {}
         pool: dict[str, list[pd.DataFrame]] = {key: [] for key in ["dev", "test"]}

--- a/octopus/modules/octo/module.py
+++ b/octopus/modules/octo/module.py
@@ -9,7 +9,7 @@ from attrs import Factory, define, field, validators
 from octopus.logger import get_logger
 from octopus.models import Models
 from octopus.modules import ModuleExecution, Task
-from octopus.types import FIComputeMethod, ModelName, OptunaReturnType
+from octopus.types import FIComputeMethod, ModelName, ScoringMethod
 
 logger = get_logger()
 
@@ -35,10 +35,10 @@ class Octo(Task):
 
     Configuration:
         models: List of model names to optimize
-        n_folds_inner: Number of inner CV folds
+        n_inner_splits: Number of inner CV splits
         n_trials: Number of Optuna trials
         ensemble_selection: Whether to perform ensemble selection
-        mrmr_feature_numbers: Feature counts for MRMR feature selection
+        n_mrmr_features: Number-of-feature options for MRMR-based Optuna search
     """
 
     models: list[ModelName] | None = field(
@@ -47,10 +47,10 @@ class Octo(Task):
     )
     """Models for ML. If None, defaults are resolved at fit time based on ml_type."""
 
-    n_folds_inner: int = field(validator=[validators.instance_of(int)], default=5)
-    """Number of inner folds."""
+    n_inner_splits: int = field(validator=[validators.instance_of(int)], default=5)
+    """Number of inner splits."""
 
-    datasplit_seeds_inner: list[int] = field(
+    inner_split_seeds: list[int] = field(
         default=Factory(lambda: [0]),
         validator=validators.deep_iterable(
             member_validator=validators.instance_of(int),
@@ -59,13 +59,10 @@ class Octo(Task):
     )
     """List of integers used as seeds for data splitting."""
 
-    model_seed: int = field(validator=[validators.instance_of(int)], default=0)
-    """Model seed."""
-
-    max_outl: int = field(validator=[validators.instance_of(int)], default=3)
+    max_outliers: int = field(validator=[validators.instance_of(int)], default=3)
     """Maximum number of outliers, optimized by Optuna"""
 
-    fi_methods_bestbag: list[FIComputeMethod] = field(
+    fi_methods: list[FIComputeMethod] = field(
         default=Factory(lambda: [FIComputeMethod.PERMUTATION]),
         converter=lambda vs: [FIComputeMethod(v) for v in vs],
         validator=validators.deep_iterable(
@@ -77,17 +74,14 @@ class Octo(Task):
     )
     """Feature importance methods for best bag."""
 
-    optuna_seed: int = field(validator=[validators.instance_of(int)], default=0)
-    """Seed for Optuna TPESampler, default=0"""
-
-    n_optuna_startup_trials: int = field(validator=[validators.instance_of(int)], default=15)
+    n_startup_trials: int = field(validator=[validators.instance_of(int)], default=15)
     """Number of Optuna startup trials (random sampler)"""
 
     ensemble_selection: bool = field(validator=[validators.in_([True, False])], default=False)
     """Whether to perform ensemble selection."""
 
-    ensel_n_save_trials: int = field(validator=[validators.instance_of(int)], default=50)
-    """Number of top trials to be saved for ensemble selection (bags)."""
+    n_ensemble_candidates: int = field(validator=[validators.instance_of(int)], default=50)
+    """Number of top-performing bags to keep as candidates for ensemble selection."""
 
     n_trials: int = field(validator=[validators.instance_of(int)], default=200 if not _RUNNING_IN_TESTSUITE else 3)
     """Number of Optuna trials."""
@@ -99,15 +93,40 @@ class Octo(Task):
     """Maximum features to constrain hyperparameter optimization. Default is zero (off)."""
 
     penalty_factor: float = field(validator=[validators.instance_of(float)], default=1.0)
-    """Factor to penalize optuna target related to feature constraint."""
+    """Penalty multiplier for the feature-count constraint in Optuna optimization.
 
-    mrmr_feature_numbers: list = field(validator=[validators.instance_of(list)], default=Factory(list))
-    """List of feature numbers to be investigated by mrmr."""
+    When ``max_features > 0``, Optuna penalises trials that use more features
+    than allowed::
 
-    optuna_return: OptunaReturnType = field(
-        default=OptunaReturnType.ENSEMBLE,
-        converter=OptunaReturnType,
-        validator=validators.in_(list(OptunaReturnType)),
+        penalty = penalty_factor * excess_features / total_features
+
+    This penalty is subtracted from the optimisation target in the same numeric
+    space as the target metric.  The default of ``1.0`` works well for metrics
+    bounded between 0 and 1 (AUCROC, ACCBAL, R2, …).  For metrics on a larger
+    scale (MAE, MSE, RMSE, …) the penalty becomes negligible relative to the
+    score and feature constraining has no effect.  In that case, increase
+    ``penalty_factor`` to match the metric's magnitude — e.g. if MAE ≈ 100,
+    try ``penalty_factor=100.0``.
+    """
+
+    n_mrmr_features: list[int] = field(validator=[validators.instance_of(list)], default=Factory(list))
+    """Number-of-feature options for MRMR pre-selection during Optuna optimization.
+
+    Each integer specifies a number of top features to pre-select via MRMR
+    (Max-Relevance Min-Redundancy). The resulting subsets become an additional
+    Optuna hyperparameter, so each trial may use a different subset size.
+    The full feature set is always included as an option.
+
+    Example: ``[10, 20, 50]`` pre-computes the top-10, top-20, and top-50
+    MRMR features; Optuna then chooses among these three subsets plus all
+    features.  An empty list (default) disables MRMR and uses all features
+    in every trial.
+    """
+
+    scoring_method: ScoringMethod = field(
+        default=ScoringMethod.COMBINED,
+        converter=ScoringMethod,
+        validator=validators.in_(list(ScoringMethod)),
     )
     """How to calculate the bag performance for the optuna optimization target."""
 

--- a/octopus/modules/octo/objective_optuna.py
+++ b/octopus/modules/octo/objective_optuna.py
@@ -9,7 +9,7 @@ from octopus.datasplit import InnerSplits
 from octopus.logger import get_logger
 from octopus.metrics import Metrics
 from octopus.models import Models
-from octopus.types import LogGroup, MetricDirection, MLType, ModelName, OptunaReturnType
+from octopus.types import LogGroup, MetricDirection, MLType, ModelName, ScoringMethod
 from octopus.utils import joblib_save
 
 from .bag import Bag, BagClassifier, BagRegressor
@@ -26,8 +26,8 @@ class ObjectiveOptuna:
 
     def __init__(
         self,
-        outersplit_task_id: str,
-        outersplit_id: int,
+        outer_split_task_id: str,
+        outer_split_id: int,
         ml_type: MLType,
         target_assignments: dict,
         feature_cols: list[str],
@@ -44,10 +44,10 @@ class ObjectiveOptuna:
         top_trials,
         mrmr_features,
         log_dir: UPath,
-        num_assigned_cpus: int,
+        n_assigned_cpus: int,
     ):
-        self.outersplit_task_id = outersplit_task_id
-        self.outersplit_id = outersplit_id
+        self.outer_split_task_id = outer_split_task_id
+        self.outer_split_id = outer_split_id
         self.ml_type = ml_type
         self.target_assignments = target_assignments
         self.feature_cols = feature_cols
@@ -65,18 +65,15 @@ class ObjectiveOptuna:
         self.mrmr_features = mrmr_features
         # saving trials
         self.ensel = self.config.ensemble_selection
-        self.n_save_trials = self.config.ensel_n_save_trials
+        self.n_save_trials = self.config.n_ensemble_candidates
         # parameters potentially used for optimizations
         self.ml_model_types = self.config.models
-        self.max_outl = self.config.max_outl
+        self.max_outl = self.config.max_outliers
         self.max_features = self.config.max_features
-        self.penalty_factor = self.config.penalty_factor
         self.hyper_parameters = self.config.hyperparameters
-        # fixed parameters
-        self.ml_seed = self.config.model_seed
         # training parameters
         self.log_dir = log_dir
-        self.num_assigned_cpus = num_assigned_cpus
+        self.n_assigned_cpus = n_assigned_cpus
 
     def __call__(self, trial: Trial) -> float:
         """Call.
@@ -99,9 +96,9 @@ class ObjectiveOptuna:
 
         # (3) number of outliers to be detected
         if self.max_outl > 0:
-            num_outl = trial.suggest_int(name="num_outl", low=0, high=self.max_outl)
+            n_outliers = trial.suggest_int(name="n_outliers", low=0, high=self.max_outl)
         else:
-            num_outl = 0
+            n_outliers = 0
 
         # (4) selected mrmr features
         if self.mrmr_features:
@@ -116,11 +113,11 @@ class ObjectiveOptuna:
             ml_model_type,
             self.hyper_parameters,
             n_jobs=1,  # inner parallelization happens over inner splits, so we do not allow any further parallelization here.  # TODO: how about setting parallelization over inner splits and then compute n_jobs accordingly?
-            model_seed=self.ml_seed,
+            model_seed=0,
         )
 
         config_training: TrainingConfig = {
-            "outl_reduction": num_outl,
+            "outl_reduction": n_outliers,
             "n_input_features": len(feature_cols),
             "ml_model_type": ml_model_type,
             "ml_model_params": model_params,
@@ -132,7 +129,7 @@ class ObjectiveOptuna:
         for key, split in self.data_splits.items():
             trainings.append(
                 Training(
-                    training_id=self.outersplit_task_id + "_" + str(key),
+                    training_id=self.outer_split_task_id + "_" + str(key),
                     ml_type=self.ml_type,
                     target_assignments=self.target_assignments,
                     feature_cols=feature_cols,
@@ -149,7 +146,7 @@ class ObjectiveOptuna:
 
         # create bag with all provided trainings
         bag_trainings = Bag(
-            bag_id=self.outersplit_task_id + "_" + str(trial.number),
+            bag_id=self.outer_split_task_id + "_" + str(trial.number),
             trainings=trainings,
             target_assignments=self.target_assignments,
             target_metric=self.target_metric,
@@ -160,10 +157,10 @@ class ObjectiveOptuna:
         )
 
         # train all models in bag
-        bag_trainings.fit(num_assigned_cpus=self.num_assigned_cpus)
+        bag_trainings.fit(n_assigned_cpus=self.n_assigned_cpus)
 
         # evaluate trainings using target metric
-        bag_performance = bag_trainings.get_performance(num_assigned_cpus=self.num_assigned_cpus)
+        bag_performance = bag_trainings.get_performance(n_assigned_cpus=self.n_assigned_cpus)
 
         # get number of features used in bag
         n_features_mean = bag_trainings.n_features_used_mean
@@ -179,7 +176,7 @@ class ObjectiveOptuna:
         self._log_trial_scores(bag_performance)
 
         # define optuna target
-        if self.config.optuna_return == OptunaReturnType.ENSEMBLE:
+        if self.config.scoring_method == ScoringMethod.COMBINED:
             optuna_target: float = bag_performance["dev_ensemble"]
         else:
             optuna_target = bag_performance["dev_avg"]
@@ -195,7 +192,7 @@ class ObjectiveOptuna:
             # only consider if n_features_mean > max_features
             diff_nfeatures = max(diff_nfeatures, 0)
             n_features = len(self.feature_cols)
-            optuna_target = optuna_target - self.penalty_factor * diff_nfeatures / n_features
+            optuna_target = optuna_target - self.config.penalty_factor * diff_nfeatures / n_features
 
         # save bag if we plan to run ensemble selection
         if self.ensel:
@@ -207,7 +204,7 @@ class ObjectiveOptuna:
         return optuna_target
 
     def _save_topn_trials(self, bag: BagClassifier | BagRegressor, target_value, n_trial):
-        max_n_trials = self.config.ensel_n_save_trials
+        max_n_trials = self.n_save_trials
         path_save = self.path_study / self.task_path / "scratch" / f"trial_{n_trial}_bag.joblib"
 
         # saving top n_trials to disk
@@ -224,7 +221,7 @@ class ObjectiveOptuna:
                 raise FileNotFoundError("Problem deleting trial-pkl file")
 
     def _log_trial_scores(self, scores):
-        logger.set_log_group(LogGroup.SCORES, f"OUTER {self.outersplit_id} SQE TBD")
+        logger.set_log_group(LogGroup.SCORES, f"OUTER {self.outer_split_id} SQE TBD")
         # Log the target metric
         logger.info(f"Trial scores for metric: {self.target_metric}")
 

--- a/octopus/modules/octo/training.py
+++ b/octopus/modules/octo/training.py
@@ -209,7 +209,7 @@ def parse_fi_storage_key(key: str) -> tuple[FIResultLabel, str]:
     """Parse a FI storage key into ``(method_label, dataset)``.
 
     Reverse of :func:`fi_storage_key` for the subset of keys used in
-    ``get_feature_importances_df()``.  Recognises partition-aware methods
+    ``get_fi_df()``.  Recognises partition-aware methods
     (permutation, shap, lofo) and returns the partition suffix; for
     partition-less methods (internal, constant) returns ``"train"`` as the
     dataset label.
@@ -303,9 +303,7 @@ class Training:
     predictions: dict = field(default=Factory(dict), validator=[validators.instance_of(dict)])
     """Model predictions."""
 
-    feature_importances: dict[str, pd.DataFrame] = field(
-        default=Factory(dict), validator=[validators.instance_of(dict)]
-    )
+    fi: dict[str, pd.DataFrame] = field(default=Factory(dict), validator=[validators.instance_of(dict)])
     """Feature importances, mapping from FI method to DataFrame."""
 
     features_used: list = field(default=Factory(list), validator=[validators.instance_of(list)])
@@ -591,7 +589,7 @@ class Training:
             raise RuntimeError(f"Model training failed for {self.ml_model_type}: {e}") from e
 
         # (4) Model prediction
-        # Parse training_id to get split metadata: "outersplit_task_innersplit" (e.g., "1_0_2")
+        # Parse training_id to get split metadata: "outer_split_task_inner_split" (e.g., "1_0_2")
         parts = self.training_id.split("_")
         try:
             outer_split_id = int(parts[0])
@@ -663,27 +661,27 @@ class Training:
 
     def _calculate_features_used(self):
         """Calculate used features, method based on model type."""
-        feature_method = Models.get_config(self.ml_model_type).feature_method
+        fi_method = Models.get_config(self.ml_model_type).fi_method
 
-        if feature_method == FIComputeMethod.INTERNAL:
+        if fi_method == FIComputeMethod.INTERNAL:
             self._calculate_fi_internal()
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.INTERNAL)]
-        elif feature_method == FIComputeMethod.SHAP:
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.INTERNAL)]
+        elif fi_method == FIComputeMethod.SHAP:
             self._calculate_fi_featuresused_shap(partition="dev")
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.SHAP, "dev")]
-        elif feature_method == FIComputeMethod.PERMUTATION:
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.SHAP, "dev")]
+        elif fi_method == FIComputeMethod.PERMUTATION:
             self._calculate_fi_permutation(partition="dev", n_repeats=2, use_groups=False)  # only 2 repeats!
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.PERMUTATION, "dev")]
-        elif feature_method == FIComputeMethod.CONSTANT:
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.PERMUTATION, "dev")]
+        elif fi_method == FIComputeMethod.CONSTANT:
             self._calculate_fi_constant()
-            fi_df = self.feature_importances[fi_storage_key(FIComputeMethod.CONSTANT)]
+            fi_df = self.fi[fi_storage_key(FIComputeMethod.CONSTANT)]
         else:
             raise ValueError("feature method provided in model config not supported")
 
         # Check if feature importance calculation failed (empty DataFrame)
         if fi_df.empty:
             logger.warning(
-                f"Feature importance calculation failed for model {self.ml_model_type} using method {feature_method}. Returning all features as used."
+                f"Feature importance calculation failed for model {self.ml_model_type} using method {fi_method}. Returning all features as used."
             )
             return self.feature_cols.copy()
 
@@ -692,7 +690,7 @@ class Training:
         # If no features have non-zero importance, return all features as a fallback
         if not features_used:
             logger.warning(
-                f"All feature importances are zero for model {self.ml_model_type} using method {feature_method}. Returning all features as used."
+                f"All feature importances are zero for model {self.ml_model_type} using method {fi_method}. Returning all features as used."
             )
             return self.feature_cols.copy()
 
@@ -708,7 +706,7 @@ class Training:
 
         Single entry point for all FI calculations. Dispatches to the
         appropriate method and stores results in
-        ``self.feature_importances``.
+        ``self.fi``.
 
         Args:
             fi_type: The feature importance method to use.
@@ -738,7 +736,7 @@ class Training:
         fi_df = pd.DataFrame()
         fi_df["feature"] = self.feature_cols
         fi_df["importance"] = 1
-        self.feature_importances[fi_storage_key(FIComputeMethod.CONSTANT)] = fi_df
+        self.fi[fi_storage_key(FIComputeMethod.CONSTANT)] = fi_df
 
     def _calculate_fi_internal(self):
         """Sklearn-provided internal feature importance (based on train dataset).
@@ -751,7 +749,7 @@ class Training:
             feature_names=self.feature_cols,
             ml_type=self.ml_type,
         )
-        self.feature_importances[fi_storage_key(FIComputeMethod.INTERNAL)] = fi_df
+        self.fi[fi_storage_key(FIComputeMethod.INTERNAL)] = fi_df
 
     def _calculate_fi_permutation(
         self,
@@ -814,7 +812,7 @@ class Training:
 
         results_df["n"] = n_repeats
         results_df = results_df.sort_values(by="importance", ascending=False)
-        self.feature_importances[fi_storage_key(FIComputeMethod.PERMUTATION, partition)] = results_df
+        self.fi[fi_storage_key(FIComputeMethod.PERMUTATION, partition)] = results_df
 
     def _calculate_fi_lofo(self):
         """LOFO feature importance.
@@ -847,7 +845,7 @@ class Training:
         )
 
         for key, df in results.items():
-            self.feature_importances[key] = df
+            self.fi[key] = df
 
     def _calculate_fi_featuresused_shap(
         self, partition: DataPartition | str = DataPartition.DEV, bg_max: int = 200
@@ -890,7 +888,7 @@ class Training:
             threshold_ratio=1.0 / 1000.0,
             ml_type=self.ml_type,
         )
-        self.feature_importances[fi_storage_key(FIComputeMethod.SHAP, partition)] = fi_df
+        self.fi[fi_storage_key(FIComputeMethod.SHAP, partition)] = fi_df
 
     def _calculate_fi_shap(
         self, partition: DataPartition | str = DataPartition.DEV, shap_type: str = "kernel", background_size: int = 200
@@ -938,7 +936,7 @@ class Training:
             threshold_ratio=1.0 / 1000.0,
             ml_type=self.ml_type,
         )
-        self.feature_importances[fi_storage_key(FIComputeMethod.SHAP, partition)] = fi_df
+        self.fi[fi_storage_key(FIComputeMethod.SHAP, partition)] = fi_df
 
     def predict(self, x: pd.DataFrame) -> np.ndarray:
         """Predict.

--- a/octopus/modules/result.py
+++ b/octopus/modules/result.py
@@ -16,7 +16,7 @@ class ModuleResult:
     """Unified result container for a single result type from a module.
 
     Carries all 5 artifacts (selected_features, scores, predictions,
-    feature_importances, model) and knows how to save/load itself.
+    fi, model) and knows how to save/load itself.
     Each result_type gets its own directory on disk.
     """
 
@@ -25,7 +25,7 @@ class ModuleResult:
     selected_features: list[str] = field(factory=list)
     scores: pd.DataFrame | None = field(default=None)
     predictions: pd.DataFrame | None = field(default=None)
-    feature_importances: pd.DataFrame | None = field(default=None)
+    fi: pd.DataFrame | None = field(default=None)
     model: Any = field(default=None)
 
     def save(self, result_dir: UPath) -> None:
@@ -47,7 +47,7 @@ class ModuleResult:
         for name, df in [
             ("scores", self.scores),
             ("predictions", self.predictions),
-            ("feature_importances", self.feature_importances),
+            ("feature_importances", self.fi),
         ]:
             if df is not None and not df.empty:
                 out = df.copy()
@@ -88,7 +88,7 @@ class ModuleResult:
         # Load DataFrames (None if file doesn't exist)
         scores: pd.DataFrame | None = None
         predictions: pd.DataFrame | None = None
-        feature_importances: pd.DataFrame | None = None
+        fi_df: pd.DataFrame | None = None
 
         for name in ["scores", "predictions", "feature_importances"]:
             path = result_dir / f"{name}.parquet"
@@ -99,7 +99,7 @@ class ModuleResult:
                 elif name == "predictions":
                     predictions = df
                 elif name == "feature_importances":
-                    feature_importances = df
+                    fi_df = df
 
         # Load model if exists
         model = None
@@ -114,6 +114,6 @@ class ModuleResult:
             selected_features=selected_features,
             scores=scores,
             predictions=predictions,
-            feature_importances=feature_importances,
+            fi=fi_df,
             model=model,
         )

--- a/octopus/modules/roc/core.py
+++ b/octopus/modules/roc/core.py
@@ -20,7 +20,7 @@ from sklearn.feature_selection import (
 from octopus.logger import get_logger
 from octopus.modules import ModuleExecution, ModuleResult
 from octopus.modules.utils import rdc_correlation_matrix
-from octopus.types import CorrelationType, MLType, ResultType, ROCFilterMethod
+from octopus.types import CorrelationType, MLType, RelevanceMethod, ResultType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -33,13 +33,13 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 # Filter functions for feature selection
-filter_inventory: dict[ROCFilterMethod, dict[MLType, Callable]] = {
-    ROCFilterMethod.MUTUAL_INFO: {
+filter_inventory: dict[RelevanceMethod, dict[MLType, Callable]] = {
+    RelevanceMethod.MUTUAL_INFO: {
         MLType.BINARY: mutual_info_classif,
         MLType.MULTICLASS: mutual_info_classif,
         MLType.REGRESSION: mutual_info_regression,
     },
-    ROCFilterMethod.F_STATISTICS: {
+    RelevanceMethod.F_STATISTICS: {
         MLType.BINARY: f_classif,
         MLType.MULTICLASS: f_classif,
         MLType.REGRESSION: f_regression,
@@ -68,8 +68,8 @@ class RocModule(ModuleExecution["Roc"]):
         np.random.seed(0)
 
         logger.info(f"Correlation type: {self.config.correlation_type}")
-        logger.info(f"Threshold: {self.config.threshold}")
-        logger.info(f"Filter type: {self.config.filter_type}")
+        logger.info(f"Correlation threshold: {self.config.correlation_threshold}")
+        logger.info(f"Relevance method: {self.config.relevance_method}")
 
         # Extract feature matrices (local variables)
         x_traindev = data_traindev[feature_cols]
@@ -79,15 +79,15 @@ class RocModule(ModuleExecution["Roc"]):
         logger.info("Calculating dependency to target")
         if study_context.ml_type == MLType.TIMETOEVENT:
             logger.info("Time2Event: Note, that the first group element is selected.")
-        elif self.config.filter_type == ROCFilterMethod.MUTUAL_INFO:
+        elif self.config.relevance_method == RelevanceMethod.MUTUAL_INFO:
             # Set random state
-            values = filter_inventory[self.config.filter_type][study_context.ml_type](
+            values = filter_inventory[self.config.relevance_method][study_context.ml_type](
                 x_traindev, y_traindev.to_numpy().ravel(), random_state=0
             )
             dependency = pd.Series(values, index=feature_cols)
-        elif self.config.filter_type == ROCFilterMethod.F_STATISTICS:
+        elif self.config.relevance_method == RelevanceMethod.F_STATISTICS:
             # Ignoring p-values
-            values, _ = filter_inventory[self.config.filter_type][study_context.ml_type](
+            values, _ = filter_inventory[self.config.relevance_method][study_context.ml_type](
                 x_traindev, y_traindev.to_numpy().ravel()
             )
             dependency = pd.Series(values, index=feature_cols)
@@ -106,7 +106,7 @@ class RocModule(ModuleExecution["Roc"]):
         g: nx.Graph = nx.Graph()
         for i in range(len(feature_cols)):
             for j in range(i + 1, len(feature_cols)):
-                if pos_corr_matrix[i, j] > self.config.threshold:
+                if pos_corr_matrix[i, j] > self.config.correlation_threshold:
                     g.add_edge(i, j)
 
         # Get connected components and sort for determinism

--- a/octopus/modules/roc/module.py
+++ b/octopus/modules/roc/module.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from attrs import define, field, validators
 
-from octopus.types import CorrelationType, ROCFilterMethod
+from octopus.types import CorrelationType, RelevanceMethod
 
 from ..base import ModuleExecution, Task
 
@@ -15,17 +15,17 @@ class Roc(Task):
 
     This module identifies groups of correlated features and selects the most
     informative feature from each group, removing the rest. Uses correlation
-    analysis (Spearman or RDC) combined with feature filtering (mutual information
-    or F-statistics) to determine which features to keep.
+    analysis (Spearman or RDC) combined with feature relevance scoring (mutual
+    information or F-statistics) to determine which features to keep.
 
     Configuration:
-        threshold: Correlation threshold above which features are considered correlated
+        correlation_threshold: Correlation threshold above which features are considered correlated
         correlation_type: Type of correlation measure (CorrelationType.SPEARMAN or CorrelationType.RDC)
-        filter_type: Method to select best feature in group (ROCFilterMethod.MUTUAL_INFO or ROCFilterMethod.F_STATISTICS)
+        relevance_method: Method to select best feature in group (RelevanceMethod.MUTUAL_INFO or RelevanceMethod.F_STATISTICS)
     """
 
-    threshold: float = field(validator=[validators.instance_of(float)], default=0.8)
-    """Threshold for feature removal (features with correlation > threshold are grouped)."""
+    correlation_threshold: float = field(validator=[validators.instance_of(float)], default=0.8)
+    """Correlation threshold for feature removal (features with correlation > threshold are grouped)."""
 
     correlation_type: CorrelationType = field(
         converter=CorrelationType,
@@ -34,12 +34,12 @@ class Roc(Task):
     )
     """Selection of correlation type."""
 
-    filter_type: ROCFilterMethod = field(
-        converter=ROCFilterMethod,
-        validator=validators.in_([ROCFilterMethod.MUTUAL_INFO, ROCFilterMethod.F_STATISTICS]),
-        default=ROCFilterMethod.F_STATISTICS,
+    relevance_method: RelevanceMethod = field(
+        converter=RelevanceMethod,
+        validator=validators.in_([RelevanceMethod.MUTUAL_INFO, RelevanceMethod.F_STATISTICS]),
+        default=RelevanceMethod.F_STATISTICS,
     )
-    """Selection of filter type for correlated features."""
+    """Method to score feature relevance within correlated groups."""
 
     def create_module(self) -> ModuleExecution:
         """Create RocModule execution instance."""

--- a/octopus/predict/feature_importance.py
+++ b/octopus/predict/feature_importance.py
@@ -68,7 +68,7 @@ def _aggregate_across_splits(
     but set to NaN on ensemble rows.
 
     Args:
-        per_split_dfs: Dict mapping outersplit_id to a DataFrame with
+        per_split_dfs: Dict mapping outer_split_id to a DataFrame with
             at least columns ``["feature", "importance"]``.  May also
             contain ``"importance_std"`` and any columns listed in
             *extra_stat_cols*.
@@ -152,10 +152,10 @@ def calculate_fi_permutation(
     union of all input features.
 
     Args:
-        models: Dict mapping outersplit_id to fitted model.
-        selected_features: Dict mapping outersplit_id to feature list.
-        test_data: Dict mapping outersplit_id to test DataFrame.
-        train_data: Dict mapping outersplit_id to train DataFrame.
+        models: Dict mapping outer_split_id to fitted model.
+        selected_features: Dict mapping outer_split_id to feature list.
+        test_data: Dict mapping outer_split_id to test DataFrame.
+        train_data: Dict mapping outer_split_id to train DataFrame.
         target_assignments: Dict mapping semantic target roles to column
             names.  For single-target tasks: ``{"default": "y"}``.
             For time-to-event: ``{"duration": "time_col", "event": "event_col"}``.
@@ -236,9 +236,9 @@ def calculate_fi_shap(
     ``_aggregate_across_splits``.
 
     Args:
-        models: Dict mapping outersplit_id to fitted model.
-        selected_features: Dict mapping outersplit_id to feature list.
-        test_data: Dict mapping outersplit_id to test DataFrame.
+        models: Dict mapping outer_split_id to fitted model.
+        selected_features: Dict mapping outer_split_id to feature list.
+        test_data: Dict mapping outer_split_id to test DataFrame.
         shap_type: SHAP explainer type (``'kernel'``, ``'permutation'``,
             ``'exact'``).
         max_samples: Maximum number of evaluation samples per split.

--- a/octopus/predict/notebook_utils.py
+++ b/octopus/predict/notebook_utils.py
@@ -108,7 +108,7 @@ def display_table(data: Any) -> None:
 def _validate_study_structure(study_path: UPath, config: dict) -> dict:
     """Validate the study directory structure against the configuration.
 
-    Checks that expected outersplit directories and workflow task directories
+    Checks that expected outer split directories and workflow task directories
     exist.  Returns a dict of validation results without printing.
 
     Args:
@@ -117,32 +117,32 @@ def _validate_study_structure(study_path: UPath, config: dict) -> dict:
 
     Returns:
         Dictionary containing validation results with keys:
-            - 'outersplit_dirs': List of found outersplit directory paths
+            - 'outer_split_dirs': List of found outer split directory paths
             - 'expected_task_ids': List of expected task IDs
             - 'octo_workflow_tasks': List of task IDs for octo modules
-            - 'missing_outersplits': List of missing outersplit IDs
+            - 'missing_outer_splits': List of missing outer split IDs
             - 'missing_workflow_dirs': List of missing workflow directories
 
     Raises:
-        ValueError: If no outersplit directories or workflow results are found.
+        ValueError: If no outer split directories or workflow results are found.
     """
-    n_folds_outer = config["n_folds_outer"]
+    n_outer_splits = config["n_outer_splits"]
     workflow_tasks = config["workflow"]
 
-    outersplit = sorted(
+    outer_split_dirs = sorted(
         [d for d in study_path.glob("outersplit*") if d.is_dir()],
         key=lambda x: int(x.name.replace("outersplit", "")),
     )
 
-    if not outersplit:
+    if not outer_split_dirs:
         raise ValueError(
-            f"No outersplit directories found in study path.\n"
+            f"No outer split directories found in study path.\n"
             f"Study path: {study_path}\nThe study may not have been run yet."
         )
 
-    expected_outersplit_ids = list(range(n_folds_outer))
-    missing_outersplits = [
-        split_id for split_id in expected_outersplit_ids if not (study_path / f"outersplit{split_id}").exists()
+    expected_outer_split_ids = list(range(n_outer_splits))
+    missing_outer_splits = [
+        split_id for split_id in expected_outer_split_ids if not (study_path / f"outersplit{split_id}").exists()
     ]
 
     expected_task_ids = [task["task_id"] for task in workflow_tasks]
@@ -150,7 +150,7 @@ def _validate_study_structure(study_path: UPath, config: dict) -> dict:
     has_results = False
     missing_workflow_dirs: list[str] = []
 
-    for split_dir in outersplit:
+    for split_dir in outer_split_dirs:
         workflow_dirs = list(split_dir.glob("task*"))
         if workflow_dirs:
             has_results = True
@@ -160,15 +160,15 @@ def _validate_study_structure(study_path: UPath, config: dict) -> dict:
                 missing_workflow_dirs.append(f"{split_dir.name}/task{task_id}")
 
     if not has_results:
-        raise ValueError("No workflow results found in outersplits.\nThe study may not have completed successfully.")
+        raise ValueError("No workflow results found in outer splits.\nThe study may not have completed successfully.")
 
     octo_workflow_lst = [item["task_id"] for item in workflow_tasks if item["module"] == "octo"]
 
     return {
-        "outersplit_dirs": outersplit,
+        "outer_split_dirs": outer_split_dirs,
         "expected_task_ids": expected_task_ids,
         "octo_workflow_tasks": octo_workflow_lst,
-        "missing_outersplits": missing_outersplits,
+        "missing_outer_splits": missing_outer_splits,
         "missing_workflow_dirs": missing_workflow_dirs,
     }
 
@@ -178,7 +178,7 @@ def show_study_details(study_directory: str | UPath, verbose: bool = True) -> di
 
     This function reads the study configuration via ``StudyLoader``, validates
     the study structure, and displays information about the workflow tasks
-    and outersplit directories.
+    and outer split directories.
 
     Args:
         study_directory: Path to the study directory.
@@ -189,16 +189,16 @@ def show_study_details(study_directory: str | UPath, verbose: bool = True) -> di
             - 'path': UPath object of the study directory
             - 'config': Study configuration dictionary
             - 'ml_type': Machine learning type
-            - 'n_folds_outer': Number of outer folds
+            - 'n_outer_splits': Number of outer splits
             - 'workflow_tasks': List of workflow task configurations
-            - 'outersplit_dirs': List of outersplit directory paths
+            - 'outer_split_dirs': List of outer split directory paths
             - 'expected_task_ids': List of expected task IDs
             - 'octo_workflow_tasks': List of task IDs for octo modules
-            - 'missing_outersplits': List of missing outersplit IDs
+            - 'missing_outer_splits': List of missing outer split IDs
             - 'missing_workflow_dirs': List of missing workflow directories
 
     Raises:
-        ValueError: If no outersplit directories or workflow results are found.
+        ValueError: If no outer split directories or workflow results are found.
         FileNotFoundError: If the study directory does not exist.
 
     Example:
@@ -218,7 +218,7 @@ def show_study_details(study_directory: str | UPath, verbose: bool = True) -> di
     config = loader.load_config()
 
     ml_type = config["ml_type"]
-    n_folds_outer = config["n_folds_outer"]
+    n_outer_splits = config["n_outer_splits"]
     workflow_tasks = config["workflow"]
 
     if verbose:
@@ -227,23 +227,23 @@ def show_study_details(study_directory: str | UPath, verbose: bool = True) -> di
 
     # Delegate structure validation
     validation = _validate_study_structure(path_study, config)
-    outersplit = validation["outersplit_dirs"]
-    missing_outersplits = validation["missing_outersplits"]
+    outer_split_dirs = validation["outer_split_dirs"]
+    missing_outer_splits = validation["missing_outer_splits"]
     missing_workflow_dirs = validation["missing_workflow_dirs"]
     expected_task_ids = validation["expected_task_ids"]
     octo_workflow_lst = validation["octo_workflow_tasks"]
 
     if verbose:
-        print(f"Found {len(outersplit)} outersplit directory/directories")
-        expected_outersplit_ids = list(range(n_folds_outer))
-        print(f"Expected outersplit IDs: {expected_outersplit_ids}")
+        print(f"Found {len(outer_split_dirs)} outer split directory/directories")
+        expected_outer_split_ids = list(range(n_outer_splits))
+        print(f"Expected outer split IDs: {expected_outer_split_ids}")
 
-        if missing_outersplits:
-            for split_id in missing_outersplits:
+        if missing_outer_splits:
+            for split_id in missing_outer_splits:
                 print(f"  WARNING: Missing directory 'outersplit{split_id}'")
-            print(f"  {len(missing_outersplits)} outersplit directory/directories missing")
+            print(f"  {len(missing_outer_splits)} outer split directory/directories missing")
         else:
-            print("All expected outersplit directories found")
+            print("All expected outer split directories found")
 
         print(f"Expected workflow task IDs: {expected_task_ids}")
 
@@ -267,12 +267,12 @@ def show_study_details(study_directory: str | UPath, verbose: bool = True) -> di
         "path": path_study,
         "config": config,
         "ml_type": ml_type,
-        "n_folds_outer": n_folds_outer,
+        "n_outer_splits": n_outer_splits,
         "workflow_tasks": workflow_tasks,
-        "outersplit_dirs": outersplit,
+        "outer_split_dirs": outer_split_dirs,
         "expected_task_ids": expected_task_ids,
         "octo_workflow_tasks": octo_workflow_lst,
-        "missing_outersplits": missing_outersplits,
+        "missing_outer_splits": missing_outer_splits,
         "missing_workflow_dirs": missing_workflow_dirs,
     }
 
@@ -286,7 +286,7 @@ def show_target_metric_performance(
 
     Args:
         study_info: Dictionary returned by show_study_details().
-        details: If True, shows detailed information for each outersplit.
+        details: If True, shows detailed information for each outer split.
         report_test: If True, includes test-set performance columns
             (``test_avg``, ``test_ensemble``) in the output.  Default is False
             to prevent accidental data leakage during model selection.
@@ -355,7 +355,7 @@ def show_selected_features(
     Returns:
         Tuple of three DataFrames:
         - feature_table: Number of features per outer split for each task-key combination
-        - frequency_table: Feature frequency across outersplits
+        - frequency_table: Feature frequency across outer splits
         - raw_feature_table: Raw performance dataframe
 
     Example:
@@ -392,7 +392,7 @@ def show_testset_performance(
     predictor: TaskPredictorTest,
     metrics: list[str] | None = None,
 ) -> pd.DataFrame:
-    """Display test performance metrics across all outersplits for a task.
+    """Display test performance metrics across all outer splits for a task.
 
     Args:
         predictor: TaskPredictorTest instance for the task to evaluate.
@@ -400,7 +400,7 @@ def show_testset_performance(
             based on ML type.
 
     Returns:
-        DataFrame with outersplits as rows (plus a 'Mean' row), metrics as columns.
+        DataFrame with outer splits as rows (plus a 'Mean' row), metrics as columns.
 
     Example:
         >>> from octopus.predict import TaskPredictorTest
@@ -418,7 +418,7 @@ def show_testset_performance(
     print("Performance on test dataset (ensemble)")
 
     performance_long = predictor.performance(metrics=metrics)
-    df = performance_long.pivot(index="outersplit", columns="metric", values="score")
+    df = performance_long.pivot(index="outer_split", columns="metric", values="score")
 
     # Reorder columns to match metrics order
     available_cols = [m for m in metrics if m in df.columns]
@@ -483,12 +483,12 @@ def show_aucroc_plots(
 
     1. Merged ROC curve (all predictions pooled)
     2. Averaged ROC curve (mean +/- 1 std dev)
-    3. Individual ROC curves per outersplit (if show_individual=True)
+    3. Individual ROC curves per outer split (if show_individual=True)
 
     Args:
         predictor: TaskPredictorTest instance for a classification task.
         figsize: Figure size as (width, height) in inches.
-        show_individual: If True, also plot individual ROC curves per outersplit.
+        show_individual: If True, also plot individual ROC curves per outer split.
 
     Raises:
         ValueError: If the task is not for classification.
@@ -509,8 +509,8 @@ def show_aucroc_plots(
     roc_data = []
     mean_fpr = np.linspace(0, 1, 100)
 
-    for split_id in predictor.outersplits:
-        split_df = proba_df[proba_df["outersplit"] == split_id]
+    for split_id in predictor.outer_splits:
+        split_df = proba_df[proba_df["outer_split"] == split_id]
         probabilities = np.asarray(split_df[positive_class])
         target = np.asarray(split_df["target"])
 
@@ -604,9 +604,9 @@ def show_aucroc_plots(
         print("=" * 60)
 
         for key, fpr, tpr, auc_score, _ in roc_data:
-            print(f"\nOutersplit {key}: AUC = {auc_score:.3f}")
+            print(f"\nOuter Split {key}: AUC = {auc_score:.3f}")
             _create_roc_figure(
-                fpr, tpr, auc_score, f"ROC Curve - Outersplit {key}", f"Outersplit {key}", width_px, height_px
+                fpr, tpr, auc_score, f"ROC Curve - Outer Split {key}", f"Outer Split {key}", width_px, height_px
             ).show()
 
 
@@ -724,13 +724,13 @@ def show_confusionmatrix(
     threshold: float = 0.5,
     metrics: list[str] | None = None,
 ) -> None:
-    """Display confusion matrices and performance metrics for all outersplits.
+    """Display confusion matrices and performance metrics for all outer splits.
 
     Uses ``predictor.predict_proba(df=True)`` to get per-split probabilities
     and targets, avoiding manual access to models/data/features.
 
     Shows absolute and relative confusion matrices side-by-side (plotly subplots)
-    plus performance metrics for each outersplit and overall mean.
+    plus performance metrics for each outer split and overall mean.
 
     Args:
         predictor: TaskPredictorTest instance for a classification task.
@@ -756,8 +756,8 @@ def show_confusionmatrix(
 
     result_rows: list[dict[str, Any]] = []
 
-    # Compute all scores once (covers all outersplits) instead of calling
-    # predictor.performance() inside the loop for each outersplit.
+    # Compute all scores once (covers all outer splits) instead of calling
+    # predictor.performance() inside the loop for each outer split.
     all_scores = predictor.performance(metrics=metrics, threshold=threshold)
 
     print("=" * 80)
@@ -766,12 +766,12 @@ def show_confusionmatrix(
     print(f"Threshold: {threshold}")
     print(f"Metrics: {metrics}\n")
 
-    for outersplit_id in predictor.outersplits:
+    for outer_split_id in predictor.outer_splits:
         print(f"\n{'=' * 60}")
-        print(f"OUTERSPLIT {outersplit_id}")
+        print(f"OUTER SPLIT {outer_split_id}")
         print("=" * 60)
 
-        split_df = proba_df[proba_df["outersplit"] == outersplit_id]
+        split_df = proba_df[proba_df["outer_split"] == outer_split_id]
         probabilities = np.asarray(split_df[positive_class])
         target = np.asarray(split_df["target"])
 
@@ -779,25 +779,27 @@ def show_confusionmatrix(
 
         class_names = [str(c) for c in predictor.classes_]
 
-        fig = _create_confusion_figure(cm_abs, cm_rel, class_names, f"Confusion Matrices - Outersplit {outersplit_id}")
+        fig = _create_confusion_figure(
+            cm_abs, cm_rel, class_names, f"Confusion Matrices - Outer Split {outer_split_id}"
+        )
 
         print("\nConfusion Matrices:")
         fig.show()
 
-        # Filter pre-computed scores to this outersplit.  Threshold was passed
+        # Filter pre-computed scores to this outer split.  Threshold was passed
         # through to get_performance_from_model() so that prediction-type
         # metrics (ACC, F1) use the same threshold as the confusion matrix.
-        split_scores = all_scores[all_scores["outersplit"] == outersplit_id]
+        split_scores = all_scores[all_scores["outer_split"] == outer_split_id]
 
         print("\nPerformance Metrics:")
         for _, row in split_scores.iterrows():
             print(f"  {row['metric']:<15}: {row['score']:.4f}")
-            result_rows.append({"metric": row["metric"], "performance": row["score"], "outersplit_id": outersplit_id})
+            result_rows.append({"metric": row["metric"], "performance": row["score"], "outer_split_id": outer_split_id})
 
     df_results = pd.DataFrame(result_rows)
 
     print(f"\n{'=' * 80}")
-    print("OVERALL PERFORMANCE (Mean across all outersplits)")
+    print("OVERALL PERFORMANCE (Mean across all outer splits)")
     print("=" * 80)
     performance_mean = df_results.groupby("metric")["performance"].mean()
     for metric_name, value in performance_mean.items():

--- a/octopus/predict/study_io.py
+++ b/octopus/predict/study_io.py
@@ -1,8 +1,8 @@
 """File I/O for reading study directories.
 
-Provides StudyLoader and TaskOutersplitLoader classes for accessing study artifacts
+Provides StudyLoader and TaskOuterSplitLoader classes for accessing study artifacts
 from disk. These handle the actual directory structure where data files are at
-the outersplit level and model artifacts are in task/module/ subdirectories.
+the outer split level and model artifacts are in task/module/ subdirectories.
 
 Also provides frozen data classes (StudyMetadata, SplitArtifacts, TaskArtifacts)
 for type-safe, immutable data bundles at the boundary between I/O and prediction.
@@ -52,7 +52,7 @@ class StudyMetadata:
         positive_class: Positive class label for classification.
         row_id_col: Row ID column name.
         feature_cols: Union of feature columns across outer splits.
-        n_outersplits: Number of outer folds from config.
+        n_outer_splits: Number of outer splits from config.
     """
 
     ml_type: MLType
@@ -62,12 +62,12 @@ class StudyMetadata:
     positive_class: Any
     row_id_col: str | None
     feature_cols: list[str]
-    n_outersplits: int
+    n_outer_splits: int
 
 
 @frozen
 class SplitArtifacts:
-    """All artifacts loaded for one outersplit.
+    """All artifacts loaded for one outer split.
 
     Attributes:
         model: The fitted model object.
@@ -84,28 +84,28 @@ class SplitArtifacts:
 
 @frozen
 class TaskArtifacts:
-    """All artifacts for a task across all outersplits.
+    """All artifacts for a task across all outer splits.
 
     Attributes:
-        splits: Dict mapping outersplit_id to SplitArtifacts.
-        outersplit_ids: Sorted list of outersplit IDs.
+        splits: Dict mapping outer_split_id to SplitArtifacts.
+        outer_split_ids: Sorted list of outer split IDs.
     """
 
     splits: dict[int, SplitArtifacts]
-    outersplit_ids: list[int]
+    outer_split_ids: list[int]
 
 
 # ═══════════════════════════════════════════════════════════════
-# TaskOutersplitLoader — frozen path resolver + artifact loader
+# TaskOuterSplitLoader — frozen path resolver + artifact loader
 # ═══════════════════════════════════════════════════════════════
 
 
 @frozen
-class TaskOutersplitLoader:
-    """Load data for a single outersplit from disk.
+class TaskOuterSplitLoader:
+    """Load data for a single outer split from disk.
 
     Matches actual disk structure:
-    - split_row_ids.json at outersplit level (row IDs into data_prepared.parquet)
+    - split_row_ids.json at outer split level (row IDs into data_prepared.parquet)
     - feature_cols.json, feature_groups.json inside task/config/
     - model.joblib, predictor.json inside task/results/{result_type}/model/
     - selected_features.json, scores.parquet, predictions.parquet,
@@ -113,25 +113,25 @@ class TaskOutersplitLoader:
 
     Attributes:
         study_path: Path to the study directory.
-        outersplit_id: Outer split index.
+        outer_split_id: Outer split index.
         task_id: Workflow task index.
         result_type: Result type for filtering results (default: 'best').
     """
 
     study_path: UPath = field(converter=_to_upath)
-    outersplit_id: int
+    outer_split_id: int
     task_id: int
     result_type: str = "best"
 
     @property
-    def fold_dir(self) -> UPath:
-        """Outersplit directory path."""
-        return self.study_path / f"outersplit{self.outersplit_id}"
+    def outer_split_dir(self) -> UPath:
+        """Outer split directory path."""
+        return self.study_path / f"outersplit{self.outer_split_id}"
 
     @property
     def task_dir(self) -> UPath:
         """Task directory path."""
-        return self.fold_dir / f"task{self.task_id}"
+        return self.outer_split_dir / f"task{self.task_id}"
 
     @property
     def result_dir(self) -> UPath:
@@ -151,20 +151,20 @@ class TaskOutersplitLoader:
     # ── Validation ──────────────────────────────────────────────
 
     def validate_directories(self) -> None:
-        """Check that fold_dir and task_dir exist on disk.
+        """Check that outer_split_dir and task_dir exist on disk.
 
         Raises:
             FileNotFoundError: If the outer split or task directory is missing.
         """
-        if not self.fold_dir.exists():
-            raise FileNotFoundError(f"Outer split directory not found: {self.fold_dir}")
+        if not self.outer_split_dir.exists():
+            raise FileNotFoundError(f"Outer split directory not found: {self.outer_split_dir}")
         if not self.task_dir.exists():
             raise FileNotFoundError(f"Task directory not found: {self.task_dir}")
 
     # ── Artifact loading ────────────────────────────────────────
 
     def load_all_artifacts(self) -> SplitArtifacts:
-        """Load all artifacts for this outersplit in one call.
+        """Load all artifacts for this outer split in one call.
 
         Validates directories, loads required artifacts (model,
         selected_features), and optional artifacts (feature_cols,
@@ -205,7 +205,7 @@ class TaskOutersplitLoader:
         if partition not in ("traindev", "test"):
             raise ValueError(f"partition must be 'traindev' or 'test', got {partition!r}")
 
-        split_ids_path = self.fold_dir / "split_row_ids.json"
+        split_ids_path = self.outer_split_dir / "split_row_ids.json"
         if not split_ids_path.exists():
             raise FileNotFoundError(f"Split row IDs not found: {split_ids_path}")
 
@@ -383,14 +383,14 @@ class StudyLoader:
             positive_class=config.get("positive_class"),
             row_id_col=row_id_col,
             feature_cols=config.get("prepared", {}).get("feature_cols", []),
-            n_outersplits=config.get("n_folds_outer", 0),
+            n_outer_splits=config.get("n_outer_splits", 0),
         )
 
     def load_task_artifacts(
         self,
         task_id: int,
         result_type: str,
-        n_outersplits: int,
+        n_outer_splits: int,
     ) -> TaskArtifacts:
         """Load all models and features for a task across all outer splits.
 
@@ -400,7 +400,7 @@ class StudyLoader:
         Args:
             task_id: Concrete task index.
             result_type: Result type for filtering.
-            n_outersplits: Number of outer folds from config.
+            n_outer_splits: Number of outer splits from config.
 
         Returns:
             TaskArtifacts with per-split models and features.
@@ -410,43 +410,43 @@ class StudyLoader:
             ValueError: If no models are found.
         """
         splits: dict[int, SplitArtifacts] = {}
-        outersplit_ids: list[int] = []
+        outer_split_ids: list[int] = []
 
-        for split_id in range(n_outersplits):
-            loader = TaskOutersplitLoader(self.study_path, split_id, task_id, result_type)
+        for split_id in range(n_outer_splits):
+            loader = TaskOuterSplitLoader(self.study_path, split_id, task_id, result_type)
             splits[split_id] = loader.load_all_artifacts()
-            outersplit_ids.append(split_id)
+            outer_split_ids.append(split_id)
 
-        if not outersplit_ids:
+        if not outer_split_ids:
             raise ValueError(f"No models found for task {task_id}. Check that the study has been run.")
 
-        return TaskArtifacts(splits=splits, outersplit_ids=outersplit_ids)
+        return TaskArtifacts(splits=splits, outer_split_ids=outer_split_ids)
 
-    # ── Outersplit loader factory ───────────────────────────────
+    # ── Outer split loader factory ───────────────────────────────
 
-    def get_outersplit_loader(
+    def get_outer_split_loader(
         self,
-        outersplit_id: int,
+        outer_split_id: int,
         task_id: int,
         result_type: str = "best",
-    ) -> TaskOutersplitLoader:
-        """Get a TaskOutersplitLoader for a specific outersplit and task.
+    ) -> TaskOuterSplitLoader:
+        """Get a TaskOuterSplitLoader for a specific outer split and task.
 
         Args:
-            outersplit_id: Outer split index.
+            outer_split_id: Outer split index.
             task_id: Task index.
             result_type: Result type for filtering.
 
         Returns:
-            TaskOutersplitLoader instance.
+            TaskOuterSplitLoader instance.
         """
-        return TaskOutersplitLoader(self.study_path, outersplit_id, task_id, result_type)
+        return TaskOuterSplitLoader(self.study_path, outer_split_id, task_id, result_type)
 
-    def get_available_outersplits(self) -> list[int]:
-        """Get list of available outersplit IDs.
+    def get_available_outer_splits(self) -> list[int]:
+        """Get list of available outer split IDs.
 
         Returns:
-            Sorted list of outersplit IDs found on disk.
+            Sorted list of outer split IDs found on disk.
         """
         dirs = sorted(
             [d for d in self.study_path.glob("outersplit*") if d.is_dir()],
@@ -454,20 +454,20 @@ class StudyLoader:
         )
         return [int(d.name.replace("outersplit", "")) for d in dirs]
 
-    def get_task_directories(self, outersplit_id: int) -> list[tuple[int, UPath]]:
-        """Get task directories for a given outersplit.
+    def get_task_directories(self, outer_split_id: int) -> list[tuple[int, UPath]]:
+        """Get task directories for a given outer split.
 
         Args:
-            outersplit_id: Outer split index.
+            outer_split_id: Outer split index.
 
         Returns:
             Sorted list of (task_id, task_path) tuples.
         """
-        fold_dir = self.study_path / f"outersplit{outersplit_id}"
-        if not fold_dir.exists():
+        outer_split_dir = self.study_path / f"outersplit{outer_split_id}"
+        if not outer_split_dir.exists():
             return []
         task_dirs = []
-        for task_dir in fold_dir.glob("task*"):
+        for task_dir in outer_split_dir.glob("task*"):
             if task_dir.is_dir():
                 match = re.search(r"\d+$", task_dir.name)
                 if match:
@@ -479,7 +479,7 @@ class StudyLoader:
     def build_performance_summary(self) -> pd.DataFrame:
         """Aggregate scores across all outer splits and tasks.
 
-        Iterates over all outersplit directories and task directories found on
+        Iterates over all outer split directories and task directories found on
         disk, loading scores and selected features for each combination.
 
         Returns:
@@ -490,7 +490,7 @@ class StudyLoader:
         _ = self.load_config()  # Validate config exists
         rows_list: list[dict[str, Any]] = []
 
-        available_splits = self.get_available_outersplits()
+        available_splits = self.get_available_outer_splits()
 
         for split_num in available_splits:
             task_dirs = self.get_task_directories(split_num)
@@ -499,7 +499,7 @@ class StudyLoader:
                 workflow_name = str(path_workflow.name)
 
                 try:
-                    loader = self.get_outersplit_loader(outersplit_id=split_num, task_id=workflow_num)
+                    loader = self.get_outer_split_loader(outer_split_id=split_num, task_id=workflow_num)
                     try:
                         selected_features = loader.load_selected_features()
                     except FileNotFoundError:
@@ -507,9 +507,9 @@ class StudyLoader:
 
                     perf_df = loader.load_scores()
 
-                    # Filter out per_fold rows — only keep avg and ensemble aggregations
+                    # Filter out per_split rows — only keep avg and ensemble aggregations
                     if not perf_df.empty and "aggregation" in perf_df.columns:
-                        perf_df = perf_df[perf_df["aggregation"] != "per_fold"]
+                        perf_df = perf_df[perf_df["aggregation"] != "per_split"]
 
                     if not perf_df.empty and "result_type" in perf_df.columns:
                         group_cols = ["result_type"]
@@ -594,7 +594,7 @@ class StudyLoader:
             Tuple of two DataFrames:
             - feature_table: Number of features per outer split for each
               task-key combination (with Mean row).
-            - frequency_table: Feature frequency across outersplits.
+            - frequency_table: Feature frequency across outer splits.
         """
         raw = self.build_performance_summary()
 

--- a/octopus/predict/task_predictor.py
+++ b/octopus/predict/task_predictor.py
@@ -52,7 +52,7 @@ class TaskPredictor:
     _metadata: StudyMetadata = field(init=False)
 
     # Flattened from artifacts for fast access
-    _outersplits: list[int] = field(init=False, factory=list)
+    _outer_splits: list[int] = field(init=False, factory=list)
     _models: dict[int, Any] = field(init=False, factory=dict, repr=False)
     _selected_features: dict[int, list[str]] = field(init=False, factory=dict, repr=False)
     _feature_cols_per_split: dict[int, list[str]] = field(init=False, factory=dict, repr=False)
@@ -74,20 +74,20 @@ class TaskPredictor:
         artifacts = loader.load_task_artifacts(
             self._task_id,
             self._result_type,
-            self._metadata.n_outersplits,
+            self._metadata.n_outer_splits,
         )
 
         # Flatten artifacts for fast per-split access
-        self._outersplits = list(artifacts.outersplit_ids)
+        self._outer_splits = list(artifacts.outer_split_ids)
         for split_id, sa in artifacts.splits.items():
             self._models[split_id] = sa.model
             self._selected_features[split_id] = sa.selected_features
             self._feature_cols_per_split[split_id] = sa.feature_cols
             self._feature_groups_per_split[split_id] = sa.feature_groups
 
-        # Compute union of feature_cols across all outersplits
+        # Compute union of feature_cols across all outer splits
         all_feature_cols: set[str] = set()
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             split_fcols = self._feature_cols_per_split.get(split_id, [])
             if split_fcols:
                 all_feature_cols.update(split_fcols)
@@ -135,14 +135,14 @@ class TaskPredictor:
         return self._feature_cols
 
     @property
-    def n_outersplits(self) -> int:
-        """Number of loaded outersplits."""
-        return len(self._outersplits)
+    def n_outer_splits(self) -> int:
+        """Number of loaded outer splits."""
+        return len(self._outer_splits)
 
     @property
-    def outersplits(self) -> list[int]:
-        """List of loaded outersplit IDs."""
-        return list(self._outersplits)
+    def outer_splits(self) -> list[int]:
+        """List of loaded outer split IDs."""
+        return list(self._outer_splits)
 
     @property
     def config(self) -> dict[str, Any]:
@@ -162,7 +162,7 @@ class TaskPredictor:
         Raises:
             AttributeError: If the model does not have a classes_ attribute.
         """
-        model = self._models[self._outersplits[0]]
+        model = self._models[self._outer_splits[0]]
         if not hasattr(model, "classes_"):
             raise AttributeError(f"Not a classification model: {type(model).__name__}")
         result: np.ndarray = model.classes_
@@ -170,37 +170,37 @@ class TaskPredictor:
 
     @property
     def feature_cols_per_split(self) -> dict[int, list[str]]:
-        """Input feature columns per outersplit (loaded from disk)."""
+        """Input feature columns per outer split (loaded from disk)."""
         return self._feature_cols_per_split
 
     @property
     def feature_groups_per_split(self) -> dict[int, dict[str, list[str]]]:
-        """Feature groups per outersplit (loaded from disk)."""
+        """Feature groups per outer split (loaded from disk)."""
         return self._feature_groups_per_split
 
-    # ── Per-outersplit access ───────────────────────────────────
+    # ── Per-outer-split access ──────────────────────────────────
 
-    def get_model(self, outersplit_id: int) -> Any:
-        """Get the fitted model for an outersplit.
+    def get_model(self, outer_split_id: int) -> Any:
+        """Get the fitted model for an outer split.
 
         Args:
-            outersplit_id: Outer split index.
+            outer_split_id: Outer split index.
 
         Returns:
             The fitted model object.
         """
-        return self._models[outersplit_id]
+        return self._models[outer_split_id]
 
-    def get_selected_features(self, outersplit_id: int) -> list[str]:
-        """Get selected features for an outersplit.
+    def get_selected_features(self, outer_split_id: int) -> list[str]:
+        """Get selected features for an outer split.
 
         Args:
-            outersplit_id: Outer split index.
+            outer_split_id: Outer split index.
 
         Returns:
             List of selected feature names.
         """
-        return self._selected_features[outersplit_id]
+        return self._selected_features[outer_split_id]
 
     # ── Prediction ──────────────────────────────────────────────
 
@@ -209,9 +209,9 @@ class TaskPredictor:
 
         Args:
             data: DataFrame containing feature columns.
-            df: If True, return a DataFrame with per-outersplit predictions
+            df: If True, return a DataFrame with per-outer-split predictions
                 and ensemble (averaged) predictions, with columns
-                ``outersplit``, ``row_id``, ``prediction``.
+                ``outer_split``, ``row_id``, ``prediction``.
                 If False (default), return ensemble-averaged ndarray.
 
         Returns:
@@ -221,7 +221,7 @@ class TaskPredictor:
         per_split_preds: list[np.ndarray] = []
         all_rows: list[pd.DataFrame] = []
 
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             features = self._selected_features[split_id]
             preds = self._models[split_id].predict(data[features])
             per_split_preds.append(preds)
@@ -229,7 +229,7 @@ class TaskPredictor:
             if df:
                 split_df = pd.DataFrame(
                     {
-                        "outersplit": split_id,
+                        "outer_split": split_id,
                         "row_id": data.index,
                         "prediction": preds,
                     }
@@ -241,7 +241,7 @@ class TaskPredictor:
         if df:
             ensemble_df = pd.DataFrame(
                 {
-                    "outersplit": "ensemble",
+                    "outer_split": "ensemble",
                     "row_id": data.index,
                     "prediction": ensemble,
                 }
@@ -255,9 +255,9 @@ class TaskPredictor:
 
         Args:
             data: DataFrame containing feature columns.
-            df: If True, return a DataFrame with per-outersplit probabilities
+            df: If True, return a DataFrame with per-outer-split probabilities
                 and ensemble (averaged) probabilities, with columns
-                ``outersplit``, ``row_id``, plus one column per class label.
+                ``outer_split``, ``row_id``, plus one column per class label.
                 If False (default), return ensemble-averaged ndarray.
 
         Returns:
@@ -276,7 +276,7 @@ class TaskPredictor:
         all_rows: list[pd.DataFrame] = []
         class_labels = self.classes_
 
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             features = self._selected_features[split_id]
             probas = self._models[split_id].predict_proba(data[features])
             if isinstance(probas, pd.DataFrame):
@@ -285,7 +285,7 @@ class TaskPredictor:
 
             if df:
                 split_df = pd.DataFrame(probas, columns=class_labels)
-                split_df.insert(0, "outersplit", split_id)
+                split_df.insert(0, "outer_split", split_id)
                 split_df.insert(1, "row_id", data.index.values)
                 all_rows.append(split_df)
 
@@ -293,7 +293,7 @@ class TaskPredictor:
 
         if df:
             ensemble_df = pd.DataFrame(ensemble, columns=class_labels)
-            ensemble_df.insert(0, "outersplit", "ensemble")
+            ensemble_df.insert(0, "outer_split", "ensemble")
             ensemble_df.insert(1, "row_id", data.index.values)
             all_rows.append(ensemble_df)
             return pd.concat(all_rows, ignore_index=True)
@@ -319,13 +319,13 @@ class TaskPredictor:
             threshold: Classification threshold for threshold-dependent metrics.
 
         Returns:
-            DataFrame with columns: outersplit, metric, score.
+            DataFrame with columns: outer_split, metric, score.
         """
         if metrics is None:
             metrics = [self.target_metric]
 
         rows = []
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             model = self._models[split_id]
             features = self._selected_features[split_id]
 
@@ -340,7 +340,7 @@ class TaskPredictor:
                     threshold=threshold,
                     positive_class=self.positive_class,
                 )
-                rows.append({"outersplit": split_id, "metric": metric_name, "score": score})
+                rows.append({"outer_split": split_id, "metric": metric_name, "score": score})
 
         return pd.DataFrame(rows)
 
@@ -363,14 +363,14 @@ class TaskPredictor:
             data: User-provided data (used as fallback for all splits).
 
         Returns:
-            Dict mapping outersplit_id to pool DataFrame.
+            Dict mapping outer_split_id to pool DataFrame.
         """
         loader = StudyLoader(self._study_path)
         pool: dict[int, pd.DataFrame] = {}
 
-        for split_id in self._outersplits:
-            split_loader = loader.get_outersplit_loader(
-                outersplit_id=split_id,
+        for split_id in self._outer_splits:
+            split_loader = loader.get_outer_split_loader(
+                outer_split_id=split_id,
                 task_id=self._task_id,
                 result_type=self._result_type,
             )
@@ -401,8 +401,8 @@ class TaskPredictor:
         formatting.
 
         Args:
-            test_data: Dict mapping outersplit_id to test DataFrame.
-            train_data: Dict mapping outersplit_id to train DataFrame
+            test_data: Dict mapping outer_split_id to test DataFrame.
+            train_data: Dict mapping outer_split_id to train DataFrame
                 (used as the sampling pool for permutation FI).
             fi_type: Feature importance type (must already be a ``FIType``).
             n_repeats: Number of permutation repeats.
@@ -511,7 +511,7 @@ class TaskPredictor:
         # Build per-split data dicts
         # All splits share the same DataFrame reference.  Safe because
         # compute_permutation_single / compute_shap_single copy data before mutating.
-        test_data = dict.fromkeys(self._outersplits, data)
+        test_data = dict.fromkeys(self._outer_splits, data)
         train_data = self._build_pool_data(data)
 
         return self._dispatch_fi(
@@ -525,7 +525,7 @@ class TaskPredictor:
         )
 
     def _compute_feature_groups(self) -> dict[str, list[str]]:
-        """Compute merged feature groups from all outersplits.
+        """Compute merged feature groups from all outer splits.
 
         Merges the per-split feature groups loaded from disk into a single
         dict. Groups with the same name across splits are merged by taking
@@ -535,7 +535,7 @@ class TaskPredictor:
             Dict mapping group names to lists of feature names.
         """
         all_groups: dict[str, list[str]] = {}
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             split_groups = self._feature_groups_per_split.get(split_id, {})
             for group_name, group_features in split_groups.items():
                 if group_name in all_groups:
@@ -571,7 +571,7 @@ class TaskPredictor:
             "positive_class": self.positive_class,
             "row_id_col": self.row_id_col,
             "feature_cols": self._feature_cols,
-            "outersplits": self._outersplits,
+            "outer_splits": self._outer_splits,
             "result_type": self._result_type,
             "feature_cols_per_split": {str(k): v for k, v in self._feature_cols_per_split.items()},
             "feature_groups_per_split": {str(k): v for k, v in self._feature_groups_per_split.items()},
@@ -582,13 +582,13 @@ class TaskPredictor:
         # Save models
         models_dir = save_dir / "models"
         models_dir.mkdir(parents=True, exist_ok=True)
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             joblib_save(self._models[split_id], models_dir / f"model_{split_id:03d}.joblib")
 
         # Save selected features
         features_dir = save_dir / "selected_features"
         features_dir.mkdir(parents=True, exist_ok=True)
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             with (features_dir / f"split_{split_id:03d}.json").open("w") as f:
                 json.dump(self._selected_features[split_id], f)
 
@@ -646,10 +646,10 @@ class TaskPredictor:
             positive_class=metadata_dict.get("positive_class"),
             row_id_col=metadata_dict.get("row_id_col"),
             feature_cols=metadata_dict.get("feature_cols", []),
-            n_outersplits=len(metadata_dict.get("outersplits", [])),
+            n_outer_splits=len(metadata_dict.get("outer_splits", metadata_dict.get("outersplits", []))),
         )
         instance._feature_cols = metadata_dict.get("feature_cols", [])
-        instance._outersplits = metadata_dict.get("outersplits", [])
+        instance._outer_splits = metadata_dict.get("outer_splits", metadata_dict.get("outersplits", []))
         # Restore per-split data
         instance._feature_cols_per_split = {
             int(k): v for k, v in metadata_dict.get("feature_cols_per_split", {}).items()
@@ -661,13 +661,13 @@ class TaskPredictor:
         # Load models
         instance._models = {}
         models_dir = load_dir / "models"
-        for split_id in instance._outersplits:
+        for split_id in instance._outer_splits:
             instance._models[split_id] = joblib_load(models_dir / f"model_{split_id:03d}.joblib")
 
         # Load selected features
         instance._selected_features = {}
         features_dir = load_dir / "selected_features"
-        for split_id in instance._outersplits:
+        for split_id in instance._outer_splits:
             with (features_dir / f"split_{split_id:03d}.json").open() as f:
                 instance._selected_features[split_id] = json.load(f)
 

--- a/octopus/predict/task_predictor_test.py
+++ b/octopus/predict/task_predictor_test.py
@@ -57,9 +57,9 @@ class TaskPredictorTest(TaskPredictor):
 
         loader = StudyLoader(self._study_path)
 
-        for split_id in self._outersplits:
-            split_loader = loader.get_outersplit_loader(
-                outersplit_id=split_id,
+        for split_id in self._outer_splits:
+            split_loader = loader.get_outer_split_loader(
+                outer_split_id=split_id,
                 task_id=self._task_id,
                 result_type=self._result_type,
             )
@@ -102,7 +102,7 @@ class TaskPredictorTest(TaskPredictor):
         No ensemble averaging — results are collected per split.
 
         Args:
-            df: If True, return a DataFrame with outersplit, row_id, prediction,
+            df: If True, return a DataFrame with outer_split, row_id, prediction,
                 and target columns.  For T2E tasks the target columns are
                 ``target_duration`` and ``target_event`` instead of ``target``.
                 If False (default), return concatenated ndarray.
@@ -115,7 +115,7 @@ class TaskPredictorTest(TaskPredictor):
         all_preds = []
         all_rows = []
 
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             features = self._selected_features[split_id]
             test = self._test_data[split_id]
             preds = self._models[split_id].predict(test[features])
@@ -125,7 +125,7 @@ class TaskPredictorTest(TaskPredictor):
                 row_ids = test[row_id_col] if row_id_col and row_id_col in test.columns else pd.RangeIndex(len(test))
                 split_df = pd.DataFrame(
                     {
-                        "outersplit": split_id,
+                        "outer_split": split_id,
                         "row_id": row_ids.values if hasattr(row_ids, "values") else row_ids,
                         "prediction": preds,
                         **self._get_target_columns(test),
@@ -143,7 +143,7 @@ class TaskPredictorTest(TaskPredictor):
         Each model predicts only on its own test data.  No averaging.
 
         Args:
-            df: If True, return a DataFrame with outersplit, row_id, probability
+            df: If True, return a DataFrame with outer_split, row_id, probability
                 columns per class, and target column(s).  If False (default),
                 return concatenated ndarray.
 
@@ -164,7 +164,7 @@ class TaskPredictorTest(TaskPredictor):
         all_probas = []
         all_rows = []
 
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             features = self._selected_features[split_id]
             test = self._test_data[split_id]
             probas = self._models[split_id].predict_proba(test[features])
@@ -175,7 +175,7 @@ class TaskPredictorTest(TaskPredictor):
             if df:
                 row_ids = test[row_id_col] if row_id_col and row_id_col in test.columns else pd.RangeIndex(len(test))
                 split_df = pd.DataFrame(probas, columns=class_labels)
-                split_df.insert(0, "outersplit", split_id)
+                split_df.insert(0, "outer_split", split_id)
                 row_vals: Any = row_ids.values if hasattr(row_ids, "values") else row_ids
                 split_df.insert(1, "row_id", row_vals)
                 for col_name, col_values in self._get_target_columns(test).items():
@@ -204,13 +204,13 @@ class TaskPredictorTest(TaskPredictor):
             threshold: Classification threshold for threshold-dependent metrics.
 
         Returns:
-            DataFrame with columns: outersplit, metric, score.
+            DataFrame with columns: outer_split, metric, score.
         """
         if metrics is None:
             metrics = [self.target_metric]
 
         rows = []
-        for split_id in self._outersplits:
+        for split_id in self._outer_splits:
             model = self._models[split_id]
             features = self._selected_features[split_id]
             test = self._test_data[split_id]
@@ -225,7 +225,7 @@ class TaskPredictorTest(TaskPredictor):
                     threshold=threshold,
                     positive_class=self.positive_class,
                 )
-                rows.append({"outersplit": split_id, "metric": metric_name, "score": score})
+                rows.append({"outer_split": split_id, "metric": metric_name, "score": score})
 
         return pd.DataFrame(rows)
 

--- a/octopus/study/core.py
+++ b/octopus/study/core.py
@@ -41,7 +41,7 @@ class OctoStudy(ABC):
     sample_id_col: str = field(validator=validators.instance_of(str))
     """Identifier for sample instances."""
 
-    name: str = field(default="Octopus", validator=[validators.instance_of(str)])
+    study_name: str = field(default="Octopus", validator=[validators.instance_of(str)])
     """The name of the study. Defaults to 'Octopus'."""
 
     row_id_col: str | None = field(
@@ -56,24 +56,19 @@ class OctoStudy(ABC):
     )
     """Column used for stratification during data splitting."""
 
-    n_folds_outer: int = field(default=5 if not _RUNNING_IN_TESTSUITE else 2, validator=[validators.instance_of(int)])
-    """The number of outer folds for cross-validation. Defaults to 5."""
+    n_outer_splits: int = field(default=5 if not _RUNNING_IN_TESTSUITE else 2, validator=[validators.instance_of(int)])
+    """Number of outer cross-validation splits. Defaults to 5."""
 
-    datasplit_seed_outer: int = field(default=0, validator=[validators.instance_of(int)])
-    """The seed used for data splitting in outer cross-validation. Defaults to 0."""
+    outer_split_seed: int = field(default=0, validator=[validators.instance_of(int)])
+    """Seed for outer cross-validation splitting. Defaults to 0."""
 
-    ignore_data_health_warning: bool = field(default=Factory(lambda: False), validator=[validators.instance_of(bool)])
-    """Ignore data health checks warning and run machine learning workflow."""
-
-    num_cpus: int = field(default=0, validator=validators.instance_of(int))
+    n_cpus: int = field(default=0, validator=validators.instance_of(int))
     """Number of CPUs to use for parallel processing. Default value 0 uses all available CPUs.
-       Negative values indicate abs(num_cpus) to leave free, e.g. -1 means use all but one CPU.
+       Negative values indicate abs(n_cpus) to leave free, e.g. -1 means use all but one CPU.
        Set to 1 to disable all parallel processing and run sequentially."""
 
-    run_single_outersplit_num: int | None = field(
-        default=None, validator=validators.optional(validators.instance_of(int))
-    )
-    """Select a single outersplit to execute. Defaults to None to run all outersplits"""
+    single_outer_split: int | None = field(default=None, validator=validators.optional(validators.instance_of(int)))
+    """Select a single outer split to execute. Defaults to None to run all outer splits."""
 
     workflow: Sequence[Task] = field(
         default=Factory(lambda: [Octo(task_id=0)]),
@@ -81,8 +76,8 @@ class OctoStudy(ABC):
     )
     """A list of tasks that defines the processing workflow. Each item in the list is an instance of `Task`."""
 
-    path: UPath = field(default=UPath("./studies/"), converter=lambda x: UPath(x))
-    """The path where study outputs are saved. Defaults to "./studies/"."""
+    studies_directory: UPath = field(default=UPath("./studies/"), converter=lambda x: UPath(x))
+    """Parent directory under which timestamped study folders are created. Defaults to \"./studies/\"."""
 
     ml_type: MLType = field(init=False)
     """The type of machine learning model. Set automatically by subclass."""
@@ -108,8 +103,8 @@ class OctoStudy(ABC):
         if self._fit_timestamp is None:
             raise RuntimeError("output_path is not available until fit() has been called.")
         fit_dt = datetime.datetime.fromisoformat(self._fit_timestamp)
-        folder_name = f"{self.name}-{fit_dt.strftime('%Y%m%d_%H%M%S')}"
-        return self.path / folder_name
+        folder_name = f"{self.study_name}-{fit_dt.strftime('%Y%m%d_%H%M%S')}"
+        return self.studies_directory / folder_name
 
     @property
     def log_dir(self) -> UPath:
@@ -245,24 +240,24 @@ class OctoStudy(ABC):
         relevant_cols = list(dict.fromkeys(relevant_cols))
         data_clean = prepared.data[relevant_cols]
 
-        outersplits = DataSplit(
+        outer_splits = DataSplit(
             dataset=data_clean,
-            seeds=[self.datasplit_seed_outer],
-            num_folds=self.n_folds_outer,
+            seeds=[self.outer_split_seed],
+            n_splits=self.n_outer_splits,
             stratification_col=self.stratification_col,
         ).get_outer_splits()
 
-        if self.run_single_outersplit_num is not None:
-            splits_to_validate = {self.run_single_outersplit_num: outersplits[self.run_single_outersplit_num]}
+        if self.single_outer_split is not None:
+            splits_to_validate = {self.single_outer_split: outer_splits[self.single_outer_split]}
         else:
-            splits_to_validate = outersplits
+            splits_to_validate = outer_splits
 
         if ml_type in (MLType.BINARY, MLType.MULTICLASS) and hasattr(self, "target_col"):
             validate_class_coverage(splits_to_validate, self.target_col)
         elif ml_type == MLType.TIMETOEVENT and hasattr(self, "event_col"):
             validate_class_coverage(splits_to_validate, self.event_col)
 
-        return outersplits
+        return outer_splits
 
     def _run_health_check(self, prepared: PreparedData, config: HealthCheckConfig | None) -> None:
         """Run data health check, save results, and check for issues."""
@@ -294,10 +289,8 @@ class OctoStudy(ABC):
         if has_critical:
             raise ValueError(f"Critical data issues detected. Please check: {report_path}")
 
-        if has_warning and not self.ignore_data_health_warning:
-            raise ValueError(
-                f"Data issues detected. Please check: {report_path}\nTo proceed despite warnings, set `ignore_data_health_warning=True`."
-            )
+        if has_warning:
+            logger.warning("Data quality warnings detected. Please check: %s", report_path)
 
     def _flush_logger(self):
         """Flush and close the file log handler.
@@ -352,16 +345,16 @@ class OctoStudy(ABC):
         self._initialize_study_outputs(data, prepared, ml_type, positive_class)
         self._run_health_check(prepared, health_check_config)
 
-        outersplit_data = self._create_datasplits(prepared, ml_type)
+        outer_split_data = self._create_datasplits(prepared, ml_type)
         study_context = self._create_study_context(prepared, ml_type, positive_class)
         manager = OctoManager(
-            outersplit_data=outersplit_data,
+            outer_split_data=outer_split_data,
             study_context=study_context,
             workflow=self.workflow,
-            num_cpus=self.num_cpus,
-            run_single_outersplit_num=self.run_single_outersplit_num,
+            n_cpus=self.n_cpus,
+            single_outer_split=self.single_outer_split,
         )
-        manager.run_outersplits()
+        manager.run_outer_splits()
         logger.info("Study completed. Results saved to: %s", self.output_path)
         self._flush_logger()
 

--- a/octopus/study/healthChecker.py
+++ b/octopus/study/healthChecker.py
@@ -496,8 +496,7 @@ class OctoDataHealthChecker:
                 severity="Warning",
                 description=("There are duplicated rows when considering all feature columns and the sample ID."),
                 action=(
-                    "Investigate these duplicates. They may be legitimate re-measurements or indicate data integrity problems. "
-                    "To proceed despite this warning, set `ignore_data_health_warning=True`."
+                    "Investigate these duplicates. They may be legitimate re-measurements or indicate data integrity problems."
                 ),
             )
 
@@ -625,13 +624,13 @@ class OctoDataHealthChecker:
         duplicated_rows = self.data[duplicated_mask]
 
         if not duplicated_rows.empty:
-            num_duplicates = len(duplicated_rows)
+            n_duplicates = len(duplicated_rows)
             self.add_issue(
                 category="rows",
                 issue_type="duplicated_rows",
                 affected_items=[str(idx) for idx in duplicated_rows.index],
                 severity="Warning",
-                description=f"Found {num_duplicates} duplicated row(s) in the dataset.",
+                description=f"Found {n_duplicates} duplicated row(s) in the dataset.",
                 action=(
                     "Investigate these duplicates and consider removing or consolidating them based on your data requirements."
                 ),

--- a/octopus/study/prepared_data.py
+++ b/octopus/study/prepared_data.py
@@ -18,7 +18,7 @@ class PreparedData:
     """Row ID column used (auto-generated if not provided by user)."""
 
     @property
-    def num_features(self) -> list[str]:
+    def numerical_features(self) -> list[str]:
         """Get numerical feature columns from effective features."""
         return [
             col

--- a/octopus/study/validation.py
+++ b/octopus/study/validation.py
@@ -5,7 +5,8 @@ from typing import TYPE_CHECKING
 
 from attrs import Attribute
 
-from octopus.modules import Task
+from octopus.modules import Mrmr, Roc, Task
+from octopus.types import RelevanceMethod
 
 if TYPE_CHECKING:
     from octopus.study.core import OctoStudy
@@ -119,4 +120,23 @@ def validate_workflow(_instance: "OctoStudy", attribute: Attribute, value: Seque
                     f"'depends_on={depends_on}', which refers to an item"
                     " that comes after it in the workflow. 'depends_on' must"
                     " refer to a preceding 'task_id'."
+                )
+
+    # Condition 7: Mrmr with relevance_method=PERMUTATION must depend on a module
+    # that produces feature importances (not Roc or Mrmr)
+    _MODULES_WITHOUT_FI = (Roc, Mrmr)
+    for item in value:
+        if isinstance(item, Mrmr) and item.relevance_method == RelevanceMethod.PERMUTATION:
+            if item.depends_on is None:
+                raise ValueError(
+                    f"Mrmr (task_id={item.task_id}) with relevance_method='permutation' requires an upstream task "
+                    "that produces feature importances. Set depends_on to an Octo, Boruta, or AutoGluon task."
+                )
+            upstream_idx = task_id_to_index[item.depends_on]
+            upstream_task = value[upstream_idx]
+            if isinstance(upstream_task, _MODULES_WITHOUT_FI):
+                raise ValueError(
+                    f"Mrmr (task_id={item.task_id}) with relevance_method='permutation' cannot depend on "
+                    f"{type(upstream_task).__name__} (task_id={upstream_task.task_id}) because it does not produce "
+                    "feature importances. Use Octo, Boruta, or AutoGluon as the upstream task."
                 )

--- a/octopus/types.py
+++ b/octopus/types.py
@@ -101,9 +101,9 @@ class FIResultLabel(StrEnum):
 class FIComputeMethod(StrEnum):
     """Computation methods for feature importance calculation.
 
-    Used in model configuration (``ModelConfig.feature_method``), module
-    configuration (``Octo.fi_methods_bestbag``,
-    ``Mrmr.feature_importance_method``), and internal dispatch in bag
+    Used in model configuration (``ModelConfig.fi_method``), module
+    configuration (``Octo.fi_methods``,
+    ``Mrmr.fi_method``), and internal dispatch in bag
     and training code.
     """
 
@@ -164,48 +164,30 @@ class CorrelationType(StrEnum):
     RDC = "rdc"
 
 
-class MRMRRelevance(StrEnum):
-    """Method used to compute feature relevance to the target in MRMR.
+class RelevanceMethod(StrEnum):
+    """Method used to compute feature relevance to the target.
 
-    Used in ``Mrmr.relevance_type``:
-    - ``PERMUTATION``: re-uses permutation importances from a prior workflow module
-    - ``F_STATISTICS``: computes F-statistics (f_classif / f_regression) from scratch
+    Used in:
+    - ``Roc.relevance_method``: scoring features within correlated groups
+    - ``Mrmr.relevance_method``: computing feature-target relevance for MRMR ranking
+
+    Each module restricts the valid subset via its own attrs validator.
     """
 
-    PERMUTATION = "permutation"
-    F_STATISTICS = "f-statistics"
-
-
-class AutoGluonFitStrategy(StrEnum):
-    """Controls whether AutoGluon trains models sequentially or in parallel.
-
-    Used in ``AutoGluon.fit_strategy``, passed directly to ``TabularPredictor.fit()``.
-    """
-
-    SEQUENTIAL = "sequential"
-    PARALLEL = "parallel"
-
-
-class ROCFilterMethod(StrEnum):
-    """Scoring method used to rank features within a correlated group in the ROC module.
-
-    The highest-scoring feature in each group is kept; the rest are removed.
-    Used in ``Roc.filter_type``.
-    """
-
-    MUTUAL_INFO = "mutual_info"
     F_STATISTICS = "f_statistics"
+    MUTUAL_INFO = "mutual_info"
+    PERMUTATION = "permutation"
 
 
-class OptunaReturnType(StrEnum):
+class ScoringMethod(StrEnum):
     """Determines which bag performance statistic is used as the Optuna optimisation target.
 
-    Used in ``Octo.optuna_return``:
-    - ``ENSEMBLE``: uses the ensembled dev score across all inner folds (dev_ensemble)
-    - ``AVERAGE``: uses the average of per-fold dev scores (dev_avg)
+    Used in ``Octo.scoring_method``:
+    - ``COMBINED``: uses the ensembled dev score across all inner splits (dev_ensemble)
+    - ``AVERAGE``: uses the average of per-split dev scores (dev_avg)
     """
 
-    ENSEMBLE = "ensemble"
+    COMBINED = "combined"
     AVERAGE = "average"
 
 
@@ -237,18 +219,6 @@ class PredictionType(StrEnum):
 
     PREDICTIONS = "predictions"
     PROBABILITIES = "probabilities"
-
-
-class MRMRFIAggregation(StrEnum):
-    """How per-training feature importances are aggregated before MRMR relevance scoring.
-
-    Used in ``Mrmr.feature_importance_type``:
-    - ``MEAN``: averages importance values across training runs
-    - ``COUNT``: counts how often a feature has non-zero importance
-    """
-
-    MEAN = "mean"
-    COUNT = "count"
 
 
 ML_TYPES = [e.value for e in MLType]

--- a/tests/infrastructure/test_fsspec.py
+++ b/tests/infrastructure/test_fsspec.py
@@ -181,29 +181,26 @@ class TestFSSpecIntegration:
 
             try:
                 study = OctoClassification(
-                    name="test_octo_intro_execution",
+                    study_name="test_octo_intro_execution",
                     target_metric="ACCBAL",
                     feature_cols=features,
                     target_col="target",
                     sample_id_col="index",
                     stratification_col="target",
-                    datasplit_seed_outer=1,
-                    n_folds_outer=2,
-                    path=root_dir,
-                    ignore_data_health_warning=True,
-                    run_single_outersplit_num=0,
+                    outer_split_seed=1,
+                    n_outer_splits=2,
+                    studies_directory=root_dir,
+                    single_outer_split=0,
                     workflow=[
                         Octo(
                             description="step_1_octo",
                             task_id=0,
                             depends_on=None,
-                            n_folds_inner=3,
+                            n_inner_splits=3,
                             models=[ModelName.ExtraTreesClassifier],
-                            model_seed=0,
-                            max_outl=0,
-                            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-                            optuna_seed=0,
-                            n_optuna_startup_trials=3,
+                            max_outliers=0,
+                            fi_methods=[FIComputeMethod.PERMUTATION],
+                            n_startup_trials=3,
                             n_trials=2,
                             ensemble_selection=False,
                         )

--- a/tests/infrastructure/test_parallelization.py
+++ b/tests/infrastructure/test_parallelization.py
@@ -12,7 +12,7 @@ from octopus.manager import ray_parallel
 
 
 @pytest.fixture
-def outersplits():
+def outer_splits():
     return {
         0: OuterSplit(traindev=pd.DataFrame(), test=pd.DataFrame()),
         1: OuterSplit(traindev=pd.DataFrame(), test=pd.DataFrame()),
@@ -21,16 +21,16 @@ def outersplits():
     }
 
 
-def test_inner_parallelization_setup_in_workers(tmp_path, outersplits):
+def test_inner_parallelization_setup_in_workers(tmp_path, outer_splits):
     resources = ray_parallel.init(
-        num_cpus_user=0,
-        num_outersplits=len(outersplits),
-        run_single_outersplit=False,
+        n_cpus_user=0,
+        n_outer_splits=len(outer_splits),
+        run_single_outer_split=False,
         namespace="test_namespace",
     )
 
-    def run_fn(outersplit_id: int, outersplit: OuterSplit, num_cpus_per_worker: int):
-        assert num_cpus_per_worker == resources.cpus_per_worker
+    def run_fn(outersplit_id: int, outersplit: OuterSplit, n_cpus_per_worker: int):
+        assert n_cpus_per_worker == resources.cpus_per_worker
 
         for var in ray_parallel._PARALLELIZATION_ENV_VARS:
             assert os.environ.get(var, None) == str(resources.cpus_per_worker), (
@@ -46,10 +46,10 @@ def test_inner_parallelization_setup_in_workers(tmp_path, outersplits):
             assert lib["num_threads"] == 1
 
     ray_parallel.run_parallel_outer(
-        outersplit_data=outersplits,
+        outer_split_data=outer_splits,
         run_fn=run_fn,
         log_dir=UPath(tmp_path),
-        num_cpus_per_worker=resources.cpus_per_worker,
+        n_cpus_per_worker=resources.cpus_per_worker,
     )
 
     ray_parallel.shutdown()
@@ -57,7 +57,7 @@ def test_inner_parallelization_setup_in_workers(tmp_path, outersplits):
 
 @pytest.mark.skip(reason="Deadlock in Github CI to be investigated")
 @pytest.mark.parametrize("num_nodes", [1, 2, 3], ids=lambda n: f"{n}_node(s)")
-def test_connect_to_running_ray_cluster(tmp_path, outersplits, num_nodes):
+def test_connect_to_running_ray_cluster(tmp_path, outer_splits, num_nodes):
     HOST = "127.0.0.1"
     PORT = 6379
     CPUS_PER_NODE = 4
@@ -88,21 +88,21 @@ def test_connect_to_running_ray_cluster(tmp_path, outersplits, num_nodes):
 
     try:
         resources = ray_parallel.init(
-            num_cpus_user=0,
-            num_outersplits=len(outersplits),
-            run_single_outersplit=False,
+            n_cpus_user=0,
+            n_outer_splits=len(outer_splits),
+            run_single_outer_split=False,
             address=f"{HOST}:{PORT}",
             namespace="test_namespace",
         )
 
-        def run_fn(outersplit_id: int, outersplit: OuterSplit, num_cpus_per_worker: int):
-            assert num_cpus_per_worker == resources.cpus_per_worker
+        def run_fn(outersplit_id: int, outersplit: OuterSplit, n_cpus_per_worker: int):
+            assert n_cpus_per_worker == resources.cpus_per_worker
 
         ray_parallel.run_parallel_outer(
-            outersplit_data=outersplits,
+            outer_split_data=outer_splits,
             run_fn=run_fn,
             log_dir=UPath(tmp_path),
-            num_cpus_per_worker=resources.cpus_per_worker,
+            n_cpus_per_worker=resources.cpus_per_worker,
         )
     finally:
         ray.shutdown()

--- a/tests/manager/test_core.py
+++ b/tests/manager/test_core.py
@@ -41,8 +41,8 @@ def mock_workflow():
 
 
 @pytest.fixture
-def mock_outersplit_data():
-    """Create mock fold splits."""
+def mock_outer_split_data():
+    """Create mock outer splits."""
     return {
         0: OuterSplit(
             traindev=pd.DataFrame({"feature1": [1, 2], "feature2": [3, 4], "target": [0, 1]}),
@@ -73,14 +73,14 @@ def study():
 
 
 @pytest.fixture
-def octo_manager(study, mock_workflow, mock_outersplit_data):
+def octo_manager(study, mock_workflow, mock_outer_split_data):
     """Create octo manager."""
     return OctoManager(
-        outersplit_data=mock_outersplit_data,
+        outer_split_data=mock_outer_split_data,
         study_context=study,
         workflow=mock_workflow,
-        num_cpus=0,
-        run_single_outersplit_num=None,
+        n_cpus=0,
+        single_outer_split=None,
     )
 
 
@@ -103,102 +103,102 @@ class TestResourceConfig:
 
     def test_create_with_parallelization(self):
         """Test resource creation with outer parallelization."""
-        num_outersplits = 4
+        n_outer_splits = 4
 
         config = ResourceConfig.create(
             ray_nodes=self.RAY_NODES,
-            num_outersplits=num_outersplits,
-            run_single_outersplit=False,
+            n_outer_splits=n_outer_splits,
+            run_single_outer_split=False,
         )
         assert config.available_cpus == self.RAY_NODES["local"]["CPU"]
-        assert config.num_workers == min(num_outersplits, self.RAY_NODES["local"]["CPU"])
-        assert config.cpus_per_worker == self.RAY_NODES["local"]["CPU"] // num_outersplits
+        assert config.n_workers == min(n_outer_splits, self.RAY_NODES["local"]["CPU"])
+        assert config.cpus_per_worker == self.RAY_NODES["local"]["CPU"] // n_outer_splits
 
     def test_create_without_parallelization(self):
         """Test resource creation without outer parallelization."""
         config = ResourceConfig.create(
             ray_nodes=self.RAY_NODES,
-            num_outersplits=4,
-            run_single_outersplit=True,
+            n_outer_splits=4,
+            run_single_outer_split=True,
         )
         assert config.available_cpus == self.RAY_NODES["local"]["CPU"]
-        assert config.num_workers == 1
+        assert config.n_workers == 1
         assert config.cpus_per_worker == self.RAY_NODES["local"]["CPU"]  # All CPUs for sequential
 
-    def test_create_more_outersplits_than_cpus(self):
-        """Test when outersplits exceed available CPUs."""
+    def test_create_more_outer_splits_than_cpus(self):
+        """Test when outer splits exceed available CPUs."""
         config = ResourceConfig.create(
             ray_nodes=self.RAY_NODES,
-            num_outersplits=16,
-            run_single_outersplit=False,
+            n_outer_splits=16,
+            run_single_outer_split=False,
         )
-        assert config.num_workers == min(16, self.RAY_NODES["local"]["CPU"])
+        assert config.n_workers == min(16, self.RAY_NODES["local"]["CPU"])
         assert config.cpus_per_worker == max(1, self.RAY_NODES["local"]["CPU"] // 16)
 
     def test_frozen(self):
         """Test that ResourceConfig is immutable (attrs frozen)."""
         config = ResourceConfig(
             available_cpus=4,
-            num_workers=2,
+            n_workers=2,
             cpus_per_worker=2,
             ray_nodes=self.RAY_NODES,
-            run_single_outersplit=False,
-            num_outersplits=4,
+            run_single_outer_split=False,
+            n_outer_splits=4,
         )
         with pytest.raises(attrs.exceptions.FrozenInstanceError):
             config.available_cpus = 8  # type: ignore[misc]
 
-    def test_create_single_outersplit_gets_all_cpus(self):
-        """Test that when running a single outersplit, it gets all CPUs.
+    def test_create_single_outer_split_gets_all_cpus(self):
+        """Test that when running a single outer split, it gets all CPUs.
 
-        This tests the fix for the regression where single outersplits were
-        getting limited CPUs based on the total number of outersplits.
+        This tests the fix for the regression where single outer splits were
+        getting limited CPUs based on the total number of outer splits.
         """
-        # Simulate: 8 CPUs, 8 total outersplits, but running only outersplit 0
+        # Simulate: 8 CPUs, 8 total outer splits, but running only outer split 0
         config = ResourceConfig.create(
-            num_outersplits=8,
+            n_outer_splits=8,
             ray_nodes=self.RAY_NODES,
-            run_single_outersplit=True,
+            run_single_outer_split=True,
         )
         assert config.available_cpus == self.TOTAL_CPUS
-        assert config.num_workers == 1  # Only 1 outersplit running
+        assert config.n_workers == 1  # Only 1 outer split running
         assert config.cpus_per_worker == self.TOTAL_CPUS  # Gets all CPUs, not 8/8=1
 
-    def test_create_rejects_zero_outersplits(self):
-        """Test that zero outersplits raises ValueError."""
-        with pytest.raises(ValueError, match="num_outersplits must be positive"):
+    def test_create_rejects_zero_outer_splits(self):
+        """Test that zero outer splits raises ValueError."""
+        with pytest.raises(ValueError, match="n_outer_splits must be positive"):
             ResourceConfig.create(
-                num_outersplits=0,
-                run_single_outersplit=False,
+                n_outer_splits=0,
+                run_single_outer_split=False,
                 ray_nodes=self.RAY_NODES,
             )
 
-    def test_create_rejects_negative_outersplits(self):
-        """Test that negative outersplits raises ValueError."""
-        with pytest.raises(ValueError, match="num_outersplits must be positive"):
+    def test_create_rejects_negative_outer_splits(self):
+        """Test that negative outer splits raises ValueError."""
+        with pytest.raises(ValueError, match="n_outer_splits must be positive"):
             ResourceConfig.create(
-                num_outersplits=-5,
-                run_single_outersplit=False,
+                n_outer_splits=-5,
+                run_single_outer_split=False,
                 ray_nodes=self.RAY_NODES,
             )
 
     def test_str_representation(self):
         """Test string representation of ResourceConfig."""
-        num_outersplits = 4
+        n_outer_splits = 4
 
         config = ResourceConfig.create(
-            num_outersplits=num_outersplits,
-            run_single_outersplit=False,
+            n_outer_splits=n_outer_splits,
+            run_single_outer_split=False,
             ray_nodes=self.RAY_NODES,
         )
         str_repr = str(config)
 
         # Verify all key information is in the string
-        assert "Single outersplit: False" in str_repr
-        assert f"Outersplits:       {num_outersplits}" in str_repr
+        assert "Single outer split: False" in str_repr
+        assert f"Outer splits:      {n_outer_splits}" in str_repr
         assert f"Available CPUs:    {self.TOTAL_CPUS}" in str_repr
-        assert f"Workers:           {min(num_outersplits, self.TOTAL_CPUS)}" in str_repr
-        assert f"CPUs/outersplit:   {self.TOTAL_CPUS // num_outersplits}" in str_repr
+        assert f"Workers:           {min(n_outer_splits, self.TOTAL_CPUS)}" in str_repr
+        assert f"CPUs/outer split:  {self.TOTAL_CPUS // n_outer_splits}" in str_repr
 
         # Verify "Preparing execution" is NOT in the string
         assert "Preparing execution" not in str_repr
@@ -212,89 +212,89 @@ class TestResourceConfig:
 class TestOctoManager:
     """Tests for OctoManager orchestration."""
 
-    def test_run_outersplits_sequential(self, octo_manager):
-        """Test run outersplits sequential."""
-        octo_manager.num_cpus = 1
+    def test_run_outer_splits_sequential(self, octo_manager):
+        """Test run outer splits sequential."""
+        octo_manager.n_cpus = 1
 
         with (
             patch.object(WorkflowTaskRunner, "run") as mock_run,
         ):
-            octo_manager.run_outersplits()
-            assert mock_run.call_count == len(octo_manager.outersplit_data)  # Called once per outersplit
+            octo_manager.run_outer_splits()
+            assert mock_run.call_count == len(octo_manager.outer_split_data)  # Called once per outer split
 
-    def test_run_outersplits_parallel(self, study, mock_workflow, mock_outersplit_data):
-        """Test run outersplits with parallelization."""
+    def test_run_outer_splits_parallel(self, study, mock_workflow, mock_outer_split_data):
+        """Test run outer splits with parallelization."""
         manager = OctoManager(
-            outersplit_data=mock_outersplit_data,
+            outer_split_data=mock_outer_split_data,
             study_context=study,
             workflow=mock_workflow,
-            num_cpus=0,
-            run_single_outersplit_num=None,
+            n_cpus=0,
+            single_outer_split=None,
         )
 
         with (
             patch("octopus.manager.ray_parallel.run_parallel_outer", return_value=[True]) as mock_ray,
         ):
-            manager.run_outersplits()
+            manager.run_outer_splits()
             mock_ray.assert_called_once()
 
-    def test_run_single_outersplit(self, study, mock_workflow, mock_outersplit_data):
-        """Test run single outersplit."""
+    def test_run_single_outer_split(self, study, mock_workflow, mock_outer_split_data):
+        """Test run single outer split."""
         manager = OctoManager(
-            outersplit_data=mock_outersplit_data,
+            outer_split_data=mock_outer_split_data,
             study_context=study,
             workflow=mock_workflow,
-            num_cpus=1,
-            run_single_outersplit_num=0,
+            n_cpus=1,
+            single_outer_split=0,
         )
 
         with (
             patch.object(WorkflowTaskRunner, "run") as mock_run,
         ):
-            manager.run_outersplits()
-            # Verify that run was called with outersplit_id and OuterSplit
+            manager.run_outer_splits()
+            # Verify that run was called with outer_split_id and OuterSplit
             mock_run.assert_called_once()
             call_args = mock_run.call_args[0]
             assert len(call_args) == 3
-            assert call_args[0] == 0  # outersplit_id
-            assert isinstance(call_args[1], OuterSplit)  # outersplit
-            assert call_args[2] == 1  # num_assigned_cpus
+            assert call_args[0] == 0  # outer_split_id
+            assert isinstance(call_args[1], OuterSplit)  # outer_split
+            assert call_args[2] == 1  # n_assigned_cpus
 
-    def test_no_outersplits_raises_error(self, study, mock_workflow):
-        """Test that empty fold splits raises ValueError."""
+    def test_no_outer_splits_raises_error(self, study, mock_workflow):
+        """Test that empty outer splits raises ValueError."""
         manager = OctoManager(
-            outersplit_data={},
+            outer_split_data={},
             study_context=study,
             workflow=mock_workflow,
-            num_cpus=1,
-            run_single_outersplit_num=None,
+            n_cpus=1,
+            single_outer_split=None,
         )
-        with pytest.raises(ValueError, match="No outersplit data defined"):
-            manager.run_outersplits()
+        with pytest.raises(ValueError, match="No outer split data defined"):
+            manager.run_outer_splits()
 
     def test_ray_shutdown_on_error(self, octo_manager):
         """Test that Ray is shut down even if execution fails."""
-        octo_manager.num_cpus = 1
+        octo_manager.n_cpus = 1
 
         with (
             patch("octopus.manager.ray_parallel.shutdown") as mock_shutdown,
             patch.object(WorkflowTaskRunner, "run", side_effect=RuntimeError("Test error")),
         ):
             with pytest.raises(RuntimeError):
-                octo_manager.run_outersplits()
+                octo_manager.run_outer_splits()
             mock_shutdown.assert_called_once()
 
         ray_parallel.shutdown()  # Ensure Ray is shut down after test
 
-    def test_single_outersplit_resource_allocation(self, study, mock_workflow):
-        """Test that single outersplit gets all CPUs when run_single_outersplit_num is set.
+    def test_single_outer_split_resource_allocation(self, study, mock_workflow):
+        """Test that single outer split gets all CPUs when single_outer_split is set.
 
-        This is a regression test: previously, when running a single outersplit from
-        a set of 8 outersplits on 8 CPUs, the single outersplit would only get 1 CPU
+        This is a regression test: previously, when running a single outer split from
+        a set of 8 outer splits on 8 CPUs, the single outer split would only get 1 CPU
         instead of all 8.
         """
-        # Create 8 mock fold splits
-        outersplit_data = {
+        # Create 8 mock outer splits
+        outer_split_data = {
             i: OuterSplit(
                 traindev=pd.DataFrame({"feature1": [1, 2], "feature2": [3, 4], "target": [0, 1]}),
                 test=pd.DataFrame({"feature1": [5], "feature2": [6], "target": [1]}),
@@ -303,11 +303,11 @@ class TestOctoManager:
         }
 
         manager = OctoManager(
-            outersplit_data=outersplit_data,
+            outer_split_data=outer_split_data,
             study_context=study,
             workflow=mock_workflow,
-            num_cpus=0,
-            run_single_outersplit_num=0,
+            n_cpus=0,
+            single_outer_split=0,
         )
 
         with (
@@ -315,13 +315,13 @@ class TestOctoManager:
             patch.object(WorkflowTaskRunner, "__init__", return_value=None),
             patch.object(WorkflowTaskRunner, "run") as mock_run,
         ):
-            manager.run_outersplits()
+            manager.run_outer_splits()
 
-            # Verify that WorkflowTaskRunner was initialized with cpus_per_outersplit that allocates all CPUs
-            # to the single outersplit (not 8/8=1)
+            # Verify that WorkflowTaskRunner was initialized with cpus_per_outer_split that allocates all CPUs
+            # to the single outer split (not 8/8=1)
             call_args = mock_run.call_args
-            num_assigned_cpus = call_args[0][2]  # Now a keyword arg
-            assert num_assigned_cpus == 8  # All CPUs for that outersplit
+            n_assigned_cpus = call_args[0][2]  # Now a keyword arg
+            assert n_assigned_cpus == 8  # All CPUs for that outer split
 
 
 # =============================================================================

--- a/tests/models/test_hyperparameter.py
+++ b/tests/models/test_hyperparameter.py
@@ -146,7 +146,7 @@ def test_create_trial_parameters():
         """Test model config."""
         return ModelConfig(
             model_class=DummyModel,
-            feature_method=FIComputeMethod.INTERNAL,
+            fi_method=FIComputeMethod.INTERNAL,
             ml_types=[MLType.BINARY, MLType.MULTICLASS],
             hyperparameters=hyperparameters,
             n_jobs="n_jobs",

--- a/tests/models/test_model_config.py
+++ b/tests/models/test_model_config.py
@@ -22,7 +22,7 @@ def test_model_config_initialization():
 
     model = ModelConfig(
         model_class=DummyModel,
-        feature_method=FIComputeMethod.INTERNAL,
+        fi_method=FIComputeMethod.INTERNAL,
         ml_types=[MLType.REGRESSION],
         hyperparameters=hyperparameters,
         n_jobs="n_jobs",
@@ -32,7 +32,7 @@ def test_model_config_initialization():
     # Name is not set during initialization - it's added by Models.get_config()
     assert not hasattr(model, "name")
     assert isinstance(model.model_class, type)
-    assert model.feature_method == FIComputeMethod.INTERNAL
+    assert model.fi_method == FIComputeMethod.INTERNAL
     assert model.supports_ml_type(MLType.REGRESSION)
     assert model.hyperparameters == hyperparameters
     assert model.n_jobs == "n_jobs"
@@ -53,7 +53,7 @@ def test_model_config_with_conflict():
     ):
         ModelConfig(
             model_class=DummyModel,
-            feature_method=FIComputeMethod.INTERNAL,
+            fi_method=FIComputeMethod.INTERNAL,
             ml_types=[MLType.REGRESSION],
             hyperparameters=hyperparameters,
             n_jobs="n_jobs",

--- a/tests/modules/octo/test_column_ordering.py
+++ b/tests/modules/octo/test_column_ordering.py
@@ -186,7 +186,7 @@ class TestColumnOrdering:
         training.fit()
         training.calculate_fi(FIComputeMethod.INTERNAL)
 
-        fi_df = training.feature_importances[fi_storage_key(FIComputeMethod.INTERNAL)]
+        fi_df = training.fi[fi_storage_key(FIComputeMethod.INTERNAL)]
         assert not fi_df.empty, "Internal FI should not be empty"
 
         # num1 should be the most important feature (target = 10*num1 + 0.01*num2 + noise)
@@ -205,7 +205,7 @@ class TestColumnOrdering:
         training.fit()
         training.calculate_fi(FIComputeMethod.PERMUTATION, partition="dev", n_repeats=3)
 
-        fi_df = training.feature_importances[fi_storage_key(FIComputeMethod.PERMUTATION, "dev")]
+        fi_df = training.fi[fi_storage_key(FIComputeMethod.PERMUTATION, "dev")]
         assert not fi_df.empty, "Permutation FI should not be empty"
 
         # num1 (or its group numerical_group) should be the most important feature

--- a/tests/modules/octo/test_ensemble_selection.py
+++ b/tests/modules/octo/test_ensemble_selection.py
@@ -78,44 +78,44 @@ def create_data_splits(X, y_global, test_size=0.2):
     }
 
 
-def create_cv_folds(X_train, y_train, train_row_ids, n_folds=3):
-    """Create CV folds for training validation."""
-    kf = KFold(n_splits=n_folds, shuffle=True, random_state=42)
-    cv_folds = []
+def create_cv_splits(X_train, y_train, train_row_ids, n_splits=3):
+    """Create CV splits for training validation."""
+    kf = KFold(n_splits=n_splits, shuffle=True, random_state=42)
+    cv_splits = []
 
     for _, (train_idx, val_idx) in enumerate(kf.split(X_train)):
-        fold_data = {
-            "X_fold_train": X_train[train_idx],
-            "y_fold_train": y_train[train_idx],
-            "X_fold_val": X_train[val_idx],
-            "y_fold_val": y_train[val_idx],
-            "fold_train_row_ids": train_row_ids[train_idx],
-            "fold_val_row_ids": train_row_ids[val_idx],
+        split_data = {
+            "X_split_train": X_train[train_idx],
+            "y_split_train": y_train[train_idx],
+            "X_split_val": X_train[val_idx],
+            "y_split_val": y_train[val_idx],
+            "split_train_row_ids": train_row_ids[train_idx],
+            "split_val_row_ids": train_row_ids[val_idx],
         }
-        cv_folds.append(fold_data)
+        cv_splits.append(split_data)
 
-    return cv_folds
+    return cv_splits
 
 
-def create_fake_training(trained_model, model_name, feature_indices, fold_data, splits, training_id):
+def create_fake_training(trained_model, model_name, feature_indices, split_data, splits, training_id):
     """Create fake Training object with predictions using pre-trained model."""
     # Extract feature subset for this model
-    X_fold_train = fold_data["X_fold_train"][:, feature_indices]
-    X_fold_val = fold_data["X_fold_val"][:, feature_indices]
+    X_split_train = split_data["X_split_train"][:, feature_indices]
+    X_split_val = split_data["X_split_val"][:, feature_indices]
     X_test = splits["X_test"][:, feature_indices]
 
     # Create predictions using pre-trained model (NO retraining)
-    pred_train = trained_model.predict(X_fold_train)
-    pred_val = trained_model.predict(X_fold_val)
+    pred_train = trained_model.predict(X_split_train)
+    pred_val = trained_model.predict(X_split_val)
     pred_test = trained_model.predict(X_test)
 
     # Create prediction dataframes in octopus format (with required metadata columns)
     predictions = {
         "train": pd.DataFrame(
             {
-                "row_id": fold_data["fold_train_row_ids"],
+                "row_id": split_data["split_train_row_ids"],
                 "prediction": pred_train,
-                "target": fold_data["y_fold_train"],
+                "target": split_data["y_split_train"],
                 "outer_split_id": 0,
                 "inner_split_id": training_id,
                 "partition": "train",
@@ -124,9 +124,9 @@ def create_fake_training(trained_model, model_name, feature_indices, fold_data, 
         ),
         "dev": pd.DataFrame(
             {
-                "row_id": fold_data["fold_val_row_ids"],
+                "row_id": split_data["split_val_row_ids"],
                 "prediction": pred_val,
-                "target": fold_data["y_fold_val"],
+                "target": split_data["y_split_val"],
                 "outer_split_id": 0,
                 "inner_split_id": training_id,
                 "partition": "dev",
@@ -147,13 +147,13 @@ def create_fake_training(trained_model, model_name, feature_indices, fold_data, 
     }
 
     # Create proper dataframes for Training object
-    train_df = pd.DataFrame(X_fold_train, columns=[f"feature_{i}" for i in range(len(feature_indices))])
-    train_df["row_id"] = fold_data["fold_train_row_ids"]
-    train_df["target"] = fold_data["y_fold_train"]
+    train_df = pd.DataFrame(X_split_train, columns=[f"feature_{i}" for i in range(len(feature_indices))])
+    train_df["row_id"] = split_data["split_train_row_ids"]
+    train_df["target"] = split_data["y_split_train"]
 
-    val_df = pd.DataFrame(X_fold_val, columns=[f"feature_{i}" for i in range(len(feature_indices))])
-    val_df["row_id"] = fold_data["fold_val_row_ids"]
-    val_df["target"] = fold_data["y_fold_val"]
+    val_df = pd.DataFrame(X_split_val, columns=[f"feature_{i}" for i in range(len(feature_indices))])
+    val_df["row_id"] = split_data["split_val_row_ids"]
+    val_df["target"] = split_data["y_split_val"]
 
     test_df = pd.DataFrame(X_test, columns=[f"feature_{i}" for i in range(len(feature_indices))])
     test_df["row_id"] = splits["test_row_ids"]
@@ -188,13 +188,13 @@ def create_fake_training(trained_model, model_name, feature_indices, fold_data, 
     return training
 
 
-def create_fake_bag(log_dir, trained_model, model_name, feature_indices, cv_folds, splits, bag_id):
+def create_fake_bag(log_dir, trained_model, model_name, feature_indices, cv_splits, splits, bag_id):
     """Create complete fake Bag for one trial."""
     trainings = []
 
-    for fold_idx, fold_data in enumerate(cv_folds):
-        training_id = f"{bag_id}_{fold_idx}"
-        training = create_fake_training(trained_model, model_name, feature_indices, fold_data, splits, training_id)
+    for split_idx, split_data in enumerate(cv_splits):
+        training_id = f"{bag_id}_{split_idx}"
+        training = create_fake_training(trained_model, model_name, feature_indices, split_data, splits, training_id)
         trainings.append(training)
 
     bag = Bag(
@@ -227,7 +227,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
 
     # Create data splits
     splits = create_data_splits(X, y_global)
-    cv_folds = create_cv_folds(splits["X_train"], splits["y_train"], splits["train_row_ids"])
+    cv_splits = create_cv_splits(splits["X_train"], splits["y_train"], splits["train_row_ids"])
 
     # Create fake bags for each model
     feature_subsets = {"linear": list(range(0, 4)), "rf": list(range(4, 8)), "gb": list(range(8, 12))}
@@ -239,7 +239,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
     bags = {}
     for model_name, model in models.items():
         bag = create_fake_bag(
-            trials_path, model, model_name, feature_subsets[model_name], cv_folds, splits, bag_id=f"trial_{model_name}"
+            trials_path, model, model_name, feature_subsets[model_name], cv_splits, splits, bag_id=f"trial_{model_name}"
         )
         bags[model_name] = bag
 
@@ -251,7 +251,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
     # Get individual model performance
     individual_performances = []
     for _model_name, bag in bags.items():
-        scores = bag.get_performance(num_assigned_cpus=1)
+        scores = bag.get_performance(n_assigned_cpus=1)
         individual_performances.append(scores["dev_ensemble"])
 
     best_individual_mae = min(individual_performances)
@@ -263,7 +263,7 @@ def test_ensemble_selection_ensembled_data(tmp_path):
         max_n_iterations=50,  # Fewer iterations for speed
         row_id_col="row_id",
         target_assignments={"default": "target"},
-        num_assigned_cpus=1,
+        n_assigned_cpus=1,
     )
 
     # Extract ensemble results

--- a/tests/modules/octo/test_ensemble_selection_unit.py
+++ b/tests/modules/octo/test_ensemble_selection_unit.py
@@ -192,7 +192,7 @@ def create_partial_ensel(trials_path, target_metric="MAE", methods_to_run=None):
         path_trials=trials_path,
         max_n_iterations=10,
         row_id_col="row_id",
-        num_assigned_cpus=1,
+        n_assigned_cpus=1,
     )
 
 

--- a/tests/modules/octo/test_model_fitted_validation.py
+++ b/tests/modules/octo/test_model_fitted_validation.py
@@ -346,7 +346,7 @@ def _display_model_info(model_name: ModelName, model_params: dict, verbose: bool
         print(f"\n  📊 {model_name.value}")
         print(f"     Model Class: {model_config.model_class.__name__}")
         print(f"     ML Types: {model_config.ml_types}")
-        print(f"     Feature Method: {model_config.feature_method}")
+        print(f"     Feature Method: {model_config.fi_method}")
         print(f"     Scaler: {model_config.scaler}")
         print(f"     Imputation Required: {model_config.imputation_required}")
         print(f"     Categorical Enabled: {model_config.categorical_enabled}")

--- a/tests/modules/roc/test_roc.py
+++ b/tests/modules/roc/test_roc.py
@@ -6,7 +6,7 @@ import pytest
 from sklearn.datasets import make_classification
 
 from octopus.modules import Roc
-from octopus.types import CorrelationType, ROCFilterMethod
+from octopus.types import CorrelationType, RelevanceMethod
 
 
 class TestRocModule:
@@ -19,9 +19,9 @@ class TestRocModule:
         assert roc.task_id == 0
         assert roc.depends_on is None
         assert roc.description == ""
-        assert roc.threshold == 0.8
+        assert roc.correlation_threshold == 0.8
         assert roc.correlation_type == CorrelationType.SPEARMAN
-        assert roc.filter_type == ROCFilterMethod.F_STATISTICS
+        assert roc.relevance_method == RelevanceMethod.F_STATISTICS
         assert roc.module == "roc"
 
     def test_roc_module_initialization_custom_params(self):
@@ -30,43 +30,43 @@ class TestRocModule:
             task_id=1,
             depends_on=0,
             description="test_roc",
-            threshold=0.9,
+            correlation_threshold=0.9,
             correlation_type=CorrelationType.RDC,
-            filter_type=ROCFilterMethod.MUTUAL_INFO,
+            relevance_method=RelevanceMethod.MUTUAL_INFO,
         )
 
         assert roc.task_id == 1
         assert roc.depends_on == 0
         assert roc.description == "test_roc"
-        assert roc.threshold == 0.9
+        assert roc.correlation_threshold == 0.9
         assert roc.correlation_type == CorrelationType.RDC
-        assert roc.filter_type == ROCFilterMethod.MUTUAL_INFO
+        assert roc.relevance_method == RelevanceMethod.MUTUAL_INFO
 
     def test_roc_module_invalid_correlation_type(self):
         """Test ROC module with invalid correlation type."""
         with pytest.raises(ValueError, match="is not a valid CorrelationType"):
             Roc(task_id=0, correlation_type="invalid_correlation")
 
-    def test_roc_module_invalid_filter_type(self):
-        """Test ROC module with invalid filter type."""
-        with pytest.raises(ValueError, match="is not a valid ROCFilterMethod"):
-            Roc(task_id=0, filter_type="invalid_filter")
+    def test_roc_module_invalid_relevance_method(self):
+        """Test ROC module with invalid relevance method."""
+        with pytest.raises(ValueError, match="is not a valid RelevanceMethod"):
+            Roc(task_id=0, relevance_method="invalid_filter")
 
-    def test_roc_module_invalid_threshold_type(self):
-        """Test ROC module with invalid threshold type."""
+    def test_roc_module_invalid_correlation_threshold_type(self):
+        """Test ROC module with invalid correlation threshold type."""
         with pytest.raises(TypeError):
-            Roc(task_id=0, threshold="invalid")  # type: ignore[arg-type]
+            Roc(task_id=0, correlation_threshold="invalid")  # type: ignore[arg-type]
 
     def test_roc_module_negative_task_id(self):
         """Test ROC module with negative sequence ID."""
         with pytest.raises(ValueError):
             Roc(task_id=-1)
 
-    @pytest.mark.parametrize("threshold", [0.0, 0.5, 0.8, 0.95, 1.0])
-    def test_roc_module_threshold_range(self, threshold):
-        """Test ROC module with different threshold values."""
-        roc = Roc(task_id=0, threshold=threshold)
-        assert roc.threshold == threshold
+    @pytest.mark.parametrize("correlation_threshold", [0.0, 0.5, 0.8, 0.95, 1.0])
+    def test_roc_module_correlation_threshold_range(self, correlation_threshold):
+        """Test ROC module with different correlation threshold values."""
+        roc = Roc(task_id=0, correlation_threshold=correlation_threshold)
+        assert roc.correlation_threshold == correlation_threshold
 
     @pytest.mark.parametrize("correlation_type", [CorrelationType.SPEARMAN, CorrelationType.RDC])
     def test_roc_module_correlation_types(self, correlation_type):
@@ -74,11 +74,11 @@ class TestRocModule:
         roc = Roc(task_id=0, correlation_type=correlation_type)
         assert roc.correlation_type == correlation_type
 
-    @pytest.mark.parametrize("filter_type", [ROCFilterMethod.MUTUAL_INFO, ROCFilterMethod.F_STATISTICS])
-    def test_roc_module_filter_types(self, filter_type):
-        """Test ROC module with different filter types."""
-        roc = Roc(task_id=0, filter_type=filter_type)
-        assert roc.filter_type == filter_type
+    @pytest.mark.parametrize("relevance_method", [RelevanceMethod.MUTUAL_INFO, RelevanceMethod.F_STATISTICS])
+    def test_roc_module_relevance_methods(self, relevance_method):
+        """Test ROC module with different relevance methods."""
+        roc = Roc(task_id=0, relevance_method=relevance_method)
+        assert roc.relevance_method == relevance_method
 
 
 class TestRocIntegration:
@@ -100,13 +100,13 @@ class TestRocIntegration:
         roc_module = Roc(
             task_id=0,
             description="integration_test",
-            threshold=0.85,
+            correlation_threshold=0.85,
             correlation_type=CorrelationType.SPEARMAN,
-            filter_type=ROCFilterMethod.MUTUAL_INFO,
+            relevance_method=RelevanceMethod.MUTUAL_INFO,
         )
 
         # Verify module configuration
-        assert roc_module.threshold == 0.85
+        assert roc_module.correlation_threshold == 0.85
         assert roc_module.correlation_type == CorrelationType.SPEARMAN
-        assert roc_module.filter_type == ROCFilterMethod.MUTUAL_INFO
+        assert roc_module.relevance_method == RelevanceMethod.MUTUAL_INFO
         assert roc_module.description == "integration_test"

--- a/tests/modules/test_module_result.py
+++ b/tests/modules/test_module_result.py
@@ -25,7 +25,7 @@ class TestModuleResultSaveLoad:
                 "metric": ["AUCROC"],
                 "partition": ["dev"],
                 "aggregation": ["avg"],
-                "fold": [None],
+                "split": [None],
                 "value": [0.85],
             }
         )
@@ -50,7 +50,7 @@ class TestModuleResultSaveLoad:
             selected_features=["f1", "f2"],
             scores=scores,
             predictions=predictions,
-            feature_importances=fi,
+            fi=fi,
             model=model,
         )
 
@@ -75,8 +75,8 @@ class TestModuleResultSaveLoad:
         assert not loaded.scores.empty
         assert loaded.predictions is not None
         assert not loaded.predictions.empty
-        assert loaded.feature_importances is not None
-        assert not loaded.feature_importances.empty
+        assert loaded.fi is not None
+        assert not loaded.fi.empty
         assert loaded.model is not None
 
     def test_save_load_roundtrip_without_model(self, tmp_path):
@@ -92,7 +92,7 @@ class TestModuleResultSaveLoad:
             result_type=ResultType.BEST,
             module="roc",
             selected_features=["f1", "f2"],
-            feature_importances=fi,
+            fi=fi,
         )
 
         result_dir = UPath(tmp_path / "best")
@@ -105,7 +105,7 @@ class TestModuleResultSaveLoad:
 
         assert loaded.selected_features == ["f1", "f2"]
         assert loaded.model is None
-        assert loaded.feature_importances is not None and not loaded.feature_importances.empty
+        assert loaded.fi is not None and not loaded.fi.empty
         assert loaded.scores is None
         assert loaded.predictions is None
 
@@ -130,7 +130,7 @@ class TestModuleResultSaveLoad:
         assert loaded.selected_features == ["f1"]
         assert loaded.scores is None
         assert loaded.predictions is None
-        assert loaded.feature_importances is None
+        assert loaded.fi is None
 
     def test_module_and_result_type_columns_stamped(self, tmp_path):
         """Test that module and result_type columns are stamped on saved parquets."""

--- a/tests/modules/test_mrmr.py
+++ b/tests/modules/test_mrmr.py
@@ -16,13 +16,13 @@ def generate_sample_data(n_samples, n_features, random_state):
     np.random.seed(42)
     X, _y, _ = make_regression(n_samples=n_samples, n_features=n_features, random_state=random_state, coef=True)
     df_features = pd.DataFrame(X, columns=[f"feature_{i}" for i in range(n_features)])
-    df_feature_importances = pd.DataFrame(
+    fi_df = pd.DataFrame(
         {
             "feature": df_features.columns,
             "importance": np.random.rand(df_features.shape[1]),
         }
     )
-    return df_features, df_feature_importances
+    return df_features, fi_df
 
 
 @pytest.fixture(
@@ -40,12 +40,12 @@ def sample_data(request):
 
 def test_mrmr_feature_selection_order(sample_data):
     """Test MRMR feature selection for different datasets."""
-    (df_features, df_feature_importances), data_name = sample_data
+    (df_features, fi_df), data_name = sample_data
 
     results = {
-        "pearson": maxrminr(df_features, df_feature_importances, [5], correlation_type=CorrelationType.PEARSON),
-        "spearman": maxrminr(df_features, df_feature_importances, [5], correlation_type=CorrelationType.SPEARMAN),
-        "rdc": maxrminr(df_features, df_feature_importances, [5], correlation_type=CorrelationType.RDC),
+        "pearson": maxrminr(df_features, fi_df, [5], correlation_type=CorrelationType.PEARSON),
+        "spearman": maxrminr(df_features, fi_df, [5], correlation_type=CorrelationType.SPEARMAN),
+        "rdc": maxrminr(df_features, fi_df, [5], correlation_type=CorrelationType.RDC),
     }
 
     if data_name == "sample_data_1":
@@ -103,7 +103,7 @@ def scalability_data(request):
 
 def test_mrmr_scalability(scalability_data):
     """Test MRMR algorithm scalability with large feature sets."""
-    (df_features, df_feature_importances), data_name = scalability_data
+    (df_features, fi_df), data_name = scalability_data
 
     # Dictionary to store execution times
     execution_times = {}
@@ -113,7 +113,7 @@ def test_mrmr_scalability(scalability_data):
         start_time = time.time()
 
         # Select top 20 features
-        results = maxrminr(df_features, df_feature_importances, [20], correlation_type=corr_type)
+        results = maxrminr(df_features, fi_df, [20], correlation_type=corr_type)
 
         end_time = time.time()
         execution_times[corr_type] = end_time - start_time

--- a/tests/modules/test_training_feature_importances.py
+++ b/tests/modules/test_training_feature_importances.py
@@ -276,7 +276,7 @@ def _run_test_body(ml_type: MLType, model_name: str, fi_method: str) -> None:
     fi_keys = _run_fi_method(training, fi_method)
 
     for key in fi_keys:
-        fi_data = training.feature_importances.get(key)
+        fi_data = training.fi.get(key)
         assert fi_data is not None, f"Feature importance key '{key}' not found after {fi_method}"
         # calculate_fi_internal legitimately returns empty for models without
         # built-in feature importances (e.g. GaussianProcess, SVM with non-linear kernel)

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -70,33 +70,28 @@ def _create_classification_study(tmp_path: str) -> tuple[OctoClassification, pd.
     features = features[:5]  # Use only first 5 features for faster testing
 
     study = OctoClassification(
-        name="predict_test_study",
+        study_name="predict_test_study",
         target_metric="ACCBAL",
         feature_cols=features,
         target_col="target",
         sample_id_col="index",
         stratification_col="target",
-        datasplit_seed_outer=1234,
-        n_folds_outer=2,
-        path=tmp_path,
-        ignore_data_health_warning=True,
+        outer_split_seed=1234,
+        n_outer_splits=2,
+        studies_directory=tmp_path,
         workflow=[
             Octo(
                 description="step_1_octo",
                 task_id=0,
                 depends_on=None,
-                n_folds_inner=3,
+                n_inner_splits=3,
                 models=[ModelName.ExtraTreesClassifier],
-                model_seed=0,
-                max_outl=0,
-                fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-                optuna_seed=0,
-                n_optuna_startup_trials=3,
+                max_outliers=0,
+                fi_methods=[FIComputeMethod.PERMUTATION],
+                n_startup_trials=3,
                 n_trials=5,
                 max_features=5,
-                penalty_factor=1.0,
                 ensemble_selection=True,
-                ensel_n_save_trials=5,
             ),
         ],
     )
@@ -144,11 +139,11 @@ class TestStudyIO:
     """Tests for StudyLoader and StudyMetadata."""
 
     def test_load_config(self, study_path):
-        """Verify StudyLoader loads config with correct ml_type and folds."""
+        """Verify StudyLoader loads config with correct ml_type and splits."""
         loader = StudyLoader(study_path)
         cfg = loader.load_config()
         assert cfg["ml_type"] == MLType.BINARY
-        assert cfg["n_folds_outer"] == 2
+        assert cfg["n_outer_splits"] == 2
 
     def test_extract_metadata(self, study_path):
         """Verify extracted metadata matches expected study properties."""
@@ -201,13 +196,13 @@ class TestTaskPredictorTestProperties:
         """Verify ml_type is classification."""
         assert tpt.ml_type == MLType.BINARY
 
-    def test_n_outersplits(self, tpt):
-        """Verify n_outersplits matches study configuration."""
-        assert tpt.n_outersplits == 2
+    def test_n_outer_splits(self, tpt):
+        """Verify n_outer_splits matches study configuration."""
+        assert tpt.n_outer_splits == 2
 
-    def test_outersplits(self, tpt):
-        """Verify outersplits returns correct split indices."""
-        assert tpt.outersplits == [0, 1]
+    def test_outer_splits(self, tpt):
+        """Verify outer_splits returns correct split indices."""
+        assert tpt.outer_splits == [0, 1]
 
     def test_feature_cols(self, tpt):
         """Verify feature_cols is non-empty."""
@@ -231,9 +226,9 @@ class TestTaskPredictorTestPredict:
         """Verify predict with df=True returns DataFrame with expected columns."""
         result = tpt.predict(df=True)
         assert isinstance(result, pd.DataFrame)
-        for col in ("outersplit", "row_id", "prediction", "target"):
+        for col in ("outer_split", "row_id", "prediction", "target"):
             assert col in result.columns
-        assert result["outersplit"].nunique() == 2
+        assert result["outer_split"].nunique() == 2
 
 
 class TestTaskPredictorTestPredictProba:
@@ -247,10 +242,10 @@ class TestTaskPredictorTestPredictProba:
         assert result.shape[1] == 2
 
     def test_predict_proba_df(self, tpt):
-        """Verify predict_proba with df=True returns DataFrame with outersplit and target."""
+        """Verify predict_proba with df=True returns DataFrame with outer_split and target."""
         result = tpt.predict_proba(df=True)
         assert isinstance(result, pd.DataFrame)
-        assert "outersplit" in result.columns
+        assert "outer_split" in result.columns
         assert "target" in result.columns
 
     def test_predict_proba_sums_to_one(self, tpt):
@@ -263,10 +258,10 @@ class TestTaskPredictorTestPerformance:
     """Test TaskPredictorTest.performance()."""
 
     def test_performance_default(self, tpt):
-        """Verify default performance returns one row per outersplit."""
+        """Verify default performance returns one row per outer split."""
         result = tpt.performance()
         assert isinstance(result, pd.DataFrame)
-        assert len(result) == 2  # one per outersplit
+        assert len(result) == 2  # one per outer split
 
     def test_performance_multiple_metrics(self, tpt):
         """Verify performance with multiple metrics returns correct number of rows."""
@@ -312,7 +307,7 @@ class TestGetTargetColumns:
                 positive_class=tpt._metadata.positive_class,
                 row_id_col=tpt._metadata.row_id_col,
                 feature_cols=tpt._metadata.feature_cols,
-                n_outersplits=tpt._metadata.n_outersplits,
+                n_outer_splits=tpt._metadata.n_outer_splits,
             )
             result = tpt._get_target_columns(test_df)
             assert list(result.keys()) == ["target"]
@@ -326,7 +321,7 @@ class TestGetTargetColumns:
                 positive_class=tpt._metadata.positive_class,
                 row_id_col=tpt._metadata.row_id_col,
                 feature_cols=tpt._metadata.feature_cols,
-                n_outersplits=tpt._metadata.n_outersplits,
+                n_outer_splits=tpt._metadata.n_outer_splits,
             )
 
     def test_multi_target_returns_prefixed_keys(self, tpt):
@@ -348,7 +343,7 @@ class TestGetTargetColumns:
                 positive_class=tpt._metadata.positive_class,
                 row_id_col=tpt._metadata.row_id_col,
                 feature_cols=tpt._metadata.feature_cols,
-                n_outersplits=tpt._metadata.n_outersplits,
+                n_outer_splits=tpt._metadata.n_outer_splits,
             )
             result = tpt._get_target_columns(test_df)
             assert "target_duration" in result
@@ -365,7 +360,7 @@ class TestGetTargetColumns:
                 positive_class=tpt._metadata.positive_class,
                 row_id_col=tpt._metadata.row_id_col,
                 feature_cols=tpt._metadata.feature_cols,
-                n_outersplits=tpt._metadata.n_outersplits,
+                n_outer_splits=tpt._metadata.n_outer_splits,
             )
 
     def test_predict_df_single_target_has_target_column(self, tpt):
@@ -415,7 +410,7 @@ class TestTaskPredictorPredict:
         assert isinstance(result, pd.DataFrame)
         assert "prediction" in result.columns
         # Should have per-split + ensemble rows
-        assert "ensemble" in result["outersplit"].values
+        assert "ensemble" in result["outer_split"].values
 
     def test_predict_proba(self, tp, study_path):
         """Verify TaskPredictor predict_proba returns valid probabilities."""
@@ -429,11 +424,11 @@ class TestTaskPredictorSaveLoad:
     """Test TaskPredictor save/load round-trip."""
 
     def test_roundtrip(self, tp, tmp_path):
-        """Verify save/load preserves ml_type, n_outersplits, and feature_cols."""
+        """Verify save/load preserves ml_type, n_outer_splits, and feature_cols."""
         tp.save(tmp_path / "saved")
         loaded = TaskPredictor.load(tmp_path / "saved")
         assert loaded.ml_type == tp.ml_type
-        assert loaded.n_outersplits == tp.n_outersplits
+        assert loaded.n_outer_splits == tp.n_outer_splits
         assert loaded.feature_cols == tp.feature_cols
 
     def test_loaded_predicts(self, tp, study_path, tmp_path):
@@ -461,7 +456,7 @@ class TestPredictProbaMLTypeGuard:
                 positive_class=tp._metadata.positive_class,
                 row_id_col=tp._metadata.row_id_col,
                 feature_cols=tp._metadata.feature_cols,
-                n_outersplits=tp._metadata.n_outersplits,
+                n_outer_splits=tp._metadata.n_outer_splits,
             )
             data = pd.DataFrame({"f0": [1], "f1": [2], "f2": [3], "f3": [4], "f4": [5]})
             with pytest.raises(TypeError, match=r"predict_proba.*only available"):
@@ -475,7 +470,7 @@ class TestPredictProbaMLTypeGuard:
                 positive_class=tp._metadata.positive_class,
                 row_id_col=tp._metadata.row_id_col,
                 feature_cols=tp._metadata.feature_cols,
-                n_outersplits=tp._metadata.n_outersplits,
+                n_outer_splits=tp._metadata.n_outer_splits,
             )
 
 
@@ -491,9 +486,9 @@ class TestNotebookUtilsStudyLevel:
         """Verify show_study_details returns correct study info dict."""
         info = show_study_details(study_path, verbose=False)
         assert info["ml_type"] == MLType.BINARY
-        assert info["n_folds_outer"] == 2
-        assert len(info["outersplit_dirs"]) == 2
-        assert len(info["missing_outersplits"]) == 0
+        assert info["n_outer_splits"] == 2
+        assert len(info["outer_split_dirs"]) == 2
+        assert len(info["missing_outer_splits"]) == 0
 
     def test_show_study_details_verbose(self, study_path, capsys):
         """Verify verbose mode prints ML type to stdout."""
@@ -617,6 +612,6 @@ class TestNotebookWorkflow:
         show_overall_fi_plot(fi_perm)
 
         # Cell: per-split FI access
-        for split_id in tpt_local.outersplits:
+        for split_id in tpt_local.outer_splits:
             split_fi = fi_perm[fi_perm["fi_source"] == split_id]
             assert len(split_fi) > 0

--- a/tests/study/test_core.py
+++ b/tests/study/test_core.py
@@ -32,19 +32,18 @@ def basic_study():
     """Create a basic OctoClassification instance."""
     with tempfile.TemporaryDirectory() as temp_dir:
         yield OctoClassification(
-            name="test_study",
+            study_name="test_study",
             target_metric="AUCROC",
             feature_cols=["feature1", "feature2", "feature3"],
             target_col="target",
             sample_id_col="sample_id_col",
-            path=temp_dir,
-            ignore_data_health_warning=True,
+            studies_directory=temp_dir,
         )
 
 
 def test_initialization(basic_study):
     """Test OctoStudy initialization."""
-    assert basic_study.name == "test_study"
+    assert basic_study.study_name == "test_study"
     assert basic_study.ml_type is None  # ml_type is determined during data validation
     assert basic_study.target_metric == "AUCROC"
     assert basic_study.feature_cols == ["feature1", "feature2", "feature3"]
@@ -56,12 +55,12 @@ def test_regression_ml_type():
     """Test that OctoRegression sets ml_type to regression."""
     with tempfile.TemporaryDirectory() as temp_dir:
         study = OctoRegression(
-            name="test",
+            study_name="test",
             target_metric="R2",
             feature_cols=["f1"],
             target_col="target",
             sample_id_col="id",
-            path=temp_dir,
+            studies_directory=temp_dir,
         )
         assert study.ml_type == MLType.REGRESSION
 
@@ -70,12 +69,12 @@ def test_default_workflow():
     """Test that default workflow is a single Octo task."""
     with tempfile.TemporaryDirectory() as temp_dir:
         study = OctoClassification(
-            name="test",
+            study_name="test",
             target_metric="AUCROC",
             feature_cols=["f1"],
             target_col="target",
             sample_id_col="id",
-            path=temp_dir,
+            studies_directory=temp_dir,
         )
         assert len(study.workflow) == 1
         assert isinstance(study.workflow[0], Octo)
@@ -86,20 +85,19 @@ def test_default_values():
     """Test default values are set correctly."""
     with tempfile.TemporaryDirectory() as temp_dir:
         study = OctoClassification(
-            name="test",
+            study_name="test",
             target_metric="AUCROC",
             feature_cols=["f1"],
             target_col="target",
             sample_id_col="id",
-            path=temp_dir,
+            studies_directory=temp_dir,
         )
         assert study.row_id_col is None
         assert study.stratification_col is None
         assert study.positive_class is None  # positive_class is determined during data validation
-        assert study.n_folds_outer == 5 if not _RUNNING_IN_TESTSUITE else 2
-        assert study.datasplit_seed_outer == 0
-        assert study.ignore_data_health_warning is False
-        assert study.run_single_outersplit_num is None
+        assert study.n_outer_splits == 5 if not _RUNNING_IN_TESTSUITE else 2
+        assert study.outer_split_seed == 0
+        assert study.single_outer_split is None
 
 
 def test_ml_type_values():
@@ -111,11 +109,11 @@ def test_ml_type_values():
     for expected_ml_type, study_class, metric, extra_kwargs in test_cases:
         with tempfile.TemporaryDirectory() as temp_dir:
             study = study_class(
-                name="test",
+                study_name="test",
                 target_metric=metric,
                 feature_cols=["f1"],
                 sample_id_col="id",
-                path=temp_dir,
+                studies_directory=temp_dir,
                 **extra_kwargs,
             )
             assert study.ml_type == expected_ml_type

--- a/tests/study/test_output.py
+++ b/tests/study/test_output.py
@@ -22,7 +22,7 @@ def test_output_path_has_correct_timestamp_format():
         study.fit(data=df)
 
         # The mocked datetime returns 2024-01-15 10:30:45
-        expected_name = f"{study.name}-20240115_103045"
+        expected_name = f"{study.study_name}-20240115_103045"
         assert study.output_path.name == expected_name
 
 

--- a/tests/study/test_prepared_data.py
+++ b/tests/study/test_prepared_data.py
@@ -46,8 +46,8 @@ def prepared_data(sample_data_with_types):
 
 
 def test_numerical_columns(prepared_data):
-    """Test num_features property with all allowed numeric types (int, float, bool)."""
-    numerical_cols = prepared_data.num_features
+    """Test numerical_features property with all allowed numeric types (int, float, bool)."""
+    numerical_cols = prepared_data.numerical_features
     assert isinstance(numerical_cols, list)
     assert "int_feature" in numerical_cols
     assert "float_feature" in numerical_cols
@@ -84,14 +84,14 @@ def test_categorical_ordinal_columns(prepared_data):
 def test_all_columns_covered(prepared_data):
     """Test that all feature columns are covered by the three property types."""
     all_typed_columns = (
-        prepared_data.num_features + prepared_data.cat_nominal_features + prepared_data.cat_ordinal_features
+        prepared_data.numerical_features + prepared_data.cat_nominal_features + prepared_data.cat_ordinal_features
     )
     assert set(all_typed_columns) == set(prepared_data.feature_cols)
 
 
 def test_no_overlap_between_column_types(prepared_data):
     """Test that column types don't overlap and sum equals total features."""
-    numerical = set(prepared_data.num_features)
+    numerical = set(prepared_data.numerical_features)
     nominal = set(prepared_data.cat_nominal_features)
     ordinal = set(prepared_data.cat_ordinal_features)
 
@@ -102,7 +102,7 @@ def test_no_overlap_between_column_types(prepared_data):
 
     # Check sum equals total features
     total_by_type = (
-        len(prepared_data.num_features)
+        len(prepared_data.numerical_features)
         + len(prepared_data.cat_nominal_features)
         + len(prepared_data.cat_ordinal_features)
     )

--- a/tests/study/test_validation.py
+++ b/tests/study/test_validation.py
@@ -4,9 +4,9 @@ import tempfile
 
 import pytest
 
-from octopus.modules import Mrmr, Octo
+from octopus.modules import Mrmr, Octo, Roc
 from octopus.study import OctoClassification
-from octopus.types import ModelName
+from octopus.types import ModelName, RelevanceMethod
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def mrmr_task():
 def base_study_kwargs():
     """Base kwargs for creating OctoClassification instances."""
     return {
-        "name": "test",
+        "study_name": "test",
         "target_metric": "AUCROC",
         "feature_cols": ["f1"],
         "target_col": "target",
@@ -66,11 +66,11 @@ class TestWorkflowValidation:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             if expected_exception is None:
-                study = OctoClassification(**base_study_kwargs, path=temp_dir, workflow=test_workflow)
+                study = OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=test_workflow)
                 assert study.workflow == test_workflow
             else:
                 with pytest.raises(expected_exception):
-                    OctoClassification(**base_study_kwargs, path=temp_dir, workflow=test_workflow)
+                    OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=test_workflow)
 
     def test_workflow_first_task_not_zero(self, base_study_kwargs):
         """Test that workflow validation fails when first task doesn't have task_id=0."""
@@ -79,7 +79,7 @@ class TestWorkflowValidation:
             tempfile.TemporaryDirectory() as temp_dir,
             pytest.raises(ValueError, match="The first task must have 'task_id=0'"),
         ):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_workflow_non_increasing_task_ids(self, base_study_kwargs):
         """Test that workflow validation fails when task_ids are not in increasing order."""
@@ -92,7 +92,7 @@ class TestWorkflowValidation:
             tempfile.TemporaryDirectory() as temp_dir,
             pytest.raises(ValueError, match="not greater than the previous 'task_id'"),
         ):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_workflow_missing_task_ids(self, base_study_kwargs):
         """Test that workflow validation fails when task_ids have gaps."""
@@ -101,7 +101,7 @@ class TestWorkflowValidation:
             Mrmr(task_id=2, depends_on=0),
         ]
         with tempfile.TemporaryDirectory() as temp_dir, pytest.raises(ValueError, match="Missing task_ids"):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_workflow_duplicate_task_ids(self, base_study_kwargs):
         """Test that workflow validation fails when there are duplicate task_ids."""
@@ -114,7 +114,7 @@ class TestWorkflowValidation:
             tempfile.TemporaryDirectory() as temp_dir,
             pytest.raises(ValueError, match="not greater than the previous 'task_id'"),
         ):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_workflow_depends_on_nonexistent_task(self, base_study_kwargs):
         """Test that workflow validation fails when depends_on references non-existent task."""
@@ -126,7 +126,7 @@ class TestWorkflowValidation:
             tempfile.TemporaryDirectory() as temp_dir,
             pytest.raises(ValueError, match="does not correspond to any 'task_id'"),
         ):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_workflow_depends_on_later_task(self, base_study_kwargs):
         """Test that workflow validation fails when depends_on references a later task."""
@@ -139,7 +139,7 @@ class TestWorkflowValidation:
             tempfile.TemporaryDirectory() as temp_dir,
             pytest.raises(ValueError, match="refers to an item that comes after it"),
         ):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_workflow_depends_on_minus_one_after_positive(self, base_study_kwargs):
         """Test that tasks with depends_on=None must be at the start."""
@@ -152,7 +152,7 @@ class TestWorkflowValidation:
             tempfile.TemporaryDirectory() as temp_dir,
             pytest.raises(ValueError, match="appears after items with 'depends_on' set"),
         ):
-            OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
 
     def test_valid_multi_task_workflow(self, base_study_kwargs):
         """Test a valid multi-task workflow."""
@@ -162,8 +162,54 @@ class TestWorkflowValidation:
             Octo(task_id=2, depends_on=1),
         ]
         with tempfile.TemporaryDirectory() as temp_dir:
-            study = OctoClassification(**base_study_kwargs, path=temp_dir, workflow=workflow)
+            study = OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
             assert len(study.workflow) == 3
             assert study.workflow[0].task_id == 0
             assert study.workflow[1].task_id == 1
             assert study.workflow[2].task_id == 2
+
+    def test_mrmr_permutation_depends_on_roc_fails(self, base_study_kwargs):
+        """Test that Mrmr with permutation relevance cannot depend on Roc."""
+        workflow = [
+            Roc(task_id=0, depends_on=None),
+            Mrmr(task_id=1, depends_on=0, relevance_method=RelevanceMethod.PERMUTATION),
+        ]
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            pytest.raises(ValueError, match="does not produce feature importances"),
+        ):
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
+
+    def test_mrmr_permutation_without_depends_on_fails(self, base_study_kwargs):
+        """Test that Mrmr with permutation relevance must have depends_on set."""
+        workflow = [
+            Mrmr(task_id=0, depends_on=None, relevance_method=RelevanceMethod.PERMUTATION),
+        ]
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            pytest.raises(ValueError, match="requires an upstream task"),
+        ):
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
+
+    def test_mrmr_permutation_depends_on_mrmr_fails(self, base_study_kwargs):
+        """Test that Mrmr with permutation relevance cannot depend on another Mrmr."""
+        workflow = [
+            Octo(task_id=0, depends_on=None),
+            Mrmr(task_id=1, depends_on=0),
+            Mrmr(task_id=2, depends_on=1, relevance_method=RelevanceMethod.PERMUTATION),
+        ]
+        with (
+            tempfile.TemporaryDirectory() as temp_dir,
+            pytest.raises(ValueError, match="does not produce feature importances"),
+        ):
+            OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
+
+    def test_mrmr_fstats_depends_on_roc_passes(self, base_study_kwargs):
+        """Test that Mrmr with f-statistics relevance can depend on Roc."""
+        workflow = [
+            Roc(task_id=0, depends_on=None),
+            Mrmr(task_id=1, depends_on=0, relevance_method=RelevanceMethod.F_STATISTICS),
+        ]
+        with tempfile.TemporaryDirectory() as temp_dir:
+            study = OctoClassification(**base_study_kwargs, studies_directory=temp_dir, workflow=workflow)
+            assert len(study.workflow) == 2

--- a/tests/test_datasplit.py
+++ b/tests/test_datasplit.py
@@ -16,7 +16,7 @@ from octopus.datasplit import (
     OuterSplits,
     validate_class_coverage,
 )
-from octopus.exceptions import SingleClassFoldError
+from octopus.exceptions import SingleClassSplitError
 
 
 def _grouped_df() -> pd.DataFrame:
@@ -43,16 +43,16 @@ def test_get_outer_splits_keeps_groups_together_and_covers_all_rows_once():
     splits = DataSplit(
         dataset=df,
         seeds=[7],
-        num_folds=2,
+        n_splits=2,
     ).get_outer_splits()
 
     assert len(splits) == 2
     assert all(isinstance(split, OuterSplit) for split in splits.values())
 
     all_test_rows = []
-    test_fold_by_row = {}
+    test_split_by_row = {}
 
-    for fold_id, split in splits.items():
+    for split_id, split in splits.items():
         train_groups = set(split.traindev[DATASPLIT_COL])
         test_groups = set(split.test[DATASPLIT_COL])
 
@@ -60,11 +60,11 @@ def test_get_outer_splits_keeps_groups_together_and_covers_all_rows_once():
 
         for row_id in split.test["row_id"]:
             all_test_rows.append(row_id)
-            test_fold_by_row[row_id] = fold_id
+            test_split_by_row[row_id] = split_id
 
     assert sorted(all_test_rows) == [10, 11, 20, 30, 31, 40]
-    assert test_fold_by_row[10] == test_fold_by_row[11]
-    assert test_fold_by_row[30] == test_fold_by_row[31]
+    assert test_split_by_row[10] == test_split_by_row[11]
+    assert test_split_by_row[30] == test_split_by_row[31]
 
 
 def test_get_inner_splits_keeps_groups_together_and_covers_all_rows_once():
@@ -74,7 +74,7 @@ def test_get_inner_splits_keeps_groups_together_and_covers_all_rows_once():
     splits = DataSplit(
         dataset=df,
         seeds=[7],
-        num_folds=2,
+        n_splits=2,
     ).get_inner_splits()
 
     assert len(splits) == 2
@@ -92,17 +92,17 @@ def test_get_inner_splits_keeps_groups_together_and_covers_all_rows_once():
     assert sorted(all_dev_rows) == [10, 11, 20, 30, 31, 40]
 
 
-def test_multiple_seeds_concatenate_seed_results_in_seed_then_fold_order():
-    """With multiple seeds, results are returned seed by seed, then fold by fold."""
+def test_multiple_seeds_concatenate_seed_results_in_seed_then_split_order():
+    """With multiple seeds, results are returned seed by seed, then split by split."""
     df = _grouped_df()
 
-    seed_11 = DataSplit(dataset=df.copy(), seeds=[11], num_folds=2).get_outer_splits()
-    seed_22 = DataSplit(dataset=df.copy(), seeds=[22], num_folds=2).get_outer_splits()
+    seed_11 = DataSplit(dataset=df.copy(), seeds=[11], n_splits=2).get_outer_splits()
+    seed_22 = DataSplit(dataset=df.copy(), seeds=[22], n_splits=2).get_outer_splits()
 
     combined = DataSplit(
         dataset=df.copy(),
         seeds=[11, 22],
-        num_folds=2,
+        n_splits=2,
     ).get_outer_splits()
 
     assert len(combined) == 4
@@ -117,16 +117,16 @@ def test_same_seed_is_deterministic_for_outer_splits():
     """Running the same seed twice should give the exact same partitions."""
     df = _grouped_df()
 
-    first = DataSplit(dataset=df.copy(), seeds=[123], num_folds=2).get_outer_splits()
-    second = DataSplit(dataset=df.copy(), seeds=[123], num_folds=2).get_outer_splits()
+    first = DataSplit(dataset=df.copy(), seeds=[123], n_splits=2).get_outer_splits()
+    second = DataSplit(dataset=df.copy(), seeds=[123], n_splits=2).get_outer_splits()
 
     for i in range(2):
         pdt.assert_frame_equal(_norm(first[i].traindev), _norm(second[i].traindev))
         pdt.assert_frame_equal(_norm(first[i].test), _norm(second[i].test))
 
 
-def test_stratified_splitting_preserves_class_presence_across_folds():
-    """In this balanced setup, each stratified test fold should include both classes."""
+def test_stratified_splitting_preserves_class_presence_across_splits():
+    """In this balanced setup, each stratified test split should include both classes."""
     df = pd.DataFrame(
         {
             "row_id": list(range(8)),
@@ -139,7 +139,7 @@ def test_stratified_splitting_preserves_class_presence_across_folds():
     splits = DataSplit(
         dataset=df,
         seeds=[0],
-        num_folds=4,
+        n_splits=4,
         stratification_col="target",
     ).get_outer_splits()
 
@@ -151,7 +151,7 @@ def test_stratified_splitting_preserves_class_presence_across_folds():
 
 
 def test_stratified_group_split_with_mixed_label_group_has_expected_target_counts():
-    """Regression test: seed 0 should yield the known stratified target counts per fold."""
+    """Regression test: seed 0 should yield the known stratified target counts per split."""
     df = pd.DataFrame(
         {
             "row_id": list(range(32)),
@@ -165,7 +165,7 @@ def test_stratified_group_split_with_mixed_label_group_has_expected_target_count
     splits = DataSplit(
         dataset=df,
         seeds=[0],
-        num_folds=2,
+        n_splits=2,
         stratification_col="target",
     ).get_outer_splits()
 
@@ -182,7 +182,7 @@ def test_datasplit_resets_input_index_in_place():
     splitter = DataSplit(
         dataset=df,
         seeds=[0],
-        num_folds=2,
+        n_splits=2,
     )
 
     assert splitter.dataset.index.tolist() == [0, 1, 2, 3, 4, 5]
@@ -203,12 +203,12 @@ def test_missing_datasplit_group_column_raises_key_error():
         DataSplit(
             dataset=df,
             seeds=[0],
-            num_folds=2,
+            n_splits=2,
         ).get_outer_splits()
 
 
-def test_num_folds_greater_than_number_of_groups_raises_value_error():
-    """KFold should reject a fold count larger than the number of groups."""
+def test_num_splits_greater_than_number_of_groups_raises_value_error():
+    """KFold should reject a split count larger than the number of groups."""
     df = pd.DataFrame(
         {
             "row_id": [0, 1],
@@ -222,7 +222,7 @@ def test_num_folds_greater_than_number_of_groups_raises_value_error():
         DataSplit(
             dataset=df,
             seeds=[0],
-            num_folds=3,
+            n_splits=3,
         ).get_outer_splits()
 
 
@@ -241,45 +241,45 @@ def test_stratified_split_warns_when_class_has_too_few_groups():
         splits = DataSplit(
             dataset=df,
             seeds=[0],
-            num_folds=2,
+            n_splits=2,
             stratification_col="target",
         ).get_outer_splits()
 
     assert len(splits) == 2
 
 
-def test_each_fold_traindev_plus_test_equals_all_rows():
-    """Within each fold, traindev + test must equal the full dataset."""
+def test_each_split_traindev_plus_test_equals_all_rows():
+    """Within each split, traindev + test must equal the full dataset."""
     df = _grouped_df()
 
     splits = DataSplit(
         dataset=df,
         seeds=[7],
-        num_folds=2,
+        n_splits=2,
     ).get_outer_splits()
 
     all_row_ids = sorted(df["row_id"].tolist())
 
     for split in splits.values():
-        fold_rows = sorted(split.traindev["row_id"].tolist() + split.test["row_id"].tolist())
-        assert fold_rows == all_row_ids
+        split_rows = sorted(split.traindev["row_id"].tolist() + split.test["row_id"].tolist())
+        assert split_rows == all_row_ids
 
 
-def test_each_fold_train_plus_dev_equals_all_rows_inner():
-    """Within each inner fold, train + dev must equal the full dataset."""
+def test_each_split_train_plus_dev_equals_all_rows_inner():
+    """Within each inner split, train + dev must equal the full dataset."""
     df = _grouped_df()
 
     splits = DataSplit(
         dataset=df,
         seeds=[7],
-        num_folds=2,
+        n_splits=2,
     ).get_inner_splits()
 
     all_row_ids = sorted(df["row_id"].tolist())
 
     for split in splits.values():
-        fold_rows = sorted(split.train["row_id"].tolist() + split.dev["row_id"].tolist())
-        assert fold_rows == all_row_ids
+        split_rows = sorted(split.train["row_id"].tolist() + split.dev["row_id"].tolist())
+        assert split_rows == all_row_ids
 
 
 def test_datasplit_does_not_corrupt_global_random_state():
@@ -297,7 +297,7 @@ def test_datasplit_does_not_corrupt_global_random_state():
     DataSplit(
         dataset=_grouped_df(),
         seeds=[42],
-        num_folds=2,
+        n_splits=2,
     ).get_outer_splits()
 
     random_after = random.random()
@@ -308,7 +308,7 @@ def test_datasplit_does_not_corrupt_global_random_state():
 
 
 def test_inner_splits_with_stratification_preserves_class_presence():
-    """Stratified inner splits should include both classes in each dev fold."""
+    """Stratified inner splits should include both classes in each dev split."""
     df = pd.DataFrame(
         {
             "row_id": list(range(8)),
@@ -321,7 +321,7 @@ def test_inner_splits_with_stratification_preserves_class_presence():
     splits = DataSplit(
         dataset=df,
         seeds=[0],
-        num_folds=4,
+        n_splits=4,
         stratification_col="target",
     ).get_inner_splits()
 
@@ -332,30 +332,30 @@ def test_inner_splits_with_stratification_preserves_class_presence():
         assert set(split.dev["target"]) == {0, 1}
 
 
-def test_single_fold_raises_value_error():
-    """num_folds=1 is rejected by sklearn KFold."""
+def test_single_split_raises_value_error():
+    """n_splits=1 is rejected by sklearn KFold."""
     df = _grouped_df()
 
     with pytest.raises(ValueError, match=r"k-fold.*n_splits=2 or more"):
         DataSplit(
             dataset=df,
             seeds=[0],
-            num_folds=1,
+            n_splits=1,
         ).get_outer_splits()
 
 
 def test_three_seeds_produce_correct_index_numbering():
-    """Three seeds x 2 folds -> 6 entries keyed 0..5 matching individual runs."""
+    """Three seeds x 2 splits -> 6 entries keyed 0..5 matching individual runs."""
     df = _grouped_df()
 
     individual = {}
     for seed in [10, 20, 30]:
-        individual[seed] = DataSplit(dataset=df.copy(), seeds=[seed], num_folds=2).get_outer_splits()
+        individual[seed] = DataSplit(dataset=df.copy(), seeds=[seed], n_splits=2).get_outer_splits()
 
     combined = DataSplit(
         dataset=df.copy(),
         seeds=[10, 20, 30],
-        num_folds=2,
+        n_splits=2,
     ).get_outer_splits()
 
     assert list(combined.keys()) == [0, 1, 2, 3, 4, 5]
@@ -379,8 +379,8 @@ def test_different_seeds_produce_different_splits():
         }
     )
 
-    splits_a = DataSplit(dataset=df.copy(), seeds=[0], num_folds=5).get_outer_splits()
-    splits_b = DataSplit(dataset=df.copy(), seeds=[999], num_folds=5).get_outer_splits()
+    splits_a = DataSplit(dataset=df.copy(), seeds=[0], n_splits=5).get_outer_splits()
+    splits_b = DataSplit(dataset=df.copy(), seeds=[999], n_splits=5).get_outer_splits()
 
     some_differ = False
     for i in range(5):
@@ -390,11 +390,11 @@ def test_different_seeds_produce_different_splits():
             some_differ = True
             break
 
-    assert some_differ, "Different seeds should produce at least one different fold"
+    assert some_differ, "Different seeds should produce at least one different split"
 
 
-def test_single_group_with_two_folds_raises_value_error():
-    """A dataset with only one group cannot be split into 2 folds."""
+def test_single_group_with_two_splits_raises_value_error():
+    """A dataset with only one group cannot be split into 2 splits."""
     df = pd.DataFrame(
         {
             "row_id": [0, 1, 2],
@@ -408,7 +408,7 @@ def test_single_group_with_two_folds_raises_value_error():
         DataSplit(
             dataset=df,
             seeds=[0],
-            num_folds=2,
+            n_splits=2,
         ).get_outer_splits()
 
 
@@ -425,14 +425,14 @@ def _unequal_groups_df() -> pd.DataFrame:
     )
 
 
-def test_unequal_group_sizes_balances_group_count_across_folds():
-    """With unequal group sizes, each fold gets the same number of groups."""
+def test_unequal_group_sizes_balances_group_count_across_splits():
+    """With unequal group sizes, each split gets the same number of groups."""
     df = _unequal_groups_df()
 
     splits = DataSplit(
         dataset=df,
         seeds=[0],
-        num_folds=2,
+        n_splits=2,
     ).get_outer_splits()
 
     for split in splits.values():
@@ -444,8 +444,8 @@ def test_unequal_group_sizes_balances_group_count_across_folds():
     assert test_group_counts == [2, 2]
 
 
-def test_validate_class_coverage_raises_on_single_class_outer_fold():
-    """validate_class_coverage raises SingleClassFoldError when an outer fold has one class."""
+def test_validate_class_coverage_raises_on_single_class_outer_split():
+    """validate_class_coverage raises SingleClassSplitError when an outer split has one class."""
     splits: OuterSplits = {
         0: OuterSplit(
             traindev=pd.DataFrame({"target": [0, 0, 1, 1], DATASPLIT_COL: [0, 0, 1, 1]}),
@@ -453,12 +453,12 @@ def test_validate_class_coverage_raises_on_single_class_outer_fold():
         ),
     }
 
-    with pytest.raises(SingleClassFoldError, match=r"Fold 0 test.*only class"):
+    with pytest.raises(SingleClassSplitError, match=r"Split 0 test.*only class"):
         validate_class_coverage(splits, "target")
 
 
-def test_validate_class_coverage_raises_on_single_class_inner_fold():
-    """validate_class_coverage raises SingleClassFoldError for inner splits too."""
+def test_validate_class_coverage_raises_on_single_class_inner_split():
+    """validate_class_coverage raises SingleClassSplitError for inner splits too."""
     splits: InnerSplits = {
         0: InnerSplit(
             train=pd.DataFrame({"target": [0, 0, 1, 1]}),
@@ -470,7 +470,7 @@ def test_validate_class_coverage_raises_on_single_class_inner_fold():
         ),
     }
 
-    with pytest.raises(SingleClassFoldError, match=r"Fold 1 train.*only class"):
+    with pytest.raises(SingleClassSplitError, match=r"Split 1 train.*only class"):
         validate_class_coverage(splits, "target")
 
 

--- a/tests/workflows/test_ag_workflows.py
+++ b/tests/workflows/test_ag_workflows.py
@@ -47,17 +47,16 @@ class TestAutogluonWorkflows:
     def test_full_classification_workflow(self):
         """Test the complete classification workflow execution."""
         study = OctoClassification(
-            name="test_classification_workflow",
+            study_name="test_classification_workflow",
             target_metric="ACCBAL",
             feature_cols=self.features,
             target_col="target",
             sample_id_col="index",
             stratification_col="target",
-            datasplit_seed_outer=1234,
-            n_folds_outer=5,
-            path=self.studies_path,
-            ignore_data_health_warning=True,
-            run_single_outersplit_num=0,
+            outer_split_seed=1234,
+            n_outer_splits=5,
+            studies_directory=self.studies_path,
+            single_outer_split=0,
             workflow=[
                 AutoGluon(
                     description="ag_test",
@@ -65,7 +64,6 @@ class TestAutogluonWorkflows:
                     depends_on=None,
                     presets=["medium_quality"],
                     time_limit=15,
-                    verbosity=0,
                 ),
             ],
         )
@@ -81,11 +79,11 @@ class TestAutogluonWorkflows:
         assert (study_path / "data_raw.parquet").exists(), "Data parquet should exist"
         assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet should exist"
 
-        # Verify outersplit and task output
-        outersplit_dir = study_path / "outersplit0"
-        assert outersplit_dir.exists(), "Outersplit directory should exist"
+        # Verify outer split and task output
+        outer_split_dir = study_path / "outersplit0"
+        assert outer_split_dir.exists(), "Outer split directory should exist"
 
-        task_dirs = [d for d in outersplit_dir.iterdir() if d.is_dir() and d.name.startswith("task")]
+        task_dirs = [d for d in outer_split_dir.iterdir() if d.is_dir() and d.name.startswith("task")]
         assert len(task_dirs) >= 1, "Should have at least 1 task directory"
 
         # Verify AutoGluon task artifacts
@@ -113,16 +111,15 @@ class TestAutogluonWorkflows:
         df_regression = df_regression.reset_index()
 
         study = OctoRegression(
-            name="test_regression_workflow",
+            study_name="test_regression_workflow",
             target_metric="MAE",
             feature_cols=feature_names,
             target_col="target",
             sample_id_col="index",
-            datasplit_seed_outer=1234,
-            n_folds_outer=2,
-            path=self.studies_path,
-            ignore_data_health_warning=True,
-            run_single_outersplit_num=0,
+            outer_split_seed=1234,
+            n_outer_splits=2,
+            studies_directory=self.studies_path,
+            single_outer_split=0,
             workflow=[
                 AutoGluon(
                     description="ag_regression_test",
@@ -130,7 +127,6 @@ class TestAutogluonWorkflows:
                     depends_on=None,
                     presets=["medium_quality"],
                     time_limit=15,
-                    verbosity=0,
                 ),
             ],
         )
@@ -146,11 +142,11 @@ class TestAutogluonWorkflows:
         assert (study_path / "data_raw.parquet").exists(), "Data parquet should exist"
         assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet should exist"
 
-        # Verify outersplit and task output
-        outersplit_dir = study_path / "outersplit0"
-        assert outersplit_dir.exists(), "Outersplit directory should exist"
+        # Verify outer split and task output
+        outer_split_dir = study_path / "outersplit0"
+        assert outer_split_dir.exists(), "Outer split directory should exist"
 
-        task_dirs = [d for d in outersplit_dir.iterdir() if d.is_dir() and d.name.startswith("task")]
+        task_dirs = [d for d in outer_split_dir.iterdir() if d.is_dir() and d.name.startswith("task")]
         assert len(task_dirs) >= 1, "Should have at least 1 task directory"
 
         # Verify AutoGluon task artifacts

--- a/tests/workflows/test_octo_classification.py
+++ b/tests/workflows/test_octo_classification.py
@@ -62,14 +62,13 @@ class TestOctoIntroClassification:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoClassification(
-                name="test_classification",
+                study_name="test_classification",
                 target_metric="ACCBAL",
                 feature_cols=features,
                 target_col="target",
                 sample_id_col="index",
                 stratification_col="target",
-                path=temp_dir,
-                ignore_data_health_warning=True,
+                studies_directory=temp_dir,
             )
 
             assert study.target_col == "target"
@@ -83,23 +82,22 @@ class TestOctoIntroClassification:
             description="step_1_octo",
             task_id=0,
             depends_on=None,
-            n_folds_inner=3,
+            n_inner_splits=3,
             models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-            optuna_seed=0,
-            n_optuna_startup_trials=5,
+            fi_methods=[FIComputeMethod.PERMUTATION],
+            n_startup_trials=5,
             n_trials=6,
             max_features=5,
             penalty_factor=1.0,
             ensemble_selection=True,
-            ensel_n_save_trials=5,
+            n_ensemble_candidates=5,
         )
 
         assert isinstance(octo_task, Octo)
         assert octo_task.task_id == 0
         assert octo_task.depends_on is None
         assert octo_task.description == "step_1_octo"
-        assert octo_task.n_folds_inner == 3
+        assert octo_task.n_inner_splits == 3
         assert octo_task.models is not None
         assert set(octo_task.models) == {ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier}
 
@@ -112,7 +110,7 @@ class TestOctoIntroClassification:
             depends_on=None,
             models=[model],
             n_trials=3,
-            n_folds_inner=3,
+            n_inner_splits=3,
         )
 
         assert octo_task.models == [model]
@@ -126,7 +124,7 @@ class TestOctoIntroClassification:
             depends_on=None,
             models=models,
             n_trials=5,
-            n_folds_inner=3,
+            n_inner_splits=3,
         )
         assert octo_task.models is not None
         assert set(octo_task.models) == set(models)
@@ -139,11 +137,11 @@ class TestOctoIntroClassification:
             task_id=0,
             depends_on=None,
             models=[ModelName.ExtraTreesClassifier],
-            fi_methods_bestbag=fi_methods,
+            fi_methods=fi_methods,
             n_trials=3,
         )
 
-        assert octo_task.fi_methods_bestbag == fi_methods
+        assert octo_task.fi_methods == fi_methods
 
     def test_ensemble_selection_configuration(self):
         """Test ensemble selection configuration."""
@@ -153,12 +151,12 @@ class TestOctoIntroClassification:
             depends_on=None,
             models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
             ensemble_selection=True,
-            ensel_n_save_trials=15,
+            n_ensemble_candidates=15,
             n_trials=5,
         )
 
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 15
+        assert octo_task.n_ensemble_candidates == 15
 
     def test_hyperparameter_optimization_configuration(self):
         """Test hyperparameter optimization configuration."""
@@ -167,15 +165,13 @@ class TestOctoIntroClassification:
             task_id=0,
             depends_on=None,
             models=[ModelName.ExtraTreesClassifier],
-            optuna_seed=42,
-            n_optuna_startup_trials=5,
+            n_startup_trials=5,
             n_trials=5,
             max_features=5,
             penalty_factor=1.5,
         )
 
-        assert octo_task.optuna_seed == 42
-        assert octo_task.n_optuna_startup_trials == 5
+        assert octo_task.n_startup_trials == 5
         assert octo_task.n_trials == 5
         assert octo_task.max_features == 5
         assert octo_task.penalty_factor == 1.5
@@ -187,33 +183,30 @@ class TestOctoIntroClassification:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoClassification(
-                name="test_octo_intro_execution",
+                study_name="test_octo_intro_execution",
                 target_metric="ACCBAL",
                 feature_cols=features,
                 target_col="target",
                 sample_id_col="index",
                 stratification_col="target",
-                datasplit_seed_outer=1,
-                n_folds_outer=2,
-                path=temp_dir,
-                ignore_data_health_warning=True,
+                outer_split_seed=1,
+                n_outer_splits=2,
+                studies_directory=temp_dir,
                 workflow=[
                     Octo(
                         description="step_1_octo",
                         task_id=0,
                         depends_on=None,
-                        n_folds_inner=3,
+                        n_inner_splits=3,
                         models=[ModelName.ExtraTreesClassifier],
-                        model_seed=0,
-                        max_outl=0,
-                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-                        optuna_seed=0,
-                        n_optuna_startup_trials=3,
+                        max_outliers=0,
+                        fi_methods=[FIComputeMethod.PERMUTATION],
+                        n_startup_trials=3,
                         n_trials=5,
                         max_features=5,
                         penalty_factor=1.0,
                         ensemble_selection=True,
-                        ensel_n_save_trials=5,
+                        n_ensemble_candidates=5,
                     )
                 ],
             )
@@ -232,7 +225,7 @@ class TestOctoIntroClassification:
 
             assert (study_path / "study_config.json").exists(), "Config JSON file should exist"
             assert (study_path / "study_meta.json").exists(), "Study meta JSON file should exist"
-            assert (study_path / "outersplit0").exists(), "Outersplit directory should exist"
+            assert (study_path / "outersplit0").exists(), "Outer split directory should exist"
 
             # Verify that the Octo step was executed by checking for task directories
             experiment_path = study_path / "outersplit0"
@@ -246,18 +239,16 @@ class TestOctoIntroClassification:
             description="step_1_octo",
             task_id=0,
             depends_on=None,
-            n_folds_inner=5,
+            n_inner_splits=5,
             models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
-            model_seed=0,
-            max_outl=0,
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-            optuna_seed=0,
-            n_optuna_startup_trials=10,
+            max_outliers=0,
+            fi_methods=[FIComputeMethod.PERMUTATION],
+            n_startup_trials=10,
             n_trials=5,
             max_features=5,
             penalty_factor=1.0,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         # Verify all parameters are set correctly
@@ -265,16 +256,14 @@ class TestOctoIntroClassification:
         assert octo_task.task_id == 0
         assert octo_task.depends_on is None
 
-        assert octo_task.n_folds_inner == 5
+        assert octo_task.n_inner_splits == 5
         assert octo_task.models is not None
         assert set(octo_task.models) == {ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier}
-        assert octo_task.model_seed == 0
-        assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
-        assert octo_task.optuna_seed == 0
-        assert octo_task.n_optuna_startup_trials == 10
+        assert octo_task.max_outliers == 0
+        assert octo_task.fi_methods == [FIComputeMethod.PERMUTATION]
+        assert octo_task.n_startup_trials == 10
         assert octo_task.n_trials == 5
         assert octo_task.max_features == 5
         assert octo_task.penalty_factor == 1.0
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10

--- a/tests/workflows/test_octo_multiclass.py
+++ b/tests/workflows/test_octo_multiclass.py
@@ -71,14 +71,13 @@ class TestOctoMulticlass:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoClassification(
-                name="test_multiclass",
+                study_name="test_multiclass",
                 target_metric="AUCROC_MACRO",
                 feature_cols=features,
                 target_col="target",
                 sample_id_col="index",
                 stratification_col="target",
-                path=temp_dir,
-                ignore_data_health_warning=True,
+                studies_directory=temp_dir,
             )
 
             assert study.target_col == "target"
@@ -92,16 +91,15 @@ class TestOctoMulticlass:
             description="step_1_octo_multiclass",
             task_id=0,
             depends_on=None,
-            n_folds_inner=5,
+            n_inner_splits=5,
             models=[
                 ModelName.ExtraTreesClassifier,
                 ModelName.RandomForestClassifier,
                 ModelName.XGBClassifier,
                 ModelName.CatBoostClassifier,
             ],
-            model_seed=0,
-            max_outl=0,
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
+            max_outliers=0,
+            fi_methods=[FIComputeMethod.PERMUTATION],
             n_trials=20,
         )
 
@@ -109,7 +107,7 @@ class TestOctoMulticlass:
         assert octo_task.task_id == 0
         assert octo_task.depends_on is None
         assert octo_task.description == "step_1_octo_multiclass"
-        assert octo_task.n_folds_inner == 5
+        assert octo_task.n_inner_splits == 5
         assert octo_task.models is not None
         assert set(octo_task.models) == {
             ModelName.ExtraTreesClassifier,
@@ -135,7 +133,7 @@ class TestOctoMulticlass:
             depends_on=None,
             models=[model],
             n_trials=5,
-            n_folds_inner=3,
+            n_inner_splits=3,
         )
 
         assert octo_task.models == [model]
@@ -154,7 +152,7 @@ class TestOctoMulticlass:
             depends_on=None,
             models=models,
             n_trials=10,
-            n_folds_inner=3,
+            n_inner_splits=3,
         )
         assert octo_task.models is not None
         assert set(octo_task.models) == set(models)
@@ -167,11 +165,11 @@ class TestOctoMulticlass:
             task_id=0,
             depends_on=None,
             models=[ModelName.ExtraTreesClassifier],
-            fi_methods_bestbag=fi_methods,
+            fi_methods=fi_methods,
             n_trials=5,
         )
 
-        assert octo_task.fi_methods_bestbag == fi_methods
+        assert octo_task.fi_methods == fi_methods
 
     def test_hyperparameter_optimization_configuration(self):
         """Test hyperparameter optimization configuration for multiclass."""
@@ -181,11 +179,11 @@ class TestOctoMulticlass:
             depends_on=None,
             models=[ModelName.ExtraTreesClassifier],
             n_trials=25,
-            n_folds_inner=5,
+            n_inner_splits=5,
         )
 
         assert octo_task.n_trials == 25
-        assert octo_task.n_folds_inner == 5
+        assert octo_task.n_inner_splits == 5
 
     @pytest.mark.slow
     def test_multiclass_workflow_actual_execution(self, wine_dataset):
@@ -194,27 +192,25 @@ class TestOctoMulticlass:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoClassification(
-                name="test_multiclass_execution",
+                study_name="test_multiclass_execution",
                 target_metric="AUCROC_MACRO",
                 feature_cols=features,
                 target_col="target",
                 sample_id_col="index",
                 stratification_col="target",
-                datasplit_seed_outer=1234,
-                n_folds_outer=2,
-                path=temp_dir,
-                ignore_data_health_warning=True,
-                run_single_outersplit_num=0,
+                outer_split_seed=1234,
+                n_outer_splits=2,
+                studies_directory=temp_dir,
+                single_outer_split=0,
                 workflow=[
                     Octo(
                         description="step_1_octo_multiclass",
                         task_id=0,
                         depends_on=None,
-                        n_folds_inner=3,
+                        n_inner_splits=3,
                         models=[ModelName.ExtraTreesClassifier],
-                        model_seed=0,
-                        max_outl=0,
-                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
+                        max_outliers=0,
+                        fi_methods=[FIComputeMethod.PERMUTATION],
                         n_trials=12,
                     )
                 ],
@@ -233,7 +229,7 @@ class TestOctoMulticlass:
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"
             assert (study_path / "study_config.json").exists(), "Config JSON file should exist"
             assert (study_path / "study_meta.json").exists(), "Study meta JSON file should exist"
-            assert (study_path / "outersplit0").exists(), "Outersplit directory should exist"
+            assert (study_path / "outersplit0").exists(), "Outer split directory should exist"
 
             # Verify that the Octo step was executed by checking for workflow directories
             experiment_path = study_path / "outersplit0"
@@ -249,16 +245,15 @@ class TestOctoMulticlass:
             description="step_1_octo_multiclass",
             task_id=0,
             depends_on=None,
-            n_folds_inner=5,
+            n_inner_splits=5,
             models=[
                 ModelName.ExtraTreesClassifier,
                 ModelName.RandomForestClassifier,
                 ModelName.XGBClassifier,
                 ModelName.CatBoostClassifier,
             ],
-            model_seed=0,
-            max_outl=0,
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
+            max_outliers=0,
+            fi_methods=[FIComputeMethod.PERMUTATION],
             n_trials=20,
         )
 
@@ -267,7 +262,7 @@ class TestOctoMulticlass:
         assert octo_task.task_id == 0
         assert octo_task.depends_on is None
 
-        assert octo_task.n_folds_inner == 5
+        assert octo_task.n_inner_splits == 5
         assert octo_task.models is not None
         assert set(octo_task.models) == {
             ModelName.ExtraTreesClassifier,
@@ -275,9 +270,8 @@ class TestOctoMulticlass:
             ModelName.XGBClassifier,
             ModelName.CatBoostClassifier,
         }
-        assert octo_task.model_seed == 0
-        assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
+        assert octo_task.max_outliers == 0
+        assert octo_task.fi_methods == [FIComputeMethod.PERMUTATION]
         assert octo_task.n_trials == 20
 
     def test_multiclass_target_metric_options(self):
@@ -287,14 +281,13 @@ class TestOctoMulticlass:
         for target_metric in target_metrics:
             with tempfile.TemporaryDirectory() as temp_dir:
                 study = OctoClassification(
-                    name=f"test_multiclass_{target_metric.lower()}",
+                    study_name=f"test_multiclass_{target_metric.lower()}",
                     target_metric=target_metric,
                     ml_type=MLType.BINARY,
                     feature_cols=["f1"],
                     target_col="target",
                     sample_id_col="index",
-                    path=temp_dir,
-                    ignore_data_health_warning=True,
+                    studies_directory=temp_dir,
                 )
 
                 assert study.target_metric == target_metric

--- a/tests/workflows/test_octo_regression.py
+++ b/tests/workflows/test_octo_regression.py
@@ -57,13 +57,12 @@ class TestOctoRegression:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoRegression(
-                name="test_regression",
+                study_name="test_regression",
                 target_metric="MAE",
                 feature_cols=features,
                 target_col="target",
                 sample_id_col="index",
-                path=temp_dir,
-                ignore_data_health_warning=True,
+                studies_directory=temp_dir,
             )
 
             assert study.target_col == "target"
@@ -87,7 +86,7 @@ class TestOctoRegression:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert isinstance(octo_task, Octo)
@@ -97,7 +96,7 @@ class TestOctoRegression:
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10
 
         expected_models = {
             ModelName.RandomForestRegressor,
@@ -131,14 +130,14 @@ class TestOctoRegression:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert octo_task.models == [model]
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10
 
     def test_multiple_models_configuration(self):
         """Test configuration with multiple models."""
@@ -151,7 +150,7 @@ class TestOctoRegression:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
         assert octo_task.models is not None
         assert set(octo_task.models) == set(models)
@@ -166,11 +165,11 @@ class TestOctoRegression:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10
 
     def test_hyperparameter_optimization_configuration(self):
         """Test hyperparameter optimization configuration."""
@@ -182,16 +181,14 @@ class TestOctoRegression:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
-            optuna_seed=42,
-            n_optuna_startup_trials=5,
+            n_ensemble_candidates=10,
+            n_startup_trials=5,
             penalty_factor=1.5,
         )
 
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
-        assert octo_task.optuna_seed == 42
-        assert octo_task.n_optuna_startup_trials == 5
+        assert octo_task.n_startup_trials == 5
         assert octo_task.penalty_factor == 1.5
 
     @pytest.mark.slow
@@ -201,16 +198,15 @@ class TestOctoRegression:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoRegression(
-                name="test_octo_regression_execution",
+                study_name="test_octo_regression_execution",
                 target_metric="MAE",
                 feature_cols=features,
                 target_col="target",
                 sample_id_col="index",
-                datasplit_seed_outer=1234,
-                n_folds_outer=2,
-                path=temp_dir,
-                ignore_data_health_warning=True,
-                run_single_outersplit_num=0,
+                outer_split_seed=1234,
+                n_outer_splits=2,
+                studies_directory=temp_dir,
+                single_outer_split=0,
                 workflow=[
                     Octo(
                         task_id=0,
@@ -220,10 +216,8 @@ class TestOctoRegression:
                         n_trials=12,
                         max_features=6,
                         ensemble_selection=True,
-                        ensel_n_save_trials=10,
-                        model_seed=0,
-                        optuna_seed=0,
-                        n_optuna_startup_trials=3,
+                        n_ensemble_candidates=10,
+                        n_startup_trials=3,
                         penalty_factor=1.0,
                     )
                 ],
@@ -242,7 +236,7 @@ class TestOctoRegression:
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"
             assert (study_path / "study_config.json").exists(), "Config JSON file should exist"
             assert (study_path / "study_meta.json").exists(), "Study meta JSON file should exist"
-            assert (study_path / "outersplit0").exists(), "Outersplit directory should exist"
+            assert (study_path / "outersplit0").exists(), "Outer split directory should exist"
 
             # Verify that the Octo step was executed by checking for workflow directories
             experiment_path = study_path / "outersplit0"
@@ -269,14 +263,12 @@ class TestOctoRegression:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
-            model_seed=0,
-            max_outl=0,
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-            optuna_seed=0,
-            n_optuna_startup_trials=10,
+            n_ensemble_candidates=10,
+            max_outliers=0,
+            fi_methods=[FIComputeMethod.PERMUTATION],
+            n_startup_trials=10,
             penalty_factor=1.0,
-            n_folds_inner=5,
+            n_inner_splits=5,
         )
 
         # Verify all parameters are set correctly
@@ -294,14 +286,12 @@ class TestOctoRegression:
         }
         assert octo_task.models is not None
         assert set(octo_task.models) == expected_models
-        assert octo_task.model_seed == 0
-        assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
-        assert octo_task.optuna_seed == 0
-        assert octo_task.n_optuna_startup_trials == 10
+        assert octo_task.max_outliers == 0
+        assert octo_task.fi_methods == [FIComputeMethod.PERMUTATION]
+        assert octo_task.n_startup_trials == 10
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.penalty_factor == 1.0
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
-        assert octo_task.n_folds_inner == 5
+        assert octo_task.n_ensemble_candidates == 10
+        assert octo_task.n_inner_splits == 5

--- a/tests/workflows/test_octo_t2e.py
+++ b/tests/workflows/test_octo_t2e.py
@@ -73,14 +73,13 @@ class TestOctoTimeToEvent:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoTimeToEvent(
-                name="test_t2e",
+                study_name="test_t2e",
                 target_metric="CI",
                 feature_cols=features,
                 duration_col="duration",
                 event_col="event",
                 sample_id_col="index",
-                path=temp_dir,
-                ignore_data_health_warning=True,
+                studies_directory=temp_dir,
             )
 
             assert study.duration_col == "duration"
@@ -99,7 +98,7 @@ class TestOctoTimeToEvent:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert isinstance(octo_task, Octo)
@@ -109,7 +108,7 @@ class TestOctoTimeToEvent:
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10
         assert octo_task.models == [ModelName.CatBoostCoxSurvival]
 
     @pytest.mark.parametrize("model_name", [ModelName.CatBoostCoxSurvival, ModelName.XGBoostCoxSurvival])
@@ -123,14 +122,14 @@ class TestOctoTimeToEvent:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert octo_task.models == [model_name]
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10
 
     def test_multi_model_configuration(self):
         """Test configuration with both survival models."""
@@ -142,7 +141,7 @@ class TestOctoTimeToEvent:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert octo_task.models is not None
@@ -160,11 +159,11 @@ class TestOctoTimeToEvent:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
+            n_ensemble_candidates=10,
         )
 
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
+        assert octo_task.n_ensemble_candidates == 10
 
     def test_hyperparameter_optimization_configuration(self):
         """Test hyperparameter optimization configuration."""
@@ -176,9 +175,8 @@ class TestOctoTimeToEvent:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
-            optuna_seed=42,
-            n_optuna_startup_trials=5,
+            n_ensemble_candidates=10,
+            n_startup_trials=5,
             penalty_factor=1.5,
         )
 
@@ -188,9 +186,8 @@ class TestOctoTimeToEvent:
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
-        assert octo_task.optuna_seed == 42
-        assert octo_task.n_optuna_startup_trials == 5
+        assert octo_task.n_ensemble_candidates == 10
+        assert octo_task.n_startup_trials == 5
         assert octo_task.penalty_factor == 1.5
 
     @pytest.mark.slow
@@ -200,17 +197,16 @@ class TestOctoTimeToEvent:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoTimeToEvent(
-                name="test_octo_t2e_execution",
+                study_name="test_octo_t2e_execution",
                 target_metric="CI",
                 feature_cols=features,
                 duration_col="duration",
                 event_col="event",
                 sample_id_col="index",
-                datasplit_seed_outer=1234,
-                n_folds_outer=2,
-                path=temp_dir,
-                ignore_data_health_warning=True,
-                run_single_outersplit_num=0,
+                outer_split_seed=1234,
+                n_outer_splits=2,
+                studies_directory=temp_dir,
+                single_outer_split=0,
                 workflow=[
                     Octo(
                         task_id=0,
@@ -220,11 +216,9 @@ class TestOctoTimeToEvent:
                         n_trials=12,
                         max_features=6,
                         ensemble_selection=True,
-                        ensel_n_save_trials=10,
-                        model_seed=0,
-                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-                        optuna_seed=0,
-                        n_optuna_startup_trials=3,
+                        n_ensemble_candidates=10,
+                        fi_methods=[FIComputeMethod.PERMUTATION],
+                        n_startup_trials=3,
                         penalty_factor=1.0,
                     )
                 ],
@@ -243,7 +237,7 @@ class TestOctoTimeToEvent:
             assert (study_path / "data_prepared.parquet").exists(), "Prepared data parquet file should exist"
             assert (study_path / "study_config.json").exists(), "Config JSON file should exist"
             assert (study_path / "study_meta.json").exists(), "Study meta JSON file should exist"
-            assert (study_path / "outersplit0").exists(), "Outersplit directory should exist"
+            assert (study_path / "outersplit0").exists(), "Outer split directory should exist"
 
             # Verify that the Octo step was executed by checking for workflow directories
             experiment_path = study_path / "outersplit0"
@@ -263,28 +257,24 @@ class TestOctoTimeToEvent:
             n_trials=12,
             max_features=6,
             ensemble_selection=True,
-            ensel_n_save_trials=10,
-            model_seed=0,
-            max_outl=0,
-            fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
-            optuna_seed=0,
-            n_optuna_startup_trials=10,
+            n_ensemble_candidates=10,
+            max_outliers=0,
+            fi_methods=[FIComputeMethod.PERMUTATION],
+            n_startup_trials=10,
             penalty_factor=1.0,
-            n_folds_inner=5,
+            n_inner_splits=5,
         )
 
         assert octo_task.task_id == 0
         assert octo_task.depends_on is None
         assert octo_task.description == "step_1"
         assert octo_task.models == [ModelName.CatBoostCoxSurvival]
-        assert octo_task.model_seed == 0
-        assert octo_task.max_outl == 0
-        assert octo_task.fi_methods_bestbag == [FIComputeMethod.PERMUTATION]
-        assert octo_task.optuna_seed == 0
-        assert octo_task.n_optuna_startup_trials == 10
+        assert octo_task.max_outliers == 0
+        assert octo_task.fi_methods == [FIComputeMethod.PERMUTATION]
+        assert octo_task.n_startup_trials == 10
         assert octo_task.n_trials == 12
         assert octo_task.max_features == 6
         assert octo_task.penalty_factor == 1.0
         assert octo_task.ensemble_selection is True
-        assert octo_task.ensel_n_save_trials == 10
-        assert octo_task.n_folds_inner == 5
+        assert octo_task.n_ensemble_candidates == 10
+        assert octo_task.n_inner_splits == 5

--- a/tests/workflows/test_roc_octo_roc_workflow.py
+++ b/tests/workflows/test_roc_octo_roc_workflow.py
@@ -9,7 +9,7 @@ from sklearn.datasets import make_classification
 
 from octopus.modules import Octo, Roc
 from octopus.study import OctoClassification
-from octopus.types import CorrelationType, FIComputeMethod, ModelName, ROCFilterMethod
+from octopus.types import CorrelationType, FIComputeMethod, ModelName, RelevanceMethod
 
 
 class TestRocOctoRocWorkflow:
@@ -58,28 +58,27 @@ class TestRocOctoRocWorkflow:
                 description="step_0_roc_initial",
                 task_id=0,
                 depends_on=None,
-                threshold=0.85,
+                correlation_threshold=0.85,
                 correlation_type=CorrelationType.SPEARMAN,
-                filter_type=ROCFilterMethod.F_STATISTICS,
+                relevance_method=RelevanceMethod.F_STATISTICS,
             ),
             Octo(
                 description="step_1_octo",
                 task_id=1,
                 depends_on=0,
-                n_folds_inner=3,
+                n_inner_splits=3,
                 models=[ModelName.ExtraTreesClassifier],
-                model_seed=0,
-                max_outl=0,
-                fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
+                max_outliers=0,
+                fi_methods=[FIComputeMethod.PERMUTATION],
                 n_trials=6,
             ),
             Roc(
                 description="step_2_roc_final",
                 task_id=2,
                 depends_on=1,
-                threshold=0.5,
+                correlation_threshold=0.5,
                 correlation_type=CorrelationType.SPEARMAN,
-                filter_type=ROCFilterMethod.MUTUAL_INFO,
+                relevance_method=RelevanceMethod.MUTUAL_INFO,
             ),
         ]
 
@@ -91,7 +90,7 @@ class TestRocOctoRocWorkflow:
         assert isinstance(first_roc, Roc)
         assert first_roc.task_id == 0
         assert first_roc.depends_on is None
-        assert first_roc.threshold == 0.85
+        assert first_roc.correlation_threshold == 0.85
         assert first_roc.description == "step_0_roc_initial"
 
         # Verify OCTO step
@@ -106,7 +105,7 @@ class TestRocOctoRocWorkflow:
         assert isinstance(second_roc, Roc)
         assert second_roc.task_id == 2
         assert second_roc.depends_on == 1
-        assert second_roc.threshold == 0.5
+        assert second_roc.correlation_threshold == 0.5
         assert second_roc.description == "step_2_roc_final"
 
     def test_octo_study_with_roc_octo_roc(self, sample_classification_dataset):
@@ -115,39 +114,37 @@ class TestRocOctoRocWorkflow:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoClassification(
-                name="test_roc_octo_roc",
+                study_name="test_roc_octo_roc",
                 target_metric="ACCBAL",
                 feature_cols=feature_names,
                 target_col="target",
                 sample_id_col="sample_id_col",
                 stratification_col="target",
-                path=temp_dir,
-                ignore_data_health_warning=True,
+                studies_directory=temp_dir,
                 workflow=[
                     Roc(
                         description="step_0_roc_initial",
                         task_id=0,
                         depends_on=None,
-                        threshold=0.85,
+                        correlation_threshold=0.85,
                         correlation_type=CorrelationType.SPEARMAN,
-                        filter_type=ROCFilterMethod.F_STATISTICS,
+                        relevance_method=RelevanceMethod.F_STATISTICS,
                     ),
                     Octo(
                         description="step_1_octo",
                         task_id=1,
                         depends_on=0,
-                        n_folds_inner=3,
+                        n_inner_splits=3,
                         models=[ModelName.ExtraTreesClassifier],
-                        model_seed=0,
                         n_trials=15,
                     ),
                     Roc(
                         description="step_2_roc_final",
                         task_id=2,
                         depends_on=1,
-                        threshold=0.5,
+                        correlation_threshold=0.5,
                         correlation_type=CorrelationType.SPEARMAN,
-                        filter_type=ROCFilterMethod.MUTUAL_INFO,
+                        relevance_method=RelevanceMethod.MUTUAL_INFO,
                     ),
                 ],
             )
@@ -157,9 +154,9 @@ class TestRocOctoRocWorkflow:
     def test_sequence_dependency_chain(self):
         """Test that the sequence dependency chain is correctly configured."""
         workflow = [
-            Roc(task_id=0, depends_on=None, threshold=0.85),
+            Roc(task_id=0, depends_on=None, correlation_threshold=0.85),
             Octo(task_id=1, depends_on=0, models=[ModelName.ExtraTreesClassifier], n_trials=6),
-            Roc(task_id=2, depends_on=1, threshold=0.5),
+            Roc(task_id=2, depends_on=1, correlation_threshold=0.5),
         ]
 
         # First step has no dependencies
@@ -175,47 +172,54 @@ class TestRocOctoRocWorkflow:
         for i, step in enumerate(workflow):
             assert step.task_id == i
 
-    def test_roc_threshold_configuration(self):
-        """Test that ROC thresholds are configured correctly in the sequence."""
-        first_roc = Roc(task_id=0, depends_on=None, threshold=0.85)
-        second_roc = Roc(task_id=2, depends_on=1, threshold=0.5)
+    def test_roc_correlation_threshold_configuration(self):
+        """Test that ROC correlation thresholds are configured correctly in the sequence."""
+        first_roc = Roc(task_id=0, depends_on=None, correlation_threshold=0.85)
+        second_roc = Roc(task_id=2, depends_on=1, correlation_threshold=0.5)
 
-        assert first_roc.threshold == 0.85
-        assert second_roc.threshold == 0.5
+        assert first_roc.correlation_threshold == 0.85
+        assert second_roc.correlation_threshold == 0.5
 
         # Verify that final ROC has more aggressive filtering
-        assert second_roc.threshold < first_roc.threshold
+        assert second_roc.correlation_threshold < first_roc.correlation_threshold
 
     @pytest.mark.parametrize("correlation_type", [CorrelationType.SPEARMAN, CorrelationType.RDC])
-    @pytest.mark.parametrize("filter_type", [ROCFilterMethod.F_STATISTICS, ROCFilterMethod.MUTUAL_INFO])
-    def test_roc_configuration_variations(self, correlation_type, filter_type):
-        """Test ROC configuration with different correlation and filter types."""
+    @pytest.mark.parametrize("relevance_method", [RelevanceMethod.F_STATISTICS, RelevanceMethod.MUTUAL_INFO])
+    def test_roc_configuration_variations(self, correlation_type, relevance_method):
+        """Test ROC configuration with different correlation and relevance method types."""
         first_roc = Roc(
-            task_id=0, depends_on=None, threshold=0.85, correlation_type=correlation_type, filter_type=filter_type
+            task_id=0,
+            depends_on=None,
+            correlation_threshold=0.85,
+            correlation_type=correlation_type,
+            relevance_method=relevance_method,
         )
         second_roc = Roc(
-            task_id=2, depends_on=1, threshold=0.5, correlation_type=correlation_type, filter_type=filter_type
+            task_id=2,
+            depends_on=1,
+            correlation_threshold=0.5,
+            correlation_type=correlation_type,
+            relevance_method=relevance_method,
         )
 
         assert first_roc.correlation_type == correlation_type
-        assert first_roc.filter_type == filter_type
+        assert first_roc.relevance_method == relevance_method
         assert second_roc.correlation_type == correlation_type
-        assert second_roc.filter_type == filter_type
+        assert second_roc.relevance_method == relevance_method
 
     def test_octo_configuration_in_sequence(self):
         """Test OCTO module configuration within the ROC-OCTO-ROC sequence."""
         workflow = [
-            Roc(task_id=0, depends_on=None, threshold=0.85),
+            Roc(task_id=0, depends_on=None, correlation_threshold=0.85),
             Octo(
                 task_id=1,
                 depends_on=0,
                 models=[ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier],
                 n_trials=10,
                 max_features=15,
-                n_folds_inner=5,
-                model_seed=42,
+                n_inner_splits=5,
             ),
-            Roc(task_id=2, depends_on=1, threshold=0.5),
+            Roc(task_id=2, depends_on=1, correlation_threshold=0.5),
         ]
 
         octo_step = workflow[1]
@@ -225,15 +229,14 @@ class TestRocOctoRocWorkflow:
         assert set(octo_step.models) == {ModelName.ExtraTreesClassifier, ModelName.RandomForestClassifier}
         assert octo_step.n_trials == 10
         assert octo_step.max_features == 15
-        assert octo_step.n_folds_inner == 5
-        assert octo_step.model_seed == 42
+        assert octo_step.n_inner_splits == 5
 
     def test_workflow_sequence_validation(self):
         """Test that the workflow sequence is properly validated."""
         workflow = [
-            Roc(task_id=0, depends_on=None, threshold=0.85),
+            Roc(task_id=0, depends_on=None, correlation_threshold=0.85),
             Octo(task_id=1, depends_on=0, models=[ModelName.ExtraTreesClassifier], n_trials=6),
-            Roc(task_id=2, depends_on=1, threshold=0.5),
+            Roc(task_id=2, depends_on=1, correlation_threshold=0.5),
         ]
 
         assert len(workflow) == 3
@@ -253,43 +256,41 @@ class TestRocOctoRocWorkflow:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             study = OctoClassification(
-                name="test_roc_octo_roc_execution",
+                study_name="test_roc_octo_roc_execution",
                 target_metric="ACCBAL",
                 feature_cols=feature_names,
                 target_col="target",
                 sample_id_col="sample_id_col",
                 stratification_col="target",
-                datasplit_seed_outer=1234,
-                n_folds_outer=2,
-                path=temp_dir,
-                ignore_data_health_warning=True,
-                run_single_outersplit_num=0,
+                outer_split_seed=1234,
+                n_outer_splits=2,
+                studies_directory=temp_dir,
+                single_outer_split=0,
                 workflow=[
                     Roc(
                         description="step_0_roc_initial",
                         task_id=0,
                         depends_on=None,
-                        threshold=0.9,
+                        correlation_threshold=0.9,
                         correlation_type=CorrelationType.SPEARMAN,
-                        filter_type=ROCFilterMethod.F_STATISTICS,
+                        relevance_method=RelevanceMethod.F_STATISTICS,
                     ),
                     Octo(
                         description="step_1_octo",
                         task_id=1,
                         depends_on=0,
-                        n_folds_inner=5,
+                        n_inner_splits=5,
                         models=[ModelName.ExtraTreesClassifier],
-                        model_seed=0,
                         n_trials=13,
-                        fi_methods_bestbag=[FIComputeMethod.PERMUTATION],
+                        fi_methods=[FIComputeMethod.PERMUTATION],
                     ),
                     Roc(
                         description="step_2_roc_final",
                         task_id=2,
                         depends_on=1,
-                        threshold=0.5,
+                        correlation_threshold=0.5,
                         correlation_type=CorrelationType.SPEARMAN,
-                        filter_type=ROCFilterMethod.F_STATISTICS,
+                        relevance_method=RelevanceMethod.F_STATISTICS,
                     ),
                 ],
             )


### PR DESCRIPTION
Fixes #375, #414.

## Simplifying user interface

**OctoStudy**

- Rename `name` to `study_name`
- Rename `path` to `study_path`
- Rename `n_folds_outer` to `n_outer_splits`
- Rename `datasplit_seed_outer` to `outer_split_seed`
- Rename `run_single_outersplit_num` to `single_outer_split`
- Remove `ignore_data_health_warning`; warnings are now logged instead of raising

**Octo**
Rename:
- `n_folds_inner` to `n_inner_splits`
- `datasplit_seeds_inner` to `inner_split_seeds`
- `max_outl` to `max_outliers`
- `fi_methods_bestbag` to `fi_methods`
- `n_optuna_startup_trials` to `n_startup_trials`
- `optuna_return` to `scoring_method 
    - Rename correspondign Enum `OptunaReturnType` to `ScoringMethod` (`ENSEMBLE` to `COMBINED` (avoids confusion with ensemble_selection))
- `mrmr_feature_numbers` to `mrmr_subset_siztes`

Removed fields (hardcoded):
- `model_seed`: always `0`
- `optuna_seed`: always `0`
- `penalty_factor`: always `1.0`
- `ensel_n_save_trials`: now auto-computed as `max(50, n_trials // 2)`



**Boruta**
- model: change type from `str` to `ModelName`
- rename `perc` to `threshold` and validate validate 0-100
- add validation `0 < alpha < 1`
- rename `cv` to `n_inner_splits` to be consistent with `Octo`

**AutoGluon**

Clean up logging
- remove `verbosity` parameter from AutoGluon
- hardcode `verbosity=0` in AutoGluon
- route python logging through octopus logging (like optuna)
- add log messages to Boruta
- keep `fit_strategy`, but add more details to documentation

**Mrmr**

- Rename `relevance_type` to `relevance_method`
- Remove `feature_importance_type` field (never read in core)
- Remove `MRMRFIAggregation` enum from types.py
- Update docstrings to clarify `feature_importance_method` only applies
  when `relevance_method="permutation"`
- remove redundant results_module from Mrmr, solves #414

**ROC**
- Merge `ROCFilterMethod` and `MRMRRelevance` into unified `RelevanceMethod` enum
  with values: F_STATISTICS, MUTUAL_INFO, PERMUTATION
- Rename `threshold` to `correlation_threshold`
- Rename `filter_type` to `relevance_method`

## Splits vs. Folds

The codebase inconsistently mixed two naming conventions:
- `outersplit` (no underscore) vs the standard `outer_split` (underscore-separated)
- `fold` terminology alongside `split` terminology for the same concept

### Changes

**Variable/parameter renames** (underscore-separated naming):
| Before | After |
|---|---|
| `outersplit_id` | `outer_split_id` |
| `outersplit_data` | `outer_split_data` |
| `n_outersplits` | `n_outer_splits` |
| `num_outersplits` | `num_outer_splits` |
| `run_single_outersplit` | `run_single_outer_split` |
| `SingleOutersplitStrategy` | `SingleOuterSplitStrategy` |
| `TaskOutersplitLoader`  | `TaskOuterSplitLoader` |



**Terminology renames** ("fold" → "split"):
| Before | After |
|---|---|
| `num_folds` | `num_splits` |
| `fold_id` / `fold_idx` | `split_id` / `split_idx` |
| `per_fold` | `per_split` |
| `num_bag_folds` | `num_bag_splits` |
| `SingleClassFoldError` | `SingleClassSplitError` |

## Counting things

Standardize variable naming to `n_` prefix for variables that count things and `numerical_` for variables referring to numerical data.

### Changes

**`num_` → `n_` for counts**

| Old name | New name | Scope |
|---|---|---|
| `num_cpus` | `n_cpus` | `OctoStudy`, manager, execution |
| `num_splits` | `n_splits` | `DataSplit`, modules |
| `num_bag_splits` | `n_bag_splits` | `AutoGluon` module |
| `num_workers` | `n_workers` | `ResourceConfig` |
| `num_outer_splits` | `n_outer_splits` | `ResourceConfig`, manager |
| `num_assigned_cpus` | `n_assigned_cpus` | modules, workflow runner |
| `num_cpus_user` | `n_cpus_user` | ray_parallel |
| `num_cpus_per_worker` | `n_cpus_per_worker` | ray_parallel, execution |
| `num_duplicates` | `n_duplicates` | healthChecker |
| `num_outl` | `n_outliers` | objective_optuna |
| `num_threads` | `n_threads` | TabularNN models |
| `num_split` | `split_idx` | DataSplit (loop variable) |
| `num_groups` | `n_groups` | DataSplit |

**`num_` → `numerical_` for numerical data type**

| Old name | New name | Scope |
|---|---|---|
| `num_features` | `numerical_features` | `PreparedData` |
| `num_cols` | `numerical_cols` | TabularNN models |
| `num_medians_` | `numerical_medians_` | TabularNN models |
| `X_num` | `X_numerical` | TabularNN models |


## Shorthand for feature importances

Shorten `feature_importance(s)` to `fi` in all variables

### Changes

| Before | After |
|---|---|
| `ModuleResult.feature_importances` | `ModuleResult.fi` |
| `Training.feature_importances` | `Training.fi` |
| `StudyDiagnostics.feature_importances` | `StudyDiagnostics.fi` |
| `ModelConfig.feature_method` | `ModelConfig.fi_method` |
| `Mrmr.feature_importance_method` | `Mrmr.fi_method` |
| `FeatureImportanceWithLogging` | `FIWithLogging` |
| `get_feature_importances_df()` | `get_fi_df()` |
| `calculate_feature_importances()` | `calculate_fi()` |
| `plot_feature_importance()` | `plot_fi()` |
| `load_feature_importances()` | `load_fi()` |

**Kept unchanged**:
- Filesystem: `feature_importances.parquet`, `combined_feature_importances.json`
