### PR TITLE
Fix autogluon feature importances

### DIFF
--- a/octopus/_optional/autogluon.py
+++ b/octopus/_optional/autogluon.py
@@ -11,10 +11,13 @@ try:
         log_loss,
         mcc,
         mean_absolute_error,
+        mean_squared_error,
         precision,
         r2,
         recall,
         roc_auc,
+        roc_auc_ovr,
+        roc_auc_ovr_weighted,
         root_mean_squared_error,
     )
     from autogluon.tabular import TabularPredictor
@@ -37,9 +40,12 @@ __all__ = [
     "log_loss",
     "mcc",
     "mean_absolute_error",
+    "mean_squared_error",
     "precision",
     "r2",
     "recall",
     "roc_auc",
+    "roc_auc_ovr",
+    "roc_auc_ovr_weighted",
     "root_mean_squared_error",
 ]

--- a/octopus/modules/autogluon/adapters.py
+++ b/octopus/modules/autogluon/adapters.py
@@ -1,0 +1,87 @@
+"""Sklearn-compatible inference wrappers around a fitted AutoGluon TabularPredictor.
+
+Persistence
+-----------
+`TabularPredictor` owns native artifacts that are not picklable. We override
+`__reduce__` to pickle only the AG store path so in-process pickling
+(`ModuleResult.save`, ray, multiprocessing) round-trips cheaply within a
+single study tree.
+
+Removing the on-disk AG store at `predictor.path` invalidates every wrapper
+that pickled against it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+
+from octopus._optional.autogluon import TabularPredictor
+
+
+def _load_sklearn_classifier(path: str) -> SklearnClassifier:
+    return SklearnClassifier(TabularPredictor.load(path))
+
+
+def _load_sklearn_regressor(path: str) -> SklearnRegressor:
+    return SklearnRegressor(TabularPredictor.load(path))
+
+
+class SklearnClassifier(BaseEstimator, ClassifierMixin):
+    """Sklearn classifier wrapper for an AutoGluon TabularPredictor.
+
+    Inference-only. Calling `fit()` raises NotImplementedError; the wrapped
+    predictor is already trained.
+
+    Pickling persists the AG store path, not the predictor itself. Unpickling
+    reads the predictor back via `TabularPredictor.load(path)`.
+    """
+
+    def __init__(self, predictor: TabularPredictor) -> None:
+        self.predictor = predictor
+        self.classes_ = np.asarray(self.predictor.class_labels)
+        self.n_classes_ = len(self.classes_)
+        self.feature_names_in_ = self.predictor.original_features
+        self.n_features_in_ = len(self.feature_names_in_)
+
+    def predict(self, x: Any) -> np.ndarray:
+        """Return hard class-label predictions as a numpy array."""
+        return np.asarray(self.predictor.predict(x, as_pandas=False))
+
+    def predict_proba(self, x: Any) -> np.ndarray:
+        """Return class-probability predictions of shape (n_samples, n_classes)."""
+        return np.asarray(self.predictor.predict_proba(x, as_pandas=False, as_multiclass=True))
+
+    def fit(self, x: Any, y: Any) -> None:
+        """Refuse to refit; the wrapped predictor is already trained."""
+        raise NotImplementedError("This classifier is already fitted. Only for inference use.")
+
+    def __reduce__(self) -> tuple[Any, tuple[str]]:
+        return (_load_sklearn_classifier, (self.predictor.path,))
+
+
+class SklearnRegressor(BaseEstimator, RegressorMixin):
+    """Sklearn regressor wrapper for an AutoGluon TabularPredictor.
+
+    Inference-only. Pickle round-trips through the AG on-disk store path; see
+    the module docstring for details.
+    """
+
+    def __init__(self, predictor: TabularPredictor) -> None:
+        self.predictor = predictor
+        self.feature_names_in_ = self.predictor.original_features
+        self.n_features_in_ = len(self.feature_names_in_)
+        self.n_outputs_ = 1
+
+    def predict(self, x: Any) -> np.ndarray:
+        """Return numeric predictions as a numpy array."""
+        return np.asarray(self.predictor.predict(x, as_pandas=False))
+
+    def fit(self, x: Any, y: Any) -> None:
+        """Refuse to refit; the wrapped predictor is already trained."""
+        raise NotImplementedError("This regressor is already fitted. Only for inference use.")
+
+    def __reduce__(self) -> tuple[Any, tuple[str]]:
+        return (_load_sklearn_regressor, (self.predictor.path,))

--- a/octopus/modules/autogluon/core.py
+++ b/octopus/modules/autogluon/core.py
@@ -20,17 +20,20 @@ from octopus._optional.autogluon import (
     log_loss,
     mcc,
     mean_absolute_error,
+    mean_squared_error,
     precision,
     r2,
     recall,
     roc_auc,
+    roc_auc_ovr,
+    roc_auc_ovr_weighted,
     root_mean_squared_error,
 )
 from octopus.logger import get_logger
 from octopus.metrics import Metrics
-from octopus.metrics.utils import get_score_from_model
+from octopus.metrics.utils import get_performance_from_model
 from octopus.modules import ModuleExecution, ModuleResult, StudyContext
-from octopus.types import DataPartition, FIResultLabel, LogGroup, MLType, ResultType
+from octopus.types import DataPartition, FIResultLabel, LogGroup, MLType, PredictionType, ResultType
 from octopus.utils import csv_save
 
 if TYPE_CHECKING:
@@ -88,21 +91,26 @@ class SklearnRegressor(BaseEstimator, RegressorMixin):
 
 # Mapping of Octopus metrics to AutoGluon metrics
 metrics_inventory_autogluon = {
-    "AUCROC": roc_auc,
     "ACC": accuracy,
     "ACCBAL": balanced_accuracy,
+    "ACCBAL_MC": balanced_accuracy,
     "AUCPR": average_precision,
+    "AUCROC": roc_auc,
+    "AUCROC_MACRO": roc_auc_ovr,
+    "AUCROC_WEIGHTED": roc_auc_ovr_weighted,
     "F1": f1,
     "LOGLOSS": log_loss,
     "MAE": mean_absolute_error,
     "MCC": mcc,
-    "MSE": root_mean_squared_error,
+    "MSE": mean_squared_error,
     "NEGBRIERSCORE": "brier_score_loss",
     "PRECISION": precision,
-    "RECALL": recall,
     "R2": r2,
+    "RECALL": recall,
     "RMSE": root_mean_squared_error,
 }
+
+_AG_INNER_SPLIT_ID = "autogluon"
 
 
 @define
@@ -118,11 +126,19 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         study_context: StudyContext,
         outer_split_id: int,
         results_dir: UPath,
+        scratch_dir: UPath,
         n_assigned_cpus: int,
         feature_groups: dict[str, list[str]],
+        prior_results: dict[str, pd.DataFrame],
         **kwargs,
     ) -> dict[ResultType, ModuleResult]:
         """Fit AutoGluon TabularPredictor."""
+        if study_context.ml_type == MLType.TIMETOEVENT:
+            raise ValueError(
+                "AutoGluon does not support time-to-event tasks. "
+                "Use the Octo module with CatBoostCoxSurvival or XGBoostCoxSurvival models."
+            )
+
         target_cols = list(study_context.target_assignments.values())
         row_id_col = study_context.row_id_col
 
@@ -157,6 +173,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             eval_metric=scoring_type,
             verbosity=0,
             log_to_file=False,
+            learner_kwargs={"cache_data": True},
         )
 
         # Log configuration summary
@@ -193,30 +210,24 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             print(predictor.model_failures(), file=text_file)
 
         # Save leaderboard and model info
-        self._save_leaderboard_info(predictor, ag_test_data, outer_split_id, results_dir)
+        self._save_leaderboard_info(predictor, outer_split_id, results_dir)
 
-        # Get raw results
-        raw_scores = self._get_scores(predictor, study_context, ag_train_data, ag_test_data, feature_cols, results_dir)
+        # Get raw results (predictions first — needed for dev scores)
         raw_predictions = self._get_predictions(
             predictor, study_context, ag_test_data, row_test, row_traindev, outer_split_id
         )
-        raw_fi = self._get_fi(predictor, ag_test_data, outer_split_id, feature_groups, results_dir)
-
-        # Build flat scores DataFrame
-        scores_rows = []
-        for key, value in raw_scores.items():
-            if isinstance(value, (int, float)):
-                scores_rows.append(
-                    {
-                        "result_type": ResultType.BEST,
-                        "metric": key,
-                        "partition": "combined",
-                        "aggregation": "single",
-                        "split": None,
-                        "value": value,
-                    }
-                )
-        scores = pd.DataFrame(scores_rows)
+        scores = self._get_scores(
+            predictor,
+            study_context,
+            ag_train_data,
+            ag_test_data,
+            feature_cols,
+            raw_predictions,
+            data_traindev,
+            data_test,
+            results_dir,
+        )
+        raw_fi = self._get_fi(predictor, ag_train_data, outer_split_id, feature_cols, feature_groups, results_dir)
 
         # Build flat predictions DataFrame
         pred_dfs = []
@@ -231,18 +242,11 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         fi_dfs = []
         for _fi_key, fi_df in raw_fi.items():
             if isinstance(fi_df, pd.DataFrame) and not fi_df.empty:
-                temp = fi_df.reset_index() if fi_df.index.name is not None else fi_df.copy()
-                if "feature" not in temp.columns and temp.index.name is None:
-                    temp = temp.reset_index()
-                    temp.columns = ["feature", "importance", *list(temp.columns[2:])]
-                temp = (
-                    temp[["feature", "importance"]].copy()
-                    if "feature" in temp.columns and "importance" in temp.columns
-                    else temp
-                )
+                temp = fi_df[["importance"]].reset_index()
+                temp.columns = ["feature", "importance"]
                 temp["fi_method"] = FIResultLabel.PERMUTATION
-                temp["fi_dataset"] = DataPartition.TEST
-                temp["training_id"] = "autogluon"
+                temp["fi_dataset"] = DataPartition.DEV
+                temp["training_id"] = "mean"
                 temp["result_type"] = ResultType.BEST
                 fi_dfs.append(temp)
         fi_df = pd.concat(fi_dfs, ignore_index=True) if fi_dfs else pd.DataFrame()
@@ -271,68 +275,119 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
     def _get_fi(
         self,
         model: TabularPredictor,
-        ag_test_data: pd.DataFrame,
+        ag_train_data: pd.DataFrame,
         outer_split_id: int,
+        feature_cols: list[str],
         feature_groups: dict[str, list[str]],
         results_dir: UPath,
     ) -> dict[str, pd.DataFrame]:
-        """Calculate feature importances using AutoGluon's permutation importance."""
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
-        logger.info("Calculating test permutation feature importances...")
+        """Calculate feature importances using OOF or traindev permutation importance.
 
-        fi: dict[str, pd.DataFrame] = {}
+        Attempts OOF (out-of-fold) FI via the best level-1 bagged model,
+        which provides truly unbiased importance scores on original features.
+        Falls back to permutation FI on traindev data if OOF is unavailable.
+
+        Args:
+            model: Fitted AutoGluon TabularPredictor.
+            ag_train_data: Training data (traindev split) for fallback FI.
+            outer_split_id: Outer split index for logging.
+            feature_cols: Original feature column names for safety check.
+            feature_groups: Feature groups (logged as unsupported, not used).
+            results_dir: Directory to save diagnostic output.
+
+        Returns:
+            Dict with single key mapping to the FI DataFrame.
+        """
+        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
+
+        if feature_groups:
+            logger.info(
+                "Group feature importances not supported for AutoGluon — "
+                "only individual feature importances will be computed."
+            )
+
         np.random.seed(42)
 
-        # AutoGluon permutation feature importances
-        fi["autogluon_permutation_test"] = model.feature_importance(
-            data=ag_test_data,
-            subsample_size=5000,
-            time_limit=None,
-            include_confidence_band=True,
-            confidence_level=0.95,
-            num_shuffle_sets=15,
-            silent=True,
-        )
+        fi_df = self._compute_oof_fi(model, feature_cols)
 
-        # Calculate group feature importances if feature_groups provided
-        if feature_groups:
-            group_importances = {}
-            for group_name, features in feature_groups.items():
-                group_importance = model.feature_importance(
-                    data=ag_test_data,
-                    features=[(group_name, features)],
-                    subsample_size=5000,
-                    time_limit=None,
-                    include_confidence_band=True,
-                    confidence_level=0.95,
-                    num_shuffle_sets=15,
-                    silent=True,
-                )
-                group_importances[group_name] = group_importance
+        if fi_df is None:
+            logger.info("Computing permutation FI on traindev data (fallback)...")
+            fi_df = model.feature_importance(
+                data=ag_train_data,
+                feature_stage="original",
+                subsample_size=5000,
+                time_limit=None,
+                include_confidence_band=True,
+                confidence_level=0.95,
+                num_shuffle_sets=15,
+                silent=True,
+            )
 
-            # Combine feature and group importances
-            combined_fi = [fi["autogluon_permutation_test"]]
+        fi_df = fi_df.sort_values(by="importance", ascending=False)
 
-            for group_name, importance in group_importances.items():
-                group_row = importance.copy()
-                group_row.index = [f"{group_name}"] * len(group_row)
-                combined_fi.append(group_row)
+        with (results_dir / "feature_importances_raw.json").open("w", encoding="utf-8") as f:
+            json.dump(fi_df.to_dict(orient="index"), f, indent=4)
 
-            fi["autogluon_permutation_test"] = pd.concat(combined_fi)
+        return {"autogluon_permutation_dev": fi_df}
 
-        fi["autogluon_permutation_test"] = fi["autogluon_permutation_test"].sort_values(
-            by="importance", ascending=False
-        )
+    def _compute_oof_fi(
+        self,
+        model: TabularPredictor,
+        feature_cols: list[str],
+    ) -> pd.DataFrame | None:
+        """Compute OOF feature importance via the best level-1 bagged model.
 
-        # Save combined importances
-        combined_importances = {
-            "autogluon_permutation": fi["autogluon_permutation_test"].to_dict(orient="index"),
-        }
+        Returns None if OOF FI is unavailable (no L1 models, feature mismatch,
+        or any error), signalling the caller to use the traindev fallback.
 
-        with (results_dir / "combined_feature_importances.json").open("w", encoding="utf-8") as f:
-            json.dump(combined_importances, f, indent=4)
+        Args:
+            model: Fitted AutoGluon TabularPredictor (must have cache_data=True).
+            feature_cols: Original feature column names for validation.
 
-        return fi
+        Returns:
+            FI DataFrame indexed by feature name, or None on failure.
+        """
+        l1_models = model.model_names(level=1)
+        if not l1_models:
+            logger.info("No level-1 models found — cannot compute OOF FI.")
+            return None
+
+        leaderboard = model.leaderboard(silent=True)
+        l1_leaderboard = leaderboard[leaderboard["model"].isin(l1_models)]
+        if l1_leaderboard.empty:
+            logger.info("No level-1 models in leaderboard — cannot compute OOF FI.")
+            return None
+
+        best_l1 = l1_leaderboard.iloc[0]["model"]
+        logger.info("Computing OOF permutation FI via L1 model: %s", best_l1)
+
+        try:
+            fi_df: pd.DataFrame = model.feature_importance(
+                data=None,
+                model=best_l1,
+                feature_stage="transformed_model",
+                subsample_size=5000,
+                time_limit=None,
+                include_confidence_band=True,
+                confidence_level=0.95,
+                num_shuffle_sets=15,
+                silent=True,
+            )
+        except Exception:
+            logger.warning("OOF FI failed — falling back to traindev FI", exc_info=True)
+            return None
+
+        fi_features = set(fi_df.index)
+        original_features = set(feature_cols)
+        if not fi_features <= original_features:
+            unexpected = fi_features - original_features
+            logger.warning(
+                "OOF FI returned unexpected features %s — falling back to traindev FI",
+                unexpected,
+            )
+            return None
+
+        return fi_df
 
     def _get_scores(
         self,
@@ -341,69 +396,155 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         ag_train_data: pd.DataFrame,
         ag_test_data: pd.DataFrame,
         feature_cols: list[str],
+        raw_predictions: dict[str, pd.DataFrame],
+        data_traindev: pd.DataFrame,
+        data_test: pd.DataFrame,
         results_dir: UPath,
-    ) -> dict[str, Any]:
-        """Calculate performance scores on train/dev/test sets."""
-        # Test performance
-        test_performance = model.evaluate(ag_test_data, detailed_report=True, silent=True)
-        test_performance_with_suffix = {f"{key}_test": value for key, value in test_performance.items()}
+    ) -> pd.DataFrame:
+        """Calculate performance scores on dev and test sets using octopus metrics.
 
-        # Dev performance from leaderboard
-        leaderboard = model.leaderboard(silent=True)
-        best_model_info = leaderboard.iloc[0].to_dict()
-        dev_performance = {key: value for key, value in best_model_info.items() if "val" in key or "score" in key}
-        dev_performance_with_suffix = {f"{key}_dev": value for key, value in dev_performance.items()}
+        Dev scores are computed from OOF predictions joined with traindev targets.
+        Test scores are computed via model prediction on test data.
+        AG-native metrics are saved separately for diagnostics.
 
-        # Train performance
-        train_performance = model.evaluate(ag_train_data, detailed_report=True, silent=True)
-        train_performance_with_suffix = {f"{key}_train": value for key, value in train_performance.items()}
+        Args:
+            model: Fitted AutoGluon TabularPredictor.
+            study_context: Study configuration and metadata.
+            ag_train_data: Training data (features + target) for AG diagnostics.
+            ag_test_data: Test data (features + target) for AG diagnostics.
+            feature_cols: Feature column names.
+            raw_predictions: Dict with "dev" and "test" prediction DataFrames.
+            data_traindev: Original traindev data (with row_id and target cols).
+            data_test: Original test data (with row_id and target cols).
+            results_dir: Directory to save diagnostic output.
 
-        # Test scores using Octopus metrics for comparison
-        assert study_context.target_metric is not None, "target_metric should be set during fit()"
-        all_metrics = Metrics.get_by_type(study_context.ml_type)
-        test_performance_octo = {}
-        for metric in all_metrics:
-            assert feature_cols is not None, "feature_cols should be set during fit()"
-            assert metric is not None, "metric should not be None"
-            performance = get_score_from_model(
+        Returns:
+            Scores DataFrame with columns: result_type, metric, partition,
+            aggregation, split, value.
+        """
+        self._save_ag_diagnostics(model, ag_train_data, ag_test_data, results_dir)
+
+        all_metric_names = Metrics.get_by_type(study_context.ml_type)
+        target_col = list(study_context.target_assignments.values())[0]
+        row_id_col = study_context.row_id_col
+
+        dev_pred = raw_predictions["dev"]
+        dev_with_target = dev_pred.merge(data_traindev[[row_id_col, target_col]], on=row_id_col)
+
+        rows = []
+        for metric_name in all_metric_names:
+            dev_value = self._compute_metric_from_predictions(
+                metric_name,
+                dev_with_target,
+                target_col,
+                study_context,
+            )
+            rows.append(
+                {
+                    "result_type": ResultType.BEST,
+                    "metric": metric_name,
+                    "partition": DataPartition.DEV,
+                    "aggregation": "ensemble",
+                    "split": None,
+                    "value": dev_value,
+                }
+            )
+
+            test_value = get_performance_from_model(
                 model,
                 ag_test_data,
                 feature_cols,
-                metric,
+                metric_name,
                 study_context.target_assignments,
                 positive_class=study_context.positive_class,
             )
-            test_performance_octo[metric + "_test_octo"] = performance
+            rows.append(
+                {
+                    "result_type": ResultType.BEST,
+                    "metric": metric_name,
+                    "partition": DataPartition.TEST,
+                    "aggregation": "ensemble",
+                    "split": None,
+                    "value": test_value,
+                }
+            )
 
-        # Combine all performance metrics
-        combined_performance = {
-            **dev_performance_with_suffix,
-            **train_performance_with_suffix,
-            **test_performance_with_suffix,
-            **test_performance_octo,
+        return pd.DataFrame(rows)
+
+    @staticmethod
+    def _compute_metric_from_predictions(
+        metric_name: str,
+        pred_df: pd.DataFrame,
+        target_col: str,
+        study_context: StudyContext,
+    ) -> float:
+        """Compute a single octopus metric from a predictions DataFrame.
+
+        Args:
+            metric_name: Registered metric name (e.g. "ACCBAL").
+            pred_df: DataFrame with target column and prediction/probability columns.
+            target_col: Name of the target column.
+            study_context: Study context for positive_class and ml_type.
+
+        Returns:
+            Metric value as float.
+        """
+        metric = Metrics.get_instance(metric_name)
+        target = pred_df[target_col]
+        positive_class = study_context.positive_class
+
+        if positive_class is not None and metric.supports_ml_type(MLType.BINARY):
+            probabilities = pred_df[positive_class]
+            if metric.prediction_type == PredictionType.PROBABILITIES:
+                return metric.calculate(target, probabilities)
+            predictions = (probabilities >= 0.5).astype(int)
+            return metric.calculate(target, predictions)
+
+        if metric.supports_ml_type(MLType.MULTICLASS) and positive_class is None:
+            if metric.prediction_type == PredictionType.PROBABILITIES:
+                prob_columns = sorted(c for c in pred_df.columns if isinstance(c, int))
+                prob_matrix = pred_df[prob_columns].to_numpy()
+                return metric.calculate(target, prob_matrix)
+            predictions = pred_df["prediction"].astype(int)
+            return metric.calculate(target, predictions)
+
+        if metric.supports_ml_type(MLType.REGRESSION):
+            predictions = pred_df["prediction"]
+            return metric.calculate(target, predictions)
+
+        raise ValueError(f"Cannot compute metric '{metric_name}' for ml_type={study_context.ml_type}")
+
+    @staticmethod
+    def _save_ag_diagnostics(
+        model: TabularPredictor,
+        ag_train_data: pd.DataFrame,
+        ag_test_data: pd.DataFrame,
+        results_dir: UPath,
+    ) -> None:
+        """Save AG-native performance metrics for diagnostics only."""
+        test_performance = model.evaluate(ag_test_data, detailed_report=True, silent=True)
+        leaderboard = model.leaderboard(silent=True)
+        best_model_info = leaderboard.iloc[0].to_dict()
+        train_performance = model.evaluate(ag_train_data, detailed_report=True, silent=True)
+
+        diagnostics: dict[str, Any] = {
+            "ag_test": {k: v for k, v in test_performance.items() if isinstance(v, (int, float))},
+            "ag_train": {k: v for k, v in train_performance.items() if isinstance(v, (int, float))},
+            "ag_best_model": {k: v for k, v in best_model_info.items() if isinstance(v, (int, float, str))},
         }
 
-        # Save performance results
-        if isinstance(combined_performance, dict):
-            for key, value in combined_performance.items():
-                if isinstance(value, pd.DataFrame):
-                    combined_performance[key] = value.to_dict(orient="records")
-
         with (results_dir / "performance_results.json").open("w", encoding="utf-8") as f:
-            json.dump(combined_performance, f, indent=4)
-
-        return combined_performance
+            json.dump(diagnostics, f, indent=4, default=str)
 
     def _save_leaderboard_info(
         self,
         model: TabularPredictor,
-        ag_test_data: pd.DataFrame,
         outer_split_id: int,
         results_dir: UPath,
     ) -> None:
         """Save AutoGluon leaderboard and model information."""
-        # Save leaderboard
-        leaderboard = model.leaderboard(ag_test_data, extra_info=True, silent=True)
+        # Save leaderboard (without test data — diagnostic only, uses AG internal val scores)
+        leaderboard = model.leaderboard(extra_info=True, silent=True)
         leaderboard_path = results_dir / "leaderboard.csv"
         csv_save(leaderboard, leaderboard_path)
 
@@ -440,7 +581,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
 
         # Metadata for all predictions (AutoGluon doesn't use inner splits)
         task_id = self.config.task_id
-        inner_split_id = "autogluon"  # AutoGluon doesn't have inner CV splits
+        inner_split_id = _AG_INNER_SPLIT_ID
 
         # Test predictions
         rowid_test = pd.DataFrame({row_column: row_test})
@@ -452,6 +593,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             test_pred = model.predict_proba(ag_test_data)
             class_labels = model.class_labels
             test_pred.columns = class_labels
+            test_pred["prediction"] = test_pred[class_labels].values.argmax(axis=1)
         else:
             raise ValueError(f"Unsupported problem type: {problem_type}")
 
@@ -463,7 +605,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         # Add metadata
         test_df["outer_split_id"] = outer_split_id
         test_df["inner_split_id"] = inner_split_id
-        test_df["partition"] = "test"
+        test_df["partition"] = DataPartition.TEST
         test_df["task_id"] = task_id
         predictions["test"] = test_df
 
@@ -477,6 +619,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             oof_pred = model.predict_proba_oof(model=best_model_name)
             class_labels = model.class_labels
             oof_pred.columns = class_labels
+            oof_pred["prediction"] = oof_pred[class_labels].values.argmax(axis=1)
         else:
             raise ValueError(f"Unsupported problem type: {problem_type}")
 
@@ -488,7 +631,7 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         # Add metadata
         dev_df["outer_split_id"] = outer_split_id
         dev_df["inner_split_id"] = inner_split_id
-        dev_df["partition"] = "dev"
+        dev_df["partition"] = DataPartition.DEV
         dev_df["task_id"] = task_id
         predictions["dev"] = dev_df
 

--- a/octopus/modules/autogluon/core.py
+++ b/octopus/modules/autogluon/core.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
-import numpy as np
 import pandas as pd
 from attrs import define
-from sklearn.base import BaseEstimator, ClassifierMixin, RegressorMixin
+from sklearn.base import BaseEstimator
 from upath import UPath
 
 from octopus._optional.autogluon import (
@@ -32,69 +30,20 @@ from octopus._optional.autogluon import (
 )
 from octopus.logger import get_logger
 from octopus.metrics import Metrics
-from octopus.metrics.utils import get_score_from_model
+from octopus.metrics.utils import get_performance_from_predictions
 from octopus.modules import ModuleExecution, ModuleResult, StudyContext
+from octopus.modules.autogluon.adapters import SklearnClassifier, SklearnRegressor
+from octopus.modules.autogluon.feature_importance import compute_fi
+from octopus.modules.autogluon.predictions import build_predictions
 from octopus.types import DataPartition, FIResultLabel, LogGroup, MLType, ResultType
-from octopus.utils import csv_save
 
 if TYPE_CHECKING:
-    from octopus.modules import (
-        AutoGluon,  # noqa: F401
-        StudyContext,
-    )
+    from octopus.modules import AutoGluon  # noqa: F401
 
 logger = get_logger()
 
 
-class SklearnClassifier(BaseEstimator, ClassifierMixin):
-    """Sklearn classifier wrapper for AutoGluon predictor."""
-
-    def __init__(self, predictor: TabularPredictor):
-        self.predictor = predictor
-        self.classes_ = self.predictor.class_labels
-        self.n_classes_ = len(self.classes_)
-        self.feature_names_in_ = self.predictor.original_features
-        self.n_features_in_ = len(self.feature_names_in_)
-        self._is_fitted = True
-
-    def predict(self, x):
-        """Predict class labels."""
-        return self.predictor.predict(x, as_pandas=False)
-
-    def predict_proba(self, x):
-        """Predict class probabilities."""
-        probabilities = self.predictor.predict_proba(x, as_pandas=False, as_multiclass=True)
-        return probabilities
-
-    def fit(self, x, y):
-        """Fit method - not implemented as predictor is already fitted."""
-        raise NotImplementedError("This classifier is already fitted. Only for inference use.")
-
-
-class SklearnRegressor(BaseEstimator, RegressorMixin):
-    """Sklearn regressor wrapper for AutoGluon predictor."""
-
-    def __init__(self, predictor: TabularPredictor):
-        self.predictor = predictor
-        self.feature_names_in_ = self.predictor.original_features
-        self.n_features_in_ = len(self.feature_names_in_)
-        self.n_outputs_ = 1
-        self._is_fitted = True
-
-    def predict(self, x):
-        """Predict target values."""
-        return self.predictor.predict(x, as_pandas=False)
-
-    def fit(self, x, y):
-        """Fit method - not implemented as predictor is already fitted."""
-        raise NotImplementedError("This regressor is already fitted. Only for inference use.")
-
-
-# Mapping of Octopus metric name -> AutoGluon scorer.
-# Validity per ml_type is enforced upstream by Metrics.get_by_type(); this dict
-# assumes the caller has already chosen a metric supported by their ml_type
-# (e.g. AUCROC is binary-only and will error if used for multiclass).
-metrics_inventory_autogluon = {
+_AG_METRIC_MAP: Final[dict[str, Any]] = {
     "ACC": accuracy,
     "ACCBAL": balanced_accuracy,
     "ACCBAL_MC": balanced_accuracy,
@@ -132,57 +81,50 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         feature_groups: dict[str, list[str]],
         **kwargs,
     ) -> dict[ResultType, ModuleResult]:
-        """Fit AutoGluon TabularPredictor."""
-        target_cols = list(study_context.target_assignments.values())
-        row_id_col = study_context.row_id_col
+        """Fit AutoGluon TabularPredictor.
 
-        x_traindev = data_traindev[feature_cols]
-        y_traindev = data_traindev[target_cols]
-        x_test = data_test[feature_cols]
-        y_test = data_test[target_cols]
-        row_traindev = data_traindev[row_id_col]
-        row_test = data_test[row_id_col]
+        AG fits in a single phase and persists directly under `results_dir`
+        (specifically `results_dir/best/model/ag_predictor/`); it does not
+        use `scratch_dir`. `dependency_results` is unused because AG has no
+        upstream task contract. Both are accepted via `**kwargs` to satisfy
+        the `ModuleExecution` ABC.
+        """
+        if study_context.ml_type == MLType.TIMETOEVENT:
+            raise ValueError(
+                "AutoGluon does not support time-to-event tasks. "
+                "Use the Tako module with CatBoostCoxSurvival or XGBoostCoxSurvival models."
+            )
 
-        ag_train_data = pd.concat([x_traindev, y_traindev], axis=1)
-        ag_test_data = pd.concat([x_test, y_test], axis=1)
-
-        # Set up logging and resources
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
-
-        # Get target column
-        if len(study_context.target_assignments) == 1:
-            target = next(iter(study_context.target_assignments.values()))
-        else:
+        if len(study_context.target_assignments) != 1:
             raise ValueError(f"Single target expected. Got keys: {study_context.target_assignments.keys()}")
+        target_col = next(iter(study_context.target_assignments.values()))
 
-        # Get scoring metric
-        if study_context.target_metric is None:
-            raise ValueError("target_metric should be set during fit()")
-
-        if study_context.target_metric not in metrics_inventory_autogluon:
+        scoring = _AG_METRIC_MAP.get(study_context.target_metric) if study_context.target_metric else None
+        if scoring is None:
             raise ValueError(
                 f"target_metric={study_context.target_metric!r} is not supported by AutoGluon. "
-                f"Supported metrics: {sorted(metrics_inventory_autogluon)}"
+                f"Supported metrics: {sorted(_AG_METRIC_MAP)}"
             )
-        scoring_type = metrics_inventory_autogluon[study_context.target_metric]
 
-        # Initialize TabularPredictor (store temporarily for fit operations)
+        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
+
+        ag_train_data = data_traindev[[*feature_cols, target_col]]
+        ag_predictor_path = results_dir / ResultType.BEST.value / "model" / "ag_predictor"
+
         predictor = TabularPredictor(
-            label=target,
-            eval_metric=scoring_type,
+            label=target_col,
+            eval_metric=scoring,
             verbosity=0,
             log_to_file=False,
+            path=str(ag_predictor_path),
         )
 
-        # Log configuration summary
         logger.info(
             "Starting fit: presets=%s, time_limit=%s, model_types=%s",
             self.config.presets,
             self.config.time_limit,
             self.config.included_model_types or "all",
         )
-
-        # Fit predictor
         predictor.fit(
             ag_train_data,
             time_limit=self.config.time_limit,
@@ -194,317 +136,99 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
             included_model_types=self.config.included_model_types,
             num_cpus=n_assigned_cpus,
         )
-
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
         logger.info("Fitting completed")
 
-        # Log best model summary
-        leaderboard_summary = predictor.leaderboard(silent=True)
-        best = leaderboard_summary.iloc[0]
-        logger.info("Best model: %s (score_val=%.4f)", best["model"], best["score_val"])
+        leaderboard = predictor.leaderboard(silent=True)
+        best_row = leaderboard.iloc[0]
+        logger.info("Best model: %s (score_val=%.4f)", best_row["model"], best_row["score_val"])
 
-        # Save failure info
-        with (results_dir / "autogluon_debug_info.txt").open("w", encoding="utf-8") as text_file:
-            print(predictor.model_failures(), file=text_file)
-
-        # Save leaderboard and model info
-        self._save_leaderboard_info(predictor, ag_test_data, outer_split_id, results_dir)
-
-        # Get raw results
-        raw_scores = self._get_scores(predictor, study_context, ag_train_data, ag_test_data, feature_cols, results_dir)
-        raw_predictions = self._get_predictions(
-            predictor, study_context, ag_test_data, row_test, row_traindev, outer_split_id
+        prediction_frames = build_predictions(
+            predictor,
+            study_context=study_context,
+            data_traindev=data_traindev,
+            data_test=data_test,
+            outer_split_id=outer_split_id,
+            task_id=self.config.task_id,
         )
-        raw_fi = self._get_fi(predictor, ag_test_data, outer_split_id, feature_groups, results_dir)
+        scores = _compute_scores(prediction_frames, study_context=study_context)
+        raw_fi = compute_fi(
+            predictor,
+            feature_cols=feature_cols,
+            feature_groups=feature_groups,
+            leaderboard=leaderboard,
+        )
 
-        # Build flat scores DataFrame
-        scores_rows = []
-        for key, value in raw_scores.items():
-            if isinstance(value, (int, float)):
-                scores_rows.append(
-                    {
-                        "result_type": ResultType.BEST,
-                        "metric": key,
-                        "partition": "combined",
-                        "aggregation": "single",
-                        "split": None,
-                        "value": value,
-                    }
-                )
-        scores = pd.DataFrame(scores_rows)
-
-        # Build flat predictions DataFrame
-        pred_dfs = []
-        for _part_name, df in raw_predictions.items():
-            if isinstance(df, pd.DataFrame) and not df.empty:
-                temp = df.copy()
-                temp["result_type"] = ResultType.BEST
-                pred_dfs.append(temp)
-        predictions = pd.concat(pred_dfs, ignore_index=True) if pred_dfs else pd.DataFrame()
-
-        # Build flat feature importance DataFrame
-        fi_dfs = []
-        for _fi_key, fi_df in raw_fi.items():
-            if isinstance(fi_df, pd.DataFrame) and not fi_df.empty:
-                temp = fi_df.reset_index() if fi_df.index.name is not None else fi_df.copy()
-                if "feature" not in temp.columns and temp.index.name is None:
-                    temp = temp.reset_index()
-                    temp.columns = ["feature", "importance", *list(temp.columns[2:])]
-                temp = (
-                    temp[["feature", "importance"]].copy()
-                    if "feature" in temp.columns and "importance" in temp.columns
-                    else temp
-                )
-                temp["fi_method"] = FIResultLabel.PERMUTATION
-                temp["fi_dataset"] = DataPartition.TEST
-                temp["training_id"] = "autogluon"
-                temp["result_type"] = ResultType.BEST
-                fi_dfs.append(temp)
-        fi_df = pd.concat(fi_dfs, ignore_index=True) if fi_dfs else pd.DataFrame()
+        predictions = pd.concat(list(prediction_frames.values()), ignore_index=True)
+        if raw_fi.empty:
+            fi_df = pd.DataFrame()
+        else:
+            fi_df = raw_fi[["importance"]].reset_index()
+            fi_df.columns = ["feature", "importance"]
+            fi_df["fi_method"] = FIResultLabel.PERMUTATION
+            fi_df["fi_dataset"] = DataPartition.DEV
+            fi_df["training_id"] = raw_fi.attrs["training_id"]
 
         return {
             ResultType.BEST: ModuleResult(
                 result_type=ResultType.BEST,
                 module=self.config.module,
-                selected_features=feature_cols,  # AutoGluon doesn't do feature selection, so return all features
+                selected_features=feature_cols,
                 scores=scores,
                 predictions=predictions,
                 fi=fi_df,
-                model=self._get_sklearn_model(predictor, study_context),
+                model=_build_sklearn_wrapper(predictor, study_context.ml_type),
             )
         }
 
-    def _get_sklearn_model(self, model: TabularPredictor, study_context: StudyContext) -> BaseEstimator:
-        """Get sklearn-compatible wrapper for the AutoGluon model."""
-        if study_context.ml_type in (MLType.BINARY, MLType.MULTICLASS):
-            return SklearnClassifier(model)
-        elif study_context.ml_type == MLType.REGRESSION:
-            return SklearnRegressor(model)
-        else:
-            raise ValueError(f"ML type {study_context.ml_type} not supported")
 
-    def _get_fi(
-        self,
-        model: TabularPredictor,
-        ag_test_data: pd.DataFrame,
-        outer_split_id: int,
-        feature_groups: dict[str, list[str]],
-        results_dir: UPath,
-    ) -> dict[str, pd.DataFrame]:
-        """Calculate feature importances using AutoGluon's permutation importance."""
-        logger.set_log_group(LogGroup.AUTOGLUON, f"OUTER {outer_split_id}")
-        logger.info("Calculating test permutation feature importances...")
+def _build_sklearn_wrapper(predictor: TabularPredictor, ml_type: MLType) -> BaseEstimator:
+    """Wrap the fitted AG predictor as an sklearn-compatible inference object."""
+    if ml_type in (MLType.BINARY, MLType.MULTICLASS):
+        return SklearnClassifier(predictor)
+    if ml_type == MLType.REGRESSION:
+        return SklearnRegressor(predictor)
+    raise ValueError(f"ML type {ml_type} not supported")
 
-        fi: dict[str, pd.DataFrame] = {}
-        np.random.seed(42)
 
-        # AutoGluon permutation feature importances
-        fi["autogluon_permutation_test"] = model.feature_importance(
-            data=ag_test_data,
-            subsample_size=5000,
-            time_limit=None,
-            include_confidence_band=True,
-            confidence_level=0.95,
-            num_shuffle_sets=15,
-            silent=True,
+def _compute_scores(
+    predictions: dict[DataPartition, pd.DataFrame],
+    *,
+    study_context: StudyContext,
+) -> pd.DataFrame:
+    """Compute scores for every metric supported by `study_context.ml_type`.
+
+    Delegates entirely to `octopus.metrics.utils.get_performance_from_predictions`
+    so AG and Tako share one metric router.
+
+    Args:
+        predictions: Mapping from DataPartition to a Tako-schema prediction
+            frame (must include the target column).
+        study_context: Study configuration (ml_type, target_assignments,
+            positive_class).
+
+    Returns:
+        Long-format DataFrame with columns
+        `{metric, partition, aggregation, split, value}` and one row per
+        (metric, partition).
+    """
+    metric_names = Metrics.get_by_type(study_context.ml_type)
+    rows: list[dict[str, object]] = []
+    predictions_for_helper = {"ensemble": dict(predictions.items())}
+    for metric_name in metric_names:
+        performance = get_performance_from_predictions(
+            predictions_for_helper,
+            target_metric=metric_name,
+            target_assignments=study_context.target_assignments,
+            positive_class=study_context.positive_class,
         )
-
-        # Calculate group feature importances if feature_groups provided
-        if feature_groups:
-            group_importances = {}
-            for group_name, features in feature_groups.items():
-                group_importance = model.feature_importance(
-                    data=ag_test_data,
-                    features=[(group_name, features)],
-                    subsample_size=5000,
-                    time_limit=None,
-                    include_confidence_band=True,
-                    confidence_level=0.95,
-                    num_shuffle_sets=15,
-                    silent=True,
-                )
-                group_importances[group_name] = group_importance
-
-            # Combine feature and group importances
-            combined_fi = [fi["autogluon_permutation_test"]]
-
-            for group_name, importance in group_importances.items():
-                group_row = importance.copy()
-                group_row.index = [f"{group_name}"] * len(group_row)
-                combined_fi.append(group_row)
-
-            fi["autogluon_permutation_test"] = pd.concat(combined_fi)
-
-        fi["autogluon_permutation_test"] = fi["autogluon_permutation_test"].sort_values(
-            by="importance", ascending=False
-        )
-
-        # Save combined importances
-        combined_importances = {
-            "autogluon_permutation": fi["autogluon_permutation_test"].to_dict(orient="index"),
-        }
-
-        with (results_dir / "combined_feature_importances.json").open("w", encoding="utf-8") as f:
-            json.dump(combined_importances, f, indent=4)
-
-        return fi
-
-    def _get_scores(
-        self,
-        model: TabularPredictor,
-        study_context: StudyContext,
-        ag_train_data: pd.DataFrame,
-        ag_test_data: pd.DataFrame,
-        feature_cols: list[str],
-        results_dir: UPath,
-    ) -> dict[str, Any]:
-        """Calculate performance scores on train/dev/test sets."""
-        # Test performance
-        test_performance = model.evaluate(ag_test_data, detailed_report=True, silent=True)
-        test_performance_with_suffix = {f"{key}_test": value for key, value in test_performance.items()}
-
-        # Dev performance from leaderboard
-        leaderboard = model.leaderboard(silent=True)
-        best_model_info = leaderboard.iloc[0].to_dict()
-        dev_performance = {key: value for key, value in best_model_info.items() if "val" in key or "score" in key}
-        dev_performance_with_suffix = {f"{key}_dev": value for key, value in dev_performance.items()}
-
-        # Train performance
-        train_performance = model.evaluate(ag_train_data, detailed_report=True, silent=True)
-        train_performance_with_suffix = {f"{key}_train": value for key, value in train_performance.items()}
-
-        # Test scores using Octopus metrics for comparison
-        assert study_context.target_metric is not None, "target_metric should be set during fit()"
-        all_metrics = Metrics.get_by_type(study_context.ml_type)
-        test_performance_octo = {}
-        for metric in all_metrics:
-            assert feature_cols is not None, "feature_cols should be set during fit()"
-            assert metric is not None, "metric should not be None"
-            performance = get_score_from_model(
-                model,
-                ag_test_data,
-                feature_cols,
-                metric,
-                study_context.target_assignments,
-                positive_class=study_context.positive_class,
+        for partition, value in performance["ensemble"].items():
+            rows.append(
+                {
+                    "metric": metric_name,
+                    "partition": partition,
+                    "aggregation": "ensemble",
+                    "split": None,
+                    "value": value,
+                }
             )
-            test_performance_octo[metric + "_test_octo"] = performance
-
-        # Combine all performance metrics
-        combined_performance = {
-            **dev_performance_with_suffix,
-            **train_performance_with_suffix,
-            **test_performance_with_suffix,
-            **test_performance_octo,
-        }
-
-        # Save performance results
-        if isinstance(combined_performance, dict):
-            for key, value in combined_performance.items():
-                if isinstance(value, pd.DataFrame):
-                    combined_performance[key] = value.to_dict(orient="records")
-
-        with (results_dir / "performance_results.json").open("w", encoding="utf-8") as f:
-            json.dump(combined_performance, f, indent=4)
-
-        return combined_performance
-
-    def _save_leaderboard_info(
-        self,
-        model: TabularPredictor,
-        ag_test_data: pd.DataFrame,
-        outer_split_id: int,
-        results_dir: UPath,
-    ) -> None:
-        """Save AutoGluon leaderboard and model information."""
-        # Save leaderboard
-        leaderboard = model.leaderboard(ag_test_data, extra_info=True, silent=True)
-        leaderboard_path = results_dir / "leaderboard.csv"
-        csv_save(leaderboard, leaderboard_path)
-
-        # Save best model results
-        best_model = leaderboard.iloc[0]
-        best_result_df = pd.DataFrame(best_model).transpose()
-        best_result_path = results_dir / "best_model_result.csv"
-        csv_save(best_result_df, best_result_path)
-
-        # Save model info
-        model_info = model.info()
-        with (results_dir / "model_info.json").open("w", encoding="utf-8") as f:
-            json.dump(model_info, f, default=str, indent=4)
-
-        # Save fit summary
-        fit_summary = model.fit_summary(verbosity=0)
-        with (results_dir / "model_stats.txt").open("w", encoding="utf-8") as text_file:
-            print(fit_summary, file=text_file)
-
-    def _get_predictions(
-        self,
-        model: TabularPredictor,
-        study_context: StudyContext,
-        ag_test_data: pd.DataFrame,
-        row_test: pd.Series,
-        row_traindev: pd.Series,
-        outer_split_id: int,
-    ) -> dict[str, pd.DataFrame]:
-        """Get out-of-split and test predictions with metadata."""
-        predictions = {}
-        best_model_name = model.model_best
-        problem_type = model.problem_type
-        row_column = study_context.row_id_col
-
-        # Metadata for all predictions (AutoGluon doesn't use inner splits)
-        task_id = self.config.task_id
-        inner_split_id = "autogluon"  # AutoGluon doesn't have inner CV splits
-
-        # Test predictions
-        rowid_test = pd.DataFrame({row_column: row_test})
-
-        if problem_type == "regression":
-            test_pred_data = model.predict(ag_test_data)
-            test_pred = pd.DataFrame({"prediction": test_pred_data})
-        elif problem_type in ["binary", "multiclass"]:
-            test_pred = model.predict_proba(ag_test_data)
-            class_labels = model.class_labels
-            test_pred.columns = class_labels
-        else:
-            raise ValueError(f"Unsupported problem type: {problem_type}")
-
-        assert len(rowid_test) == len(test_pred), "Mismatch in number of test rows!"
-        test_df = pd.concat(
-            [rowid_test.reset_index(drop=True), test_pred.reset_index(drop=True)],
-            axis=1,
-        )
-        # Add metadata
-        test_df["outer_split_id"] = outer_split_id
-        test_df["inner_split_id"] = inner_split_id
-        test_df["partition"] = "test"
-        test_df["task_id"] = task_id
-        predictions["test"] = test_df
-
-        # Out-of-split validation predictions
-        rowid_dev = pd.DataFrame({row_column: row_traindev})
-
-        if problem_type == "regression":
-            oof_pred_data = model.predict_oof(model=best_model_name)
-            oof_pred = pd.DataFrame({"prediction": oof_pred_data})
-        elif problem_type in ["binary", "multiclass"]:
-            oof_pred = model.predict_proba_oof(model=best_model_name)
-            class_labels = model.class_labels
-            oof_pred.columns = class_labels
-        else:
-            raise ValueError(f"Unsupported problem type: {problem_type}")
-
-        assert len(rowid_dev) == len(oof_pred), "Mismatch in number of dev rows!"
-        dev_df = pd.concat(
-            [rowid_dev.reset_index(drop=True), oof_pred.reset_index(drop=True)],
-            axis=1,
-        )
-        # Add metadata
-        dev_df["outer_split_id"] = outer_split_id
-        dev_df["inner_split_id"] = inner_split_id
-        dev_df["partition"] = "dev"
-        dev_df["task_id"] = task_id
-        predictions["dev"] = dev_df
-
-        return predictions
+    return pd.DataFrame(rows)

--- a/octopus/modules/autogluon/feature_importance.py
+++ b/octopus/modules/autogluon/feature_importance.py
@@ -1,0 +1,183 @@
+"""OOF permutation feature importance for AutoGluon.
+
+The AG module produces FI on the DEV partition only; computing FI on test
+data is `TaskPredictor`'s responsibility, not the module's.
+
+Algorithm
+---------
+
+1. Enumerate level-1 children via `predictor.model_names(level=1)`.
+2. Keep only children for which `_bagged_mode is True and not _child_oof`.
+   These are the children that expose OOF predictions usable for permutation
+   FI without a held-out dataset (random forests / extra trees do not
+   qualify because AG fits them in non-bagged mode with `_child_oof=True`).
+3. Pick the leaderboard-best survivor.
+4. Call `predictor.feature_importance(data=None, model=best, feature_stage="transformed_model", ...)`.
+   `feature_stage="original"` is forbidden with `data=None`; `feature_stage="transformed"`
+   raises for bagged models.
+5. Aggregate transformed-feature importances back to original feature names
+   via `predictor._learner.feature_generator.get_feature_links()`. Permutation
+   importance is additive in expectation, so summing transformed children per
+   original is the conservative-honest reduction.
+
+If no qualifying L1 child exists (e.g. AG only fitted RF/XT models), return
+an empty DataFrame and log a warning - never fall back to test-data FI, and
+never fail the whole module on optional FI.
+
+AG private API surface
+----------------------
+
+This module reads two AG-internal attributes that have no public equivalent
+in current AG releases:
+
+* `predictor._trainer.load_model(name)` to inspect a child's `_bagged_mode`
+  and `_child_oof` flags.
+* `predictor._learner.feature_generator.get_feature_links()` to map
+  transformed columns back to originals.
+
+If either breaks across an AG upgrade, `compute_fi` will raise (caught by
+`Module.fit` callers as a hard FI failure rather than silent corruption).
+
+Reproducibility
+---------------
+
+AG's permutation FI uses `np.random` internally and exposes no `seed=` parameter.
+This function therefore does not attempt to seed RNG; the resulting FI ranking
+is non-deterministic across runs (typically stable for top features, noisy in
+the tail). If reproducibility matters for a downstream consumer, raise
+`_FI_NUM_SHUFFLE_SETS` (module constant) to tighten the confidence band.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import pandas as pd
+
+from octopus._optional.autogluon import TabularPredictor
+from octopus.logger import get_logger
+
+logger = get_logger()
+
+_FI_SUBSAMPLE_SIZE: Final[int] = 5000
+_FI_NUM_SHUFFLE_SETS: Final[int | None] = None
+_FI_CONFIDENCE_LEVEL: Final[float] = 0.99
+
+
+def compute_fi(
+    predictor: TabularPredictor,
+    *,
+    feature_cols: list[str],
+    feature_groups: dict[str, list[str]],
+    leaderboard: pd.DataFrame,
+) -> pd.DataFrame:
+    """Compute OOF permutation feature importance, aggregated to original feature names.
+
+    Args:
+        predictor: Fitted AutoGluon predictor.
+        feature_cols: Original feature column names. The published FI frame's
+            feature names are guaranteed to be a subset of this list.
+        feature_groups: Caller-supplied feature groups. AG cannot compute group-level
+            FI; if non-empty, a single warning is logged.
+        leaderboard: Pre-fetched leaderboard from `predictor.leaderboard(silent=True)`,
+            used to pick the best qualifying L1 child by validation score.
+
+    Returns:
+        DataFrame indexed by original feature name with a single `importance` column,
+        sorted by importance descending. The result also carries
+        `df.attrs["training_id"] = "<actual_l1_model_name>"`. Returns an empty
+        DataFrame when no qualifying L1 child is available.
+    """
+    if feature_groups:
+        logger.warning(
+            "Group feature importances are not supported by AutoGluon; computing per-feature importances only."
+        )
+
+    best_l1 = _select_oof_l1_child(predictor, leaderboard)
+    if best_l1 is None:
+        return pd.DataFrame()
+
+    logger.info("Computing OOF permutation FI via L1 model: %s", best_l1)
+    fi_transformed: pd.DataFrame = predictor.feature_importance(
+        data=None,
+        model=best_l1,
+        feature_stage="transformed_model",
+        subsample_size=_FI_SUBSAMPLE_SIZE,
+        time_limit=None,
+        include_confidence_band=True,
+        confidence_level=_FI_CONFIDENCE_LEVEL,
+        num_shuffle_sets=_FI_NUM_SHUFFLE_SETS,
+        silent=True,
+    )
+
+    fi_df = _aggregate_transformed_to_original(
+        fi_transformed,
+        predictor=predictor,
+        feature_cols=feature_cols,
+        training_id=best_l1,
+    )
+    return fi_df.sort_values(by="importance", ascending=False)
+
+
+def _select_oof_l1_child(predictor: TabularPredictor, leaderboard: pd.DataFrame) -> str | None:
+    """Return the leaderboard-best L1 child supporting OOF FI, or None."""
+    l1_models = predictor.model_names(level=1)
+    if not l1_models:
+        logger.info("No level-1 models found; cannot compute OOF FI.")
+        return None
+
+    qualifying: list[str] = []
+    for name in l1_models:
+        try:
+            child = predictor._trainer.load_model(name)
+        except Exception as exc:
+            logger.debug("Skipping L1 child %s (load failed: %s)", name, exc)
+            continue
+        if getattr(child, "_bagged_mode", False) and not getattr(child, "_child_oof", False):
+            qualifying.append(name)
+
+    if not qualifying:
+        logger.warning(
+            "No qualifying L1 child for OOF FI (need _bagged_mode=True and not _child_oof). Returning empty FI."
+        )
+        return None
+
+    l1_leaderboard = leaderboard[leaderboard["model"].isin(qualifying)]
+    if l1_leaderboard.empty:
+        logger.warning("No qualifying L1 child appears in leaderboard; returning empty FI.")
+        return None
+    best_l1: str = l1_leaderboard.iloc[0]["model"]
+    return best_l1
+
+
+def _aggregate_transformed_to_original(
+    fi_transformed: pd.DataFrame,
+    *,
+    predictor: TabularPredictor,
+    feature_cols: list[str],
+    training_id: str,
+) -> pd.DataFrame:
+    """Sum transformed-feature importances back into the original feature space."""
+    links: dict[str, list[str]] = predictor._learner.feature_generator.get_feature_links()
+    transformed_to_original = {t: o for o, ts in links.items() for t in ts}
+
+    unmapped = set(fi_transformed.index) - set(transformed_to_original) - set(feature_cols)
+    if unmapped:
+        raise RuntimeError(
+            f"AutoGluon returned permutation FI for transformed features {sorted(unmapped)} "
+            f"that are absent from feature_generator.get_feature_links() and from feature_cols. "
+            f"This indicates a get_feature_links contract change in AutoGluon "
+            f"({predictor.__class__.__module__}); aggregating would silently drop these importances."
+        )
+
+    agg = (
+        fi_transformed["importance"]
+        .rename(index=transformed_to_original)
+        .groupby(level=0)
+        .sum()
+        .reindex(feature_cols, fill_value=0.0)
+        .to_frame()
+    )
+    agg.index.name = "feature"
+    agg.attrs["training_id"] = training_id
+    return agg

--- a/octopus/modules/autogluon/predictions.py
+++ b/octopus/modules/autogluon/predictions.py
@@ -1,0 +1,191 @@
+"""Build prediction frames from a fitted AutoGluon TabularPredictor.
+
+The frames produced here match Tako's prediction schema so that
+`octopus.metrics.utils.get_performance_from_predictions` can score AG and Tako
+output through the same code path.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from octopus._optional.autogluon import TabularPredictor
+from octopus.types import DataPartition
+
+if TYPE_CHECKING:
+    from octopus.modules import StudyContext
+
+_AG_INNER_SPLIT_ID = "autogluon"
+
+
+def build_predictions(
+    predictor: TabularPredictor,
+    *,
+    study_context: StudyContext,
+    data_traindev: pd.DataFrame,
+    data_test: pd.DataFrame,
+    outer_split_id: int,
+    task_id: int,
+) -> dict[DataPartition, pd.DataFrame]:
+    """Build DEV (OOF) and TEST prediction frames in Tako's canonical schema.
+
+    Each frame carries:
+        - row_id_col, target_col (so the canonical scoring helper can read both),
+        - prediction (hard label for classification, value for regression),
+        - one column per integer class label with predicted probabilities
+          (classification only; named with `predictor.class_labels`),
+        - outer_split_id, inner_split_id="autogluon", partition, task_id.
+
+    Args:
+        predictor: Fitted AutoGluon TabularPredictor.
+        study_context: Study configuration; supplies row_id_col, target column,
+            ml_type, and positive_class.
+        data_traindev: Train/dev frame used for OOF predictions. Must include
+            the row_id_col and target column(s).
+        data_test: Test frame used for held-out predictions. Must include the
+            row_id_col and target column(s).
+        outer_split_id: Outer split index.
+        task_id: Task identifier.
+
+    Returns:
+        Mapping `{DataPartition.DEV: dev_df, DataPartition.TEST: test_df}`.
+
+    Raises:
+        RuntimeError: If AG OOF predictions miss any traindev row index.
+        ValueError: If `problem_type` is unsupported, or AG class labels are
+            not integer-convertible.
+    """
+    target_col = next(iter(study_context.target_assignments.values()))
+    row_id_col = study_context.row_id_col
+    problem_type = predictor.problem_type
+    best_model_name = predictor.model_best
+
+    return {
+        DataPartition.DEV: _build_one(
+            partition=DataPartition.DEV,
+            source_data=data_traindev,
+            predictor=predictor,
+            problem_type=problem_type,
+            best_model_name=best_model_name,
+            row_id_col=row_id_col,
+            target_col=target_col,
+            outer_split_id=outer_split_id,
+            task_id=task_id,
+        ),
+        DataPartition.TEST: _build_one(
+            partition=DataPartition.TEST,
+            source_data=data_test,
+            predictor=predictor,
+            problem_type=problem_type,
+            best_model_name=best_model_name,
+            row_id_col=row_id_col,
+            target_col=target_col,
+            outer_split_id=outer_split_id,
+            task_id=task_id,
+        ),
+    }
+
+
+def _build_one(
+    *,
+    partition: DataPartition,
+    source_data: pd.DataFrame,
+    problem_type: str,
+    predictor: TabularPredictor,
+    best_model_name: str,
+    row_id_col: str,
+    target_col: str,
+    outer_split_id: int,
+    task_id: int,
+) -> pd.DataFrame:
+    """Build one prediction frame (DEV or TEST) in Tako's schema.
+
+    `partition == DataPartition.DEV` triggers the OOF path
+    (`predict_oof` / `predict_proba_oof`); otherwise the in-memory
+    `predict` / `predict_proba` path runs against `source_data`.
+    """
+    is_oof = partition == DataPartition.DEV
+    if problem_type == "regression":
+        if is_oof:
+            pred_values = _aligned_oof_predict(predictor, best_model_name, source_data.index).to_numpy()
+        else:
+            x_data = source_data[list(predictor.original_features)]
+            pred_values = predictor.predict(x_data, as_pandas=False)
+        proba_df: pd.DataFrame | None = None
+    elif problem_type in ("binary", "multiclass"):
+        if is_oof:
+            proba_df = _aligned_oof_predict_proba(predictor, best_model_name, source_data.index)
+        else:
+            x_data = source_data[list(predictor.original_features)]
+            proba_df = predictor.predict_proba(x_data, as_multiclass=True)
+        int_labels = _coerce_int_labels(predictor.class_labels)
+        proba_df.columns = int_labels
+        pred_values = np.asarray(int_labels)[proba_df.to_numpy().argmax(axis=1)]
+    else:
+        raise ValueError(f"Unsupported problem_type: {problem_type!r}")
+
+    base_cols = source_data[[row_id_col, target_col]].reset_index(drop=True)
+    pred_col = pd.DataFrame({"prediction": pred_values})
+    parts = [base_cols, pred_col]
+    if proba_df is not None:
+        parts.append(proba_df.reset_index(drop=True))
+    out = pd.concat(parts, axis=1)
+    out["outer_split_id"] = outer_split_id
+    out["inner_split_id"] = _AG_INNER_SPLIT_ID
+    out["partition"] = partition
+    out["task_id"] = task_id
+    return out
+
+
+def _coerce_int_labels(class_labels: list) -> list[int]:
+    """Convert AG class labels to ints, raising a clear error on string labels."""
+    try:
+        return [int(c) for c in class_labels]
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"AutoGluon class labels {class_labels!r} are not integer-convertible. "
+            "Octopus requires integer-encoded class labels (e.g. [0, 1] or [0, 1, 2])."
+        ) from exc
+
+
+def _aligned_oof_predict(predictor: TabularPredictor, best_model_name: str, source_index: pd.Index) -> pd.Series:
+    """Return OOF predictions reindexed to the traindev source index.
+
+    AG's `predict_oof` returns one row per training row, indexed by the
+    training-frame index. Reindexing locks the output to the caller's row
+    order so downstream `reset_index(drop=True)` of predictions and target
+    are aligned by construction rather than by AG-internal coincidence.
+    """
+    oof: pd.Series = predictor.predict_oof(model=best_model_name)
+    oof = oof.reindex(source_index)
+    if oof.isna().any():
+        n_missing = int(oof.isna().sum())
+        raise RuntimeError(
+            f"AG OOF predictions are missing rows for {n_missing} of {len(source_index)} traindev "
+            f"indices. predict_oof did not return a row per training row; this indicates an "
+            f"AG-internal index contract change."
+        )
+    return oof
+
+
+def _aligned_oof_predict_proba(
+    predictor: TabularPredictor, best_model_name: str, source_index: pd.Index
+) -> pd.DataFrame:
+    """Return OOF probabilities reindexed to the traindev source index.
+
+    See `_aligned_oof_predict` for rationale; this is the multiclass-aware
+    counterpart that preserves the per-class column structure.
+    """
+    proba: pd.DataFrame = predictor.predict_proba_oof(model=best_model_name)
+    proba = proba.reindex(source_index)
+    if proba.isna().any().any():
+        n_missing = int(proba.isna().any(axis=1).sum())
+        raise RuntimeError(
+            f"AG OOF probabilities are missing rows for {n_missing} of {len(source_index)} traindev "
+            f"indices. predict_proba_oof did not return a row per training row; this indicates an "
+            f"AG-internal index contract change."
+        )
+    return proba

--- a/tests/modules/autogluon/test_feature_importance.py
+++ b/tests/modules/autogluon/test_feature_importance.py
@@ -1,0 +1,219 @@
+"""Unit tests for octopus.modules.autogluon.feature_importance.
+
+Covers:
+  * OOF success on numeric data: non-empty FI, training_id is set to the
+    actual L1 model name, feature index is a subset of feature_cols.
+  * OOF success on text-feature data: text-derived transformed columns
+    (`txt.char_count`, `txt.word_count`, ...) are aggregated back to the
+    original text column name and never leak into the published FI frame.
+  * No qualifying L1 child: fitting with only `included_model_types=["RF"]`
+    produces children with `_bagged_mode=False`, so `compute_fi` returns
+    an empty DataFrame.
+  * Group-FI warning: passing non-empty feature_groups logs a single warning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+import ray
+from sklearn.datasets import make_classification
+
+from octopus._optional.autogluon import TabularPredictor
+from octopus.modules.autogluon.feature_importance import compute_fi
+
+
+def _binary_numeric_data(n: int = 80) -> pd.DataFrame:
+    X, y = make_classification(
+        n_samples=n,
+        n_features=5,
+        n_informative=3,
+        n_redundant=2,
+        n_classes=2,
+        random_state=42,
+    )
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(5)])
+    df["target"] = y
+    return df
+
+
+def _binary_text_data(n: int = 80) -> pd.DataFrame:
+    rng = np.random.default_rng(0)
+    X, y = make_classification(
+        n_samples=n,
+        n_features=3,
+        n_informative=2,
+        n_redundant=0,
+        n_classes=2,
+        random_state=42,
+    )
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(3)])
+    sentences = ["alpha bravo charlie delta", "echo foxtrot golf hotel", "india juliet kilo lima"]
+    df["txt"] = rng.choice(sentences, size=n)
+    df["target"] = y
+    return df
+
+
+def _fit(
+    train: pd.DataFrame,
+    *,
+    feature_cols: list[str],
+    eval_metric: str,
+    path,
+    included_model_types: list[str] | None = None,
+) -> TabularPredictor:
+    train_data = train[[*feature_cols, "target"]]
+    predictor = TabularPredictor(
+        label="target",
+        eval_metric=eval_metric,
+        verbosity=0,
+        log_to_file=False,
+        path=str(path),
+    )
+    fit_kwargs: dict = {"time_limit": 30, "num_bag_folds": 2, "num_bag_sets": 1}
+    if included_model_types is not None:
+        fit_kwargs["included_model_types"] = included_model_types
+    predictor.fit(train_data, **fit_kwargs)
+    if ray.is_initialized():
+        ray.shutdown()
+    return predictor
+
+
+def _bundle(predictor: TabularPredictor, feature_cols: list[str]) -> dict:
+    return {
+        "predictor": predictor,
+        "feature_cols": feature_cols,
+        "leaderboard": predictor.leaderboard(silent=True),
+    }
+
+
+@pytest.fixture(scope="module")
+def numeric_predictor(tmp_path_factory):
+    """Fit a tiny binary AG predictor on numeric features only."""
+    df = _binary_numeric_data()
+    feature_cols = [f"feat_{i}" for i in range(5)]
+    predictor = _fit(
+        df,
+        feature_cols=feature_cols,
+        eval_metric="balanced_accuracy",
+        path=tmp_path_factory.mktemp("fi_numeric") / "ag_predictor",
+    )
+    return _bundle(predictor, feature_cols)
+
+
+@pytest.fixture(scope="module")
+def text_predictor(tmp_path_factory):
+    """Fit a tiny binary AG predictor with both numeric and text features."""
+    df = _binary_text_data()
+    feature_cols = [*[f"feat_{i}" for i in range(3)], "txt"]
+    predictor = _fit(
+        df,
+        feature_cols=feature_cols,
+        eval_metric="balanced_accuracy",
+        path=tmp_path_factory.mktemp("fi_text") / "ag_predictor",
+    )
+    return _bundle(predictor, feature_cols)
+
+
+@pytest.fixture(scope="module")
+def rf_only_predictor(tmp_path_factory):
+    """Fit AG with only RF: no L1 child should qualify for OOF FI."""
+    df = _binary_numeric_data()
+    feature_cols = [f"feat_{i}" for i in range(5)]
+    predictor = _fit(
+        df,
+        feature_cols=feature_cols,
+        eval_metric="balanced_accuracy",
+        path=tmp_path_factory.mktemp("fi_rf_only") / "ag_predictor",
+        included_model_types=["RF"],
+    )
+    return _bundle(predictor, feature_cols)
+
+
+def _call_fi(fixture: dict, *, feature_groups: dict | None = None) -> pd.DataFrame:
+    return compute_fi(
+        fixture["predictor"],
+        feature_cols=fixture["feature_cols"],
+        feature_groups=feature_groups or {},
+        leaderboard=fixture["leaderboard"],
+    )
+
+
+class TestNumericFI:
+    """OOF FI on a numeric-only dataset."""
+
+    def test_returns_non_empty(self, numeric_predictor) -> None:
+        """`compute_fi` produces a non-empty importance frame."""
+        fi = _call_fi(numeric_predictor)
+        assert not fi.empty
+        assert "importance" in fi.columns
+
+    def test_index_matches_feature_cols(self, numeric_predictor) -> None:
+        """Returned features form exactly the original feature_cols set."""
+        fi = _call_fi(numeric_predictor)
+        assert set(fi.index) == set(numeric_predictor["feature_cols"])
+
+    def test_training_id_is_actual_model_name(self, numeric_predictor) -> None:
+        """`attrs['training_id']` holds the AG model name used for FI, not 'mean'."""
+        fi = _call_fi(numeric_predictor)
+        training_id = fi.attrs["training_id"]
+        assert training_id != "mean"
+        assert training_id != "autogluon"
+        assert training_id in numeric_predictor["predictor"].model_names(level=1)
+
+    def test_sorted_descending(self, numeric_predictor) -> None:
+        """FI is sorted by importance descending."""
+        fi = _call_fi(numeric_predictor)
+        importances = fi["importance"].to_numpy()
+        assert (importances[:-1] >= importances[1:]).all()
+
+
+class TestTextFI:
+    """OOF FI when AG generates transformed text features must aggregate back to originals."""
+
+    def test_no_transformed_names_in_published_fi(self, text_predictor) -> None:
+        """`txt.char_count`, `txt.word_count`, etc. must not leak into the result."""
+        fi = _call_fi(text_predictor)
+        assert set(fi.index).issubset(set(text_predictor["feature_cols"]))
+        for name in fi.index:
+            assert "." not in str(name), f"Transformed name {name!r} leaked into FI"
+
+    def test_txt_appears_in_index(self, text_predictor) -> None:
+        """The original `txt` column has an entry in the published FI frame."""
+        fi = _call_fi(text_predictor)
+        assert "txt" in fi.index
+
+
+class TestEmptyFallback:
+    """No qualifying L1 child means an empty DataFrame, never a hard failure."""
+
+    def test_rf_only_returns_empty(self, rf_only_predictor) -> None:
+        """RandomForest L1 children have `_child_oof=True` and so don't qualify."""
+        assert _call_fi(rf_only_predictor).empty
+
+
+class TestGroupFIWarning:
+    """Passing feature_groups logs a warning but does not change the result shape."""
+
+    def test_warns_when_groups_passed(self, numeric_predictor, caplog) -> None:
+        """A WARNING-level log fires explaining group FI is unsupported."""
+        feature_groups = {"all": numeric_predictor["feature_cols"]}
+        octo_logger = logging.getLogger("OctoManager")
+        octo_logger.addHandler(caplog.handler)
+        caplog.set_level(logging.WARNING)
+        try:
+            _call_fi(numeric_predictor, feature_groups=feature_groups)
+        finally:
+            octo_logger.removeHandler(caplog.handler)
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("group feature importances are not supported" in msg.lower() for msg in warning_messages), (
+            f"Expected group-FI warning, got: {warning_messages}"
+        )
+
+    def test_per_feature_fi_still_produced(self, numeric_predictor) -> None:
+        """Passing feature_groups must not change the result shape."""
+        fi = _call_fi(numeric_predictor, feature_groups={"all": numeric_predictor["feature_cols"]})
+        assert set(fi.index) == set(numeric_predictor["feature_cols"])

--- a/tests/modules/autogluon/test_metrics_coverage.py
+++ b/tests/modules/autogluon/test_metrics_coverage.py
@@ -1,129 +1,100 @@
 """Test metrics coverage between octopus metrics and autogluon metrics inventory."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from octopus.metrics import Metrics
-from octopus.modules.autogluon.core import metrics_inventory_autogluon
+from octopus.modules.autogluon.core import AutoGluonModule, metrics_inventory_autogluon
 from octopus.types import MLType
 
 
+def _get_octopus_metrics_for_type(ml_type: MLType) -> list[str]:
+    """Get all octopus metric names that support a given ML type."""
+    result = []
+    for metric_name in Metrics.get_all_metrics():
+        config = Metrics.get_instance(metric_name)
+        if config.supports_ml_type(ml_type):
+            result.append(metric_name)
+    return result
+
+
+def _assert_all_covered(ml_type: MLType) -> None:
+    """Assert every octopus metric for ml_type is in the AG inventory."""
+    octopus_metrics = _get_octopus_metrics_for_type(ml_type)
+    ag_metrics = set(metrics_inventory_autogluon.keys())
+    missing = sorted(set(octopus_metrics) - ag_metrics)
+    assert not missing, (
+        f"Octopus {ml_type.value} metrics missing from autogluon inventory: {missing}. "
+        f"Octopus: {sorted(octopus_metrics)}. AG: {sorted(ag_metrics)}"
+    )
+
+
 class TestAutogluonMetricsCoverage:
-    """Test that all octopus classification and regression metrics are available in autogluon."""
+    """Test that all octopus classification, multiclass, and regression metrics are in AG."""
 
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.autogluon_metrics_inventory = metrics_inventory_autogluon
+    def test_all_binary_metrics_covered(self):
+        """Every octopus BINARY metric must have an AG mapping."""
+        _assert_all_covered(MLType.BINARY)
 
-    def get_octopus_classification_metrics(self):
-        """Get all octopus classification metrics."""
-        all_metrics = Metrics.get_all_metrics()
-        classification_metrics = []
+    def test_all_multiclass_metrics_covered(self):
+        """Every octopus MULTICLASS metric must have an AG mapping."""
+        _assert_all_covered(MLType.MULTICLASS)
 
-        for metric_name in all_metrics:
-            try:
-                config = Metrics.get_instance(metric_name)
-                if config.supports_ml_type(MLType.BINARY):
-                    classification_metrics.append(metric_name)
-            except Exception:
-                # Skip metrics that can't be configured
-                continue
+    def test_all_regression_metrics_covered(self):
+        """Every octopus REGRESSION metric must have an AG mapping."""
+        _assert_all_covered(MLType.REGRESSION)
 
-        return classification_metrics
-
-    def get_octopus_regression_metrics(self):
-        """Get all octopus regression metrics."""
-        all_metrics = Metrics.get_all_metrics()
-        regression_metrics = []
-
-        for metric_name in all_metrics:
-            try:
-                config = Metrics.get_instance(metric_name)
-                if config.supports_ml_type(MLType.REGRESSION):
-                    regression_metrics.append(metric_name)
-            except Exception:
-                # Skip metrics that can't be configured
-                continue
-
-        return regression_metrics
-
-    def test_all_classification_metrics_in_autogluon(self):
-        """Test that all octopus classification metrics are available in autogluon."""
-        octopus_classification_metrics = self.get_octopus_classification_metrics()
-        autogluon_metrics = set(self.autogluon_metrics_inventory.keys())
-
-        missing_metrics = []
-        for metric in octopus_classification_metrics:
-            if metric not in autogluon_metrics:
-                missing_metrics.append(metric)
-
-        assert not missing_metrics, (
-            f"The following octopus classification metrics are missing from autogluon inventory: "
-            f"{missing_metrics}. "
-            f"Octopus classification metrics: {sorted(octopus_classification_metrics)}. "
-            f"Autogluon metrics: {sorted(autogluon_metrics)}"
+    def test_mse_maps_to_mse_not_rmse(self):
+        """MSE and RMSE must map to different AG scorers."""
+        mse_scorer = metrics_inventory_autogluon["MSE"]
+        rmse_scorer = metrics_inventory_autogluon["RMSE"]
+        assert mse_scorer is not rmse_scorer, (
+            f"MSE and RMSE must map to different AG scorers, but both map to {mse_scorer}"
         )
 
-    def test_all_regression_metrics_in_autogluon(self):
-        """Test that all octopus regression metrics are available in autogluon."""
-        octopus_regression_metrics = self.get_octopus_regression_metrics()
-        autogluon_metrics = set(self.autogluon_metrics_inventory.keys())
+    def test_t2e_metrics_excluded(self):
+        """Time-to-event metrics should NOT be in the AG inventory."""
+        t2e_metrics = _get_octopus_metrics_for_type(MLType.TIMETOEVENT)
+        ag_metrics = set(metrics_inventory_autogluon.keys())
+        assert t2e_metrics, "Expected at least one T2E metric to exist"
+        overlap = set(t2e_metrics) & ag_metrics
+        assert not overlap, f"T2E metrics should not be in AG inventory: {overlap}"
 
-        missing_metrics = []
-        for metric in octopus_regression_metrics:
-            if metric not in autogluon_metrics:
-                missing_metrics.append(metric)
+    def test_full_coverage(self):
+        """100% coverage across binary + multiclass + regression."""
+        all_relevant = set()
+        for ml_type in (MLType.BINARY, MLType.MULTICLASS, MLType.REGRESSION):
+            all_relevant.update(_get_octopus_metrics_for_type(ml_type))
 
-        assert not missing_metrics, (
-            f"The following octopus regression metrics are missing from autogluon inventory: "
-            f"{missing_metrics}. "
-            f"Octopus regression metrics: {sorted(octopus_regression_metrics)}. "
-            f"Autogluon metrics: {sorted(autogluon_metrics)}"
-        )
+        ag_metrics = set(metrics_inventory_autogluon.keys())
+        missing = sorted(all_relevant - ag_metrics)
+        assert not missing, f"Missing metrics: {missing}"
 
-    def test_metrics_coverage_summary(self):
-        """Provide a summary of metrics coverage."""
-        octopus_classification = self.get_octopus_classification_metrics()
-        octopus_regression = self.get_octopus_regression_metrics()
-        autogluon_metrics = set(self.autogluon_metrics_inventory.keys())
 
-        total_octopus_metrics = len(octopus_classification) + len(octopus_regression)
-        covered_metrics = len([m for m in octopus_classification + octopus_regression if m in autogluon_metrics])
+class TestAutogluonT2EGuard:
+    """Test that AutoGluon rejects time-to-event tasks."""
 
-        coverage_percentage = (covered_metrics / total_octopus_metrics) * 100 if total_octopus_metrics > 0 else 0
+    def test_fit_raises_on_timetoevent(self):
+        """fit() must raise ValueError for T2E tasks."""
+        module = AutoGluonModule(config=MagicMock())
+        study_context = MagicMock()
+        study_context.ml_type = MLType.TIMETOEVENT
 
-        print("\n=== Metrics Coverage Summary ===")
-        print(f"Octopus Classification Metrics ({len(octopus_classification)}): {sorted(octopus_classification)}")
-        print(f"Octopus Regression Metrics ({len(octopus_regression)}): {sorted(octopus_regression)}")
-        print(f"Autogluon Metrics ({len(autogluon_metrics)}): {sorted(autogluon_metrics)}")
-        print(f"Coverage: {covered_metrics}/{total_octopus_metrics} ({coverage_percentage:.1f}%)")
-
-        # This test should always pass if the above tests pass
-        assert coverage_percentage == 100.0, f"Expected 100% coverage, got {coverage_percentage:.1f}%"
-
-    def test_no_time_to_event_metrics_included(self):
-        """Verify that time-to-event metrics are excluded from the comparison."""
-        all_metrics = Metrics.get_all_metrics()
-        time_to_event_metrics = []
-
-        for metric_name in all_metrics:
-            try:
-                config = Metrics.get_instance(metric_name)
-                if config.supports_ml_type(MLType.TIMETOEVENT):
-                    time_to_event_metrics.append(metric_name)
-            except Exception:
-                continue
-
-        # Verify that time-to-event metrics exist but are not in autogluon inventory
-        if time_to_event_metrics:
-            for metric in time_to_event_metrics:
-                # It's OK if time-to-event metrics are not in autogluon inventory
-                # This test just documents that they exist and are excluded
-                print(f"Time-to-event metric excluded from comparison: {metric}")
-
-        # This test always passes - it's for documentation
-        assert True, "Time-to-event metrics are properly excluded from the comparison"
+        with pytest.raises(ValueError, match="time-to-event"):
+            module.fit(
+                data_traindev=MagicMock(),
+                data_test=MagicMock(),
+                feature_cols=[],
+                study_context=study_context,
+                outer_split_id=0,
+                results_dir=MagicMock(),
+                scratch_dir=MagicMock(),
+                n_assigned_cpus=1,
+                feature_groups={},
+                prior_results={},
+            )
 
 
 if __name__ == "__main__":
-    # Allow running the test directly
     pytest.main([__file__, "-v"])

--- a/tests/modules/autogluon/test_metrics_coverage.py
+++ b/tests/modules/autogluon/test_metrics_coverage.py
@@ -3,7 +3,7 @@
 import pytest
 
 from octopus.metrics import Metrics
-from octopus.modules.autogluon.core import metrics_inventory_autogluon
+from octopus.modules.autogluon.core import _AG_METRIC_MAP
 from octopus.types import MLType
 
 
@@ -14,7 +14,7 @@ class TestAutogluonMetricsCoverage:
     def test_all_metrics_covered(self, ml_type: MLType) -> None:
         """Every octopus metric for the given ML type must have an AG mapping."""
         octopus_metrics = set(Metrics.get_by_type(ml_type))
-        ag_metrics = set(metrics_inventory_autogluon.keys())
+        ag_metrics = set(_AG_METRIC_MAP.keys())
         missing = sorted(octopus_metrics - ag_metrics)
         assert not missing, (
             f"Octopus {ml_type.value} metrics missing from autogluon inventory: {missing}. "
@@ -24,7 +24,7 @@ class TestAutogluonMetricsCoverage:
     def test_t2e_metrics_excluded(self) -> None:
         """Time-to-event metrics should NOT be in the AG inventory."""
         t2e_metrics = set(Metrics.get_by_type(MLType.TIMETOEVENT))
-        ag_metrics = set(metrics_inventory_autogluon.keys())
+        ag_metrics = set(_AG_METRIC_MAP.keys())
         assert t2e_metrics, "Expected at least one T2E metric to exist"
         overlap = t2e_metrics & ag_metrics
         assert not overlap, f"T2E metrics should not be in AG inventory: {overlap}"

--- a/tests/modules/autogluon/test_persistence.py
+++ b/tests/modules/autogluon/test_persistence.py
@@ -1,0 +1,177 @@
+"""Persistence tests for the SklearnClassifier / SklearnRegressor adapters.
+
+The on-disk contract is:
+  * AG persists itself under `<results_dir>/best/model/ag_predictor/`.
+  * `ModuleResult.save` joblib-pickles the wrapper into the same `model/` dir.
+  * Pickling the wrapper persists ONLY the AG store path; loading reads the
+    AG predictor back via `TabularPredictor.load(path)`.
+
+These tests fit a tiny AG predictor, build the wrapper, round-trip it through
+joblib, and verify the reloaded wrapper produces predictions that match the
+original (and exposes the right `classes_` / `predict_proba` contract).
+"""
+
+from __future__ import annotations
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+import ray
+from sklearn.datasets import make_classification, make_regression
+
+from octopus._optional.autogluon import TabularPredictor
+from octopus.modules.autogluon.adapters import SklearnClassifier, SklearnRegressor
+
+
+def _binary_data(n: int = 60) -> pd.DataFrame:
+    X, y = make_classification(
+        n_samples=n,
+        n_features=5,
+        n_informative=3,
+        n_redundant=2,
+        n_classes=2,
+        random_state=42,
+    )
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(5)])
+    df["target"] = y
+    return df
+
+
+def _regression_data(n: int = 60) -> pd.DataFrame:
+    X, y = make_regression(n_samples=n, n_features=5, noise=0.1, random_state=42, coef=False)  # type: ignore[misc]
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(5)])
+    df["target"] = y
+    return df
+
+
+def _fit(train: pd.DataFrame, *, eval_metric: str, path) -> TabularPredictor:
+    feature_cols = [f"feat_{i}" for i in range(5)]
+    train_data = train[[*feature_cols, "target"]]
+    predictor = TabularPredictor(
+        label="target",
+        eval_metric=eval_metric,
+        verbosity=0,
+        log_to_file=False,
+        path=str(path),
+    )
+    predictor.fit(train_data, time_limit=30, num_bag_folds=2, num_bag_sets=1)
+    if ray.is_initialized():
+        ray.shutdown()
+    return predictor
+
+
+@pytest.fixture(scope="module")
+def binary_wrapper(tmp_path_factory):
+    """Return (wrapper, x_test, classes) for a fitted binary AG predictor."""
+    df = _binary_data()
+    train, test = df.iloc[:40].reset_index(drop=True), df.iloc[40:].reset_index(drop=True)
+    ag_path = tmp_path_factory.mktemp("persist_binary") / "ag_predictor"
+    predictor = _fit(train, eval_metric="balanced_accuracy", path=ag_path)
+    wrapper = SklearnClassifier(predictor)
+    feature_cols = [f"feat_{i}" for i in range(5)]
+    return {
+        "wrapper": wrapper,
+        "x_test": test[feature_cols],
+        "y_test": test["target"].to_numpy(),
+        "class_labels": list(predictor.class_labels),
+    }
+
+
+@pytest.fixture(scope="module")
+def regression_wrapper(tmp_path_factory):
+    """Return (wrapper, x_test) for a fitted regression AG predictor."""
+    df = _regression_data()
+    train, test = df.iloc[:40].reset_index(drop=True), df.iloc[40:].reset_index(drop=True)
+    ag_path = tmp_path_factory.mktemp("persist_regression") / "ag_predictor"
+    predictor = _fit(train, eval_metric="r2", path=ag_path)
+    wrapper = SklearnRegressor(predictor)
+    feature_cols = [f"feat_{i}" for i in range(5)]
+    return {"wrapper": wrapper, "x_test": test[feature_cols]}
+
+
+def _roundtrip(wrapper, tmp_path):
+    """Pickle wrapper to disk via joblib, then load back."""
+    blob = tmp_path / "model.joblib"
+    joblib.dump(wrapper, blob)
+    return joblib.load(blob)
+
+
+class TestClassifierPersistence:
+    """Joblib round-trip yields a wrapper that produces identical predictions."""
+
+    def test_predict_matches_after_reload(self, binary_wrapper, tmp_path) -> None:
+        """Hard-label predictions are bit-exact after pickle round-trip."""
+        wrapper = binary_wrapper["wrapper"]
+        x_test = binary_wrapper["x_test"]
+        original = wrapper.predict(x_test)
+        reloaded_wrapper = _roundtrip(wrapper, tmp_path)
+        reloaded = reloaded_wrapper.predict(x_test)
+        np.testing.assert_array_equal(original, reloaded)
+
+    def test_predict_proba_matches_after_reload(self, binary_wrapper, tmp_path) -> None:
+        """Probability predictions match exactly after round-trip."""
+        wrapper = binary_wrapper["wrapper"]
+        x_test = binary_wrapper["x_test"]
+        original = wrapper.predict_proba(x_test)
+        reloaded = _roundtrip(wrapper, tmp_path).predict_proba(x_test)
+        np.testing.assert_allclose(original, reloaded, rtol=0, atol=0)
+
+    def test_classes_preserved(self, binary_wrapper, tmp_path) -> None:
+        """The reloaded wrapper exposes the same class label array.
+
+        OctoPredictor relies on `self.classes_[np.argmax(...)]` to map argmax
+        positions back to actual labels; this contract must survive reload.
+        """
+        wrapper = binary_wrapper["wrapper"]
+        reloaded = _roundtrip(wrapper, tmp_path)
+        np.testing.assert_array_equal(reloaded.classes_, np.asarray(binary_wrapper["class_labels"]))
+
+    def test_predict_proba_shape_and_normalization(self, binary_wrapper, tmp_path) -> None:
+        """`predict_proba` returns ndarray of shape (n_samples, n_classes), rows sum to 1."""
+        wrapper = binary_wrapper["wrapper"]
+        x_test = binary_wrapper["x_test"]
+        proba = _roundtrip(wrapper, tmp_path).predict_proba(x_test)
+        assert isinstance(proba, np.ndarray)
+        assert proba.shape == (len(x_test), len(binary_wrapper["class_labels"]))
+        np.testing.assert_allclose(proba.sum(axis=1), 1.0, rtol=1e-5)
+
+    def test_feature_names_preserved(self, binary_wrapper, tmp_path) -> None:
+        """`feature_names_in_` survives round-trip."""
+        wrapper = binary_wrapper["wrapper"]
+        reloaded = _roundtrip(wrapper, tmp_path)
+        assert list(reloaded.feature_names_in_) == list(wrapper.feature_names_in_)
+
+
+class TestRegressorPersistence:
+    """Regressor round-trip preserves predictions."""
+
+    def test_predict_matches_after_reload(self, regression_wrapper, tmp_path) -> None:
+        """Numeric predictions match exactly after pickle round-trip."""
+        wrapper = regression_wrapper["wrapper"]
+        x_test = regression_wrapper["x_test"]
+        original = wrapper.predict(x_test)
+        reloaded = _roundtrip(wrapper, tmp_path).predict(x_test)
+        np.testing.assert_allclose(original, reloaded, rtol=0, atol=0)
+
+    def test_feature_names_preserved(self, regression_wrapper, tmp_path) -> None:
+        """`feature_names_in_` survives round-trip."""
+        wrapper = regression_wrapper["wrapper"]
+        reloaded = _roundtrip(wrapper, tmp_path)
+        assert list(reloaded.feature_names_in_) == list(wrapper.feature_names_in_)
+
+
+class TestFitRefused:
+    """The wrappers are inference-only; calling fit must raise."""
+
+    def test_classifier_fit_raises(self, binary_wrapper) -> None:
+        """SklearnClassifier.fit raises NotImplementedError."""
+        wrapper = binary_wrapper["wrapper"]
+        with pytest.raises(NotImplementedError, match="already fitted"):
+            wrapper.fit(binary_wrapper["x_test"], binary_wrapper["y_test"])
+
+    def test_regressor_fit_raises(self, regression_wrapper) -> None:
+        """SklearnRegressor.fit raises NotImplementedError."""
+        wrapper = regression_wrapper["wrapper"]
+        with pytest.raises(NotImplementedError, match="already fitted"):
+            wrapper.fit(regression_wrapper["x_test"], np.zeros(len(regression_wrapper["x_test"])))

--- a/tests/modules/autogluon/test_predictions.py
+++ b/tests/modules/autogluon/test_predictions.py
@@ -1,0 +1,310 @@
+"""Unit tests for octopus.modules.autogluon.predictions.
+
+These tests fit small AutoGluon predictors directly (bypassing the octopus
+workflow) and verify that `build_predictions` produces frames matching Tako's
+canonical schema: columns, dtypes, target attachment, length, label space.
+
+Each predictor fixture is module-scoped so the fits happen once per module run.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+import ray
+from sklearn.datasets import make_classification, make_regression
+from upath import UPath
+
+from octopus._optional.autogluon import TabularPredictor
+from octopus.modules import StudyContext
+from octopus.modules.autogluon.predictions import build_predictions
+from octopus.types import DataPartition, MLType
+
+
+def _study_context(ml_type: MLType, *, positive_class: int | None = None) -> StudyContext:
+    return StudyContext(
+        ml_type=ml_type,
+        target_metric="ACCBAL" if ml_type == MLType.BINARY else "R2",
+        target_assignments={"target": "target"},
+        positive_class=positive_class,
+        stratification_col=None,
+        sample_id_col="row_id",
+        feature_cols=[f"feat_{i}" for i in range(5)],
+        row_id_col="row_id",
+        output_path=UPath("/tmp"),
+        log_dir=UPath("/tmp"),
+    )
+
+
+def _binary_data(n: int = 60) -> pd.DataFrame:
+    X, y = make_classification(
+        n_samples=n,
+        n_features=5,
+        n_informative=3,
+        n_redundant=2,
+        n_classes=2,
+        random_state=42,
+    )
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(5)])
+    df["target"] = y
+    df["row_id"] = np.arange(n)
+    return df
+
+
+def _multiclass_data(n: int = 90) -> pd.DataFrame:
+    X, y = make_classification(
+        n_samples=n,
+        n_features=5,
+        n_informative=4,
+        n_redundant=1,
+        n_classes=3,
+        n_clusters_per_class=1,
+        random_state=42,
+    )
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(5)])
+    df["target"] = y
+    df["row_id"] = np.arange(n)
+    return df
+
+
+def _regression_data(n: int = 60) -> pd.DataFrame:
+    X, y = make_regression(n_samples=n, n_features=5, noise=0.1, random_state=42, coef=False)  # type: ignore[misc]
+    df = pd.DataFrame(X, columns=[f"feat_{i}" for i in range(5)])
+    df["target"] = y
+    df["row_id"] = np.arange(n)
+    return df
+
+
+def _split(df: pd.DataFrame, n_test: int = 20) -> tuple[pd.DataFrame, pd.DataFrame]:
+    return df.iloc[:-n_test].reset_index(drop=True), df.iloc[-n_test:].reset_index(drop=True)
+
+
+def _fit(traindev: pd.DataFrame, *, eval_metric: str, tmp_path) -> TabularPredictor:
+    feature_cols = [f"feat_{i}" for i in range(5)]
+    train_data = traindev[[*feature_cols, "target"]]
+    predictor = TabularPredictor(
+        label="target",
+        eval_metric=eval_metric,
+        verbosity=0,
+        log_to_file=False,
+        path=str(tmp_path),
+        learner_kwargs={"cache_data": True},
+    )
+    predictor.fit(train_data, time_limit=30, num_bag_folds=2, num_bag_sets=1)
+    if ray.is_initialized():
+        ray.shutdown()
+    return predictor
+
+
+@pytest.fixture(scope="module")
+def binary_setup(tmp_path_factory):
+    df = _binary_data()
+    traindev, test = _split(df)
+    predictor = _fit(traindev, eval_metric="balanced_accuracy", tmp_path=tmp_path_factory.mktemp("ag_binary"))
+    ctx = _study_context(MLType.BINARY, positive_class=1)
+    preds = build_predictions(
+        predictor,
+        study_context=ctx,
+        data_traindev=traindev,
+        data_test=test,
+        outer_split_id=0,
+        task_id=0,
+    )
+    yield {"traindev": traindev, "test": test, "predictions": preds, "class_labels": [0, 1]}
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+@pytest.fixture(scope="module")
+def multiclass_setup(tmp_path_factory):
+    df = _multiclass_data()
+    traindev, test = _split(df, n_test=30)
+    predictor = _fit(traindev, eval_metric="balanced_accuracy", tmp_path=tmp_path_factory.mktemp("ag_multi"))
+    ctx = _study_context(MLType.MULTICLASS)
+    preds = build_predictions(
+        predictor,
+        study_context=ctx,
+        data_traindev=traindev,
+        data_test=test,
+        outer_split_id=0,
+        task_id=0,
+    )
+    yield {"traindev": traindev, "test": test, "predictions": preds, "class_labels": [0, 1, 2]}
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+@pytest.fixture(scope="module")
+def regression_setup(tmp_path_factory):
+    df = _regression_data()
+    traindev, test = _split(df)
+    predictor = _fit(traindev, eval_metric="r2", tmp_path=tmp_path_factory.mktemp("ag_reg"))
+    ctx = _study_context(MLType.REGRESSION)
+    preds = build_predictions(
+        predictor,
+        study_context=ctx,
+        data_traindev=traindev,
+        data_test=test,
+        outer_split_id=0,
+        task_id=0,
+    )
+    yield {"traindev": traindev, "test": test, "predictions": preds}
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+_COMMON_COLS = {"row_id", "target", "prediction", "outer_split_id", "inner_split_id", "partition", "task_id"}
+
+
+class TestBinarySchema:
+    """Binary predictions must include the target, hard prediction, and proba columns 0/1."""
+
+    def test_partitions_present(self, binary_setup) -> None:
+        """Both DEV and TEST partitions are returned."""
+        preds = binary_setup["predictions"]
+        assert set(preds.keys()) == {DataPartition.DEV, DataPartition.TEST}
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_columns(self, binary_setup, partition: DataPartition) -> None:
+        """Frame carries the canonical schema columns plus int probability columns 0 and 1."""
+        df = binary_setup["predictions"][partition]
+        assert _COMMON_COLS.issubset(df.columns)
+        assert 0 in df.columns and 1 in df.columns
+        assert all(isinstance(c, int) for c in (0, 1))
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_length_matches_source(self, binary_setup, partition: DataPartition) -> None:
+        """Row count equals the source data length."""
+        df = binary_setup["predictions"][partition]
+        source = binary_setup["traindev"] if partition == DataPartition.DEV else binary_setup["test"]
+        assert len(df) == len(source)
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_target_attached(self, binary_setup, partition: DataPartition) -> None:
+        """Target column values match the source frame in order."""
+        df = binary_setup["predictions"][partition]
+        source = binary_setup["traindev"] if partition == DataPartition.DEV else binary_setup["test"]
+        assert df["target"].tolist() == source["target"].tolist()
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_label_space(self, binary_setup, partition: DataPartition) -> None:
+        """Hard predictions stay within the binary label set."""
+        df = binary_setup["predictions"][partition]
+        assert set(df["prediction"].unique()).issubset({0, 1})
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_probabilities_sum_to_one(self, binary_setup, partition: DataPartition) -> None:
+        """Probabilities for the two classes sum to one per row."""
+        df = binary_setup["predictions"][partition]
+        sums = df[[0, 1]].sum(axis=1)
+        np.testing.assert_allclose(sums.to_numpy(), 1.0, rtol=1e-5)
+
+    def test_inner_split_id(self, binary_setup) -> None:
+        """All rows carry the AG-specific inner_split_id sentinel."""
+        for df in binary_setup["predictions"].values():
+            assert (df["inner_split_id"] == "autogluon").all()
+
+
+class TestMulticlassSchema:
+    """Multiclass predictions must include columns 0/1/2 and labels in [0, 1, 2]."""
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_columns(self, multiclass_setup, partition: DataPartition) -> None:
+        """Frame carries the canonical schema columns plus int probability columns 0, 1, 2."""
+        df = multiclass_setup["predictions"][partition]
+        assert _COMMON_COLS.issubset(df.columns)
+        for label in (0, 1, 2):
+            assert label in df.columns
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_label_space(self, multiclass_setup, partition: DataPartition) -> None:
+        """Hard predictions stay within the multiclass label set."""
+        df = multiclass_setup["predictions"][partition]
+        assert set(df["prediction"].unique()).issubset({0, 1, 2})
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_target_attached(self, multiclass_setup, partition: DataPartition) -> None:
+        """Target column values match the source frame in order."""
+        df = multiclass_setup["predictions"][partition]
+        source = multiclass_setup["traindev"] if partition == DataPartition.DEV else multiclass_setup["test"]
+        assert df["target"].tolist() == source["target"].tolist()
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_probabilities_sum_to_one(self, multiclass_setup, partition: DataPartition) -> None:
+        """Probabilities for the three classes sum to one per row."""
+        df = multiclass_setup["predictions"][partition]
+        sums = df[[0, 1, 2]].sum(axis=1)
+        np.testing.assert_allclose(sums.to_numpy(), 1.0, rtol=1e-5)
+
+
+class TestRegressionSchema:
+    """Regression predictions must NOT carry probability columns."""
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_columns(self, regression_setup, partition: DataPartition) -> None:
+        """Frame contains exactly the canonical columns - no probability columns."""
+        df = regression_setup["predictions"][partition]
+        assert set(df.columns) == _COMMON_COLS
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_prediction_dtype_numeric(self, regression_setup, partition: DataPartition) -> None:
+        """Regression predictions are numeric."""
+        df = regression_setup["predictions"][partition]
+        assert pd.api.types.is_numeric_dtype(df["prediction"])
+
+    @pytest.mark.parametrize("partition", [DataPartition.DEV, DataPartition.TEST])
+    def test_length_matches_source(self, regression_setup, partition: DataPartition) -> None:
+        """Row count equals the source data length."""
+        df = regression_setup["predictions"][partition]
+        source = regression_setup["traindev"] if partition == DataPartition.DEV else regression_setup["test"]
+        assert len(df) == len(source)
+
+
+@pytest.fixture(scope="module")
+def shuffled_binary_setup(tmp_path_factory):
+    """Binary fit on a traindev frame whose index is randomly permuted.
+
+    Locks in the contract that OOF predictions are aligned to the caller's
+    row order via `reindex(source_index)`, not to AG's internal order.
+    """
+    df = _binary_data()
+    traindev_unshuffled, test = _split(df)
+    rng = np.random.default_rng(123)
+    shuffled_index = rng.permutation(traindev_unshuffled.index.to_numpy())
+    traindev = traindev_unshuffled.reindex(shuffled_index)
+    predictor = _fit(
+        traindev,
+        eval_metric="balanced_accuracy",
+        tmp_path=tmp_path_factory.mktemp("ag_binary_shuffled"),
+    )
+    ctx = _study_context(MLType.BINARY, positive_class=1)
+    preds = build_predictions(
+        predictor,
+        study_context=ctx,
+        data_traindev=traindev,
+        data_test=test,
+        outer_split_id=0,
+        task_id=0,
+    )
+    yield {"predictor": predictor, "traindev": traindev, "predictions": preds}
+    if ray.is_initialized():
+        ray.shutdown()
+
+
+class TestShuffledIndexAlignment:
+    """OOF predictions must align to the caller's source-frame index, not AG's internal order."""
+
+    def test_dev_prediction_matches_manual_reindex(self, shuffled_binary_setup) -> None:
+        """`prediction` column equals `predict_oof` reindexed to the shuffled traindev index."""
+        predictor = shuffled_binary_setup["predictor"]
+        traindev = shuffled_binary_setup["traindev"]
+        dev = shuffled_binary_setup["predictions"][DataPartition.DEV]
+        expected = predictor.predict_oof(model=predictor.model_best).reindex(traindev.index).to_numpy()
+        np.testing.assert_array_equal(dev["prediction"].to_numpy(), expected)
+
+    def test_dev_target_matches_source_in_shuffled_order(self, shuffled_binary_setup) -> None:
+        """`target` column reflects the shuffled source order, not the unshuffled original."""
+        traindev = shuffled_binary_setup["traindev"]
+        dev = shuffled_binary_setup["predictions"][DataPartition.DEV]
+        assert dev["target"].tolist() == traindev["target"].tolist()

--- a/tests/modules/autogluon/test_scoring.py
+++ b/tests/modules/autogluon/test_scoring.py
@@ -1,0 +1,204 @@
+"""Unit tests for octopus.modules.autogluon.scoring.
+
+These tests hand-build prediction frames in the canonical schema and verify
+`compute_scores` produces a long-format scores DataFrame whose values agree
+with `get_performance_from_predictions` called directly. No AG fit is needed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from upath import UPath
+
+from octopus.metrics import Metrics
+from octopus.metrics.utils import get_performance_from_predictions
+from octopus.modules import StudyContext
+from octopus.modules.autogluon.core import _compute_scores as compute_scores
+from octopus.types import DataPartition, MLType
+
+
+def _study_context(ml_type: MLType, *, target_metric: str, positive_class: int | None = None) -> StudyContext:
+    return StudyContext(
+        ml_type=ml_type,
+        target_metric=target_metric,
+        target_assignments={"target": "y"},
+        positive_class=positive_class,
+        stratification_col=None,
+        sample_id_col="id",
+        feature_cols=[],
+        row_id_col="id",
+        output_path=UPath("/tmp"),
+        log_dir=UPath("/tmp"),
+    )
+
+
+def _binary_predictions() -> dict[DataPartition, pd.DataFrame]:
+    rng = np.random.default_rng(0)
+    rows = 40
+    y_dev = rng.integers(0, 2, size=rows)
+    y_test = rng.integers(0, 2, size=rows)
+    proba_dev = rng.uniform(0.0, 1.0, size=rows)
+    proba_test = rng.uniform(0.0, 1.0, size=rows)
+    dev = pd.DataFrame(
+        {
+            "id": np.arange(rows),
+            "y": y_dev,
+            "prediction": (proba_dev >= 0.5).astype(int),
+            0: 1.0 - proba_dev,
+            1: proba_dev,
+            "outer_split_id": 0,
+            "inner_split_id": "autogluon",
+            "partition": DataPartition.DEV,
+            "task_id": 0,
+        }
+    )
+    test = pd.DataFrame(
+        {
+            "id": np.arange(rows, 2 * rows),
+            "y": y_test,
+            "prediction": (proba_test >= 0.5).astype(int),
+            0: 1.0 - proba_test,
+            1: proba_test,
+            "outer_split_id": 0,
+            "inner_split_id": "autogluon",
+            "partition": DataPartition.TEST,
+            "task_id": 0,
+        }
+    )
+    return {DataPartition.DEV: dev, DataPartition.TEST: test}
+
+
+def _multiclass_predictions() -> dict[DataPartition, pd.DataFrame]:
+    rng = np.random.default_rng(1)
+    rows = 30
+    y_dev = rng.integers(0, 3, size=rows)
+    y_test = rng.integers(0, 3, size=rows)
+    proba_dev = rng.dirichlet(alpha=(1.0, 1.0, 1.0), size=rows)
+    proba_test = rng.dirichlet(alpha=(1.0, 1.0, 1.0), size=rows)
+    dev = pd.DataFrame(
+        {
+            "id": np.arange(rows),
+            "y": y_dev,
+            "prediction": proba_dev.argmax(axis=1),
+            0: proba_dev[:, 0],
+            1: proba_dev[:, 1],
+            2: proba_dev[:, 2],
+            "outer_split_id": 0,
+            "inner_split_id": "autogluon",
+            "partition": DataPartition.DEV,
+            "task_id": 0,
+        }
+    )
+    test = pd.DataFrame(
+        {
+            "id": np.arange(rows, 2 * rows),
+            "y": y_test,
+            "prediction": proba_test.argmax(axis=1),
+            0: proba_test[:, 0],
+            1: proba_test[:, 1],
+            2: proba_test[:, 2],
+            "outer_split_id": 0,
+            "inner_split_id": "autogluon",
+            "partition": DataPartition.TEST,
+            "task_id": 0,
+        }
+    )
+    return {DataPartition.DEV: dev, DataPartition.TEST: test}
+
+
+def _regression_predictions() -> dict[DataPartition, pd.DataFrame]:
+    rng = np.random.default_rng(2)
+    rows = 30
+    y_dev = rng.normal(size=rows)
+    y_test = rng.normal(size=rows)
+    dev = pd.DataFrame(
+        {
+            "id": np.arange(rows),
+            "y": y_dev,
+            "prediction": y_dev + rng.normal(scale=0.1, size=rows),
+            "outer_split_id": 0,
+            "inner_split_id": "autogluon",
+            "partition": DataPartition.DEV,
+            "task_id": 0,
+        }
+    )
+    test = pd.DataFrame(
+        {
+            "id": np.arange(rows, 2 * rows),
+            "y": y_test,
+            "prediction": y_test + rng.normal(scale=0.1, size=rows),
+            "outer_split_id": 0,
+            "inner_split_id": "autogluon",
+            "partition": DataPartition.TEST,
+            "task_id": 0,
+        }
+    )
+    return {DataPartition.DEV: dev, DataPartition.TEST: test}
+
+
+class TestComputeScores:
+    """Verify compute_scores delegates correctly to get_performance_from_predictions."""
+
+    def test_binary_score_shape(self) -> None:
+        """Binary scores cover all binary metrics for both partitions in long format."""
+        ctx = _study_context(MLType.BINARY, target_metric="ACCBAL", positive_class=1)
+        scores = compute_scores(_binary_predictions(), study_context=ctx)
+        expected_metrics = set(Metrics.get_by_type(MLType.BINARY))
+        assert set(scores["metric"]) == expected_metrics
+        assert set(scores["partition"]) == {DataPartition.DEV, DataPartition.TEST}
+        assert (scores["aggregation"] == "ensemble").all()
+        assert scores["split"].isna().all()
+        assert len(scores) == 2 * len(expected_metrics)
+
+    def test_multiclass_score_shape(self) -> None:
+        """Multiclass scores cover all multiclass metrics for both partitions."""
+        ctx = _study_context(MLType.MULTICLASS, target_metric="ACCBAL_MC")
+        scores = compute_scores(_multiclass_predictions(), study_context=ctx)
+        expected_metrics = set(Metrics.get_by_type(MLType.MULTICLASS))
+        assert set(scores["metric"]) == expected_metrics
+        assert len(scores) == 2 * len(expected_metrics)
+
+    def test_regression_score_shape(self) -> None:
+        """Regression scores cover all regression metrics for both partitions."""
+        ctx = _study_context(MLType.REGRESSION, target_metric="R2")
+        scores = compute_scores(_regression_predictions(), study_context=ctx)
+        expected_metrics = set(Metrics.get_by_type(MLType.REGRESSION))
+        assert set(scores["metric"]) == expected_metrics
+        assert len(scores) == 2 * len(expected_metrics)
+
+    @pytest.mark.parametrize(
+        ("ml_type", "metric_name", "positive_class", "factory"),
+        [
+            (MLType.BINARY, "AUCROC", 1, _binary_predictions),
+            (MLType.BINARY, "ACCBAL", 1, _binary_predictions),
+            (MLType.MULTICLASS, "ACCBAL_MC", None, _multiclass_predictions),
+            (MLType.MULTICLASS, "AUCROC_MACRO", None, _multiclass_predictions),
+            (MLType.REGRESSION, "R2", None, _regression_predictions),
+            (MLType.REGRESSION, "RMSE", None, _regression_predictions),
+        ],
+    )
+    def test_values_match_canonical_helper(
+        self,
+        ml_type: MLType,
+        metric_name: str,
+        positive_class: int | None,
+        factory,
+    ) -> None:
+        """Each value in the scores frame must equal the helper's direct result."""
+        ctx = _study_context(ml_type, target_metric=metric_name, positive_class=positive_class)
+        predictions = factory()
+        scores = compute_scores(predictions, study_context=ctx)
+
+        reference = get_performance_from_predictions(
+            {"ensemble": dict(predictions.items())},
+            target_metric=metric_name,
+            target_assignments=ctx.target_assignments,
+            positive_class=positive_class,
+        )
+
+        for partition in (DataPartition.DEV, DataPartition.TEST):
+            row = scores[(scores["metric"] == metric_name) & (scores["partition"] == partition)]
+            assert len(row) == 1
+            assert float(row["value"].iloc[0]) == pytest.approx(reference["ensemble"][partition], rel=1e-9)

--- a/tests/workflows/test_ag_workflows.py
+++ b/tests/workflows/test_ag_workflows.py
@@ -92,6 +92,76 @@ class TestAutogluonWorkflows:
         assert (task_dir / "results" / "best").exists(), "Best result directory should exist"
         assert (task_dir / "results" / "best" / "model").exists(), "Model directory should exist"
 
+    def test_full_multiclass_workflow(self):
+        """Test the multiclass classification workflow with canonical [0, 1, 2] labels.
+
+        Verifies the prediction column contains actual class labels (subset of {0,1,2}),
+        probability columns are integer-named, and ACCBAL_MC / AUCROC_MACRO are finite
+        values in [0, 1].
+        """
+        X, y = make_classification(
+            n_samples=60,
+            n_features=5,
+            n_informative=3,
+            n_redundant=2,
+            n_classes=3,
+            n_clusters_per_class=1,
+            random_state=42,
+        )
+        feature_names = [f"feature_{i}" for i in range(5)]
+        df_mc = pd.DataFrame(X, columns=feature_names)
+        df_mc["target"] = y
+        df_mc = df_mc.reset_index()
+
+        study = OctoClassification(
+            study_name="test_multiclass_workflow",
+            target_metric="ACCBAL_MC",
+            feature_cols=feature_names,
+            target_col="target",
+            sample_id_col="index",
+            stratification_col="target",
+            outer_split_seed=1234,
+            n_outer_splits=2,
+            studies_directory=self.studies_path,
+            single_outer_split=0,
+            workflow=[
+                AutoGluon(
+                    description="ag_multiclass_test",
+                    task_id=0,
+                    depends_on=None,
+                    presets=["medium_quality"],
+                    time_limit=15,
+                ),
+            ],
+        )
+
+        study.fit(data=df_mc)
+
+        study_path = study.output_path
+        task_dir = next(d for d in (study_path / "outersplit0").iterdir() if d.name.startswith("task"))
+        predictions_path = task_dir / "results" / "best" / "predictions.parquet"
+        scores_path = task_dir / "results" / "best" / "scores.parquet"
+        assert predictions_path.exists(), "Predictions parquet should exist"
+        assert scores_path.exists(), "Scores parquet should exist"
+
+        predictions = pd.read_parquet(predictions_path)
+        # Parquet roundtrip stringifies int column names; check both forms.
+        prediction_values = set(predictions["prediction"].astype(int).unique())
+        assert prediction_values.issubset({0, 1, 2})
+        prob_cols = [c for c in predictions.columns if str(c) in ("0", "1", "2")]
+        assert {str(c) for c in prob_cols} == {"0", "1", "2"}, (
+            f"expected probability columns labelled 0,1,2; got {prob_cols}"
+        )
+        prob_sums = predictions[prob_cols].sum(axis=1)
+        assert ((prob_sums - 1.0).abs() < 1e-3).all(), "row probabilities should sum to ~1.0"
+
+        scores = pd.read_parquet(scores_path)
+        for metric in ("ACCBAL_MC", "AUCROC_MACRO"):
+            metric_rows = scores[scores["metric"] == metric]
+            assert not metric_rows.empty, f"missing {metric} in scores"
+            for value in metric_rows["value"]:
+                assert pd.notna(value) and 0.0 <= float(value) <= 1.0, f"{metric}={value} not in [0, 1]"
+
     def test_full_regression_workflow(self):
         """Test the complete regression workflow execution."""
         # Create synthetic regression dataset with reduced size for faster testing


### PR DESCRIPTION
Fix correctness issues in the AutoGluon module's feature importance and score reporting, align its result schema with the rest of the codebase, and add a guard for unsupported task types. Reorganize the AG module into focused submodules and add a test suite.

Metric inventory fixes (MSE, BRIERSCORE, multiclass metrics) have been extracted to #434 and are not part of this PR.

## Correctness

- **Feature importances were computed on test data** (`feature_importance(data=ag_test_data, ...)`), leaking the test set into FI values used downstream by MRMR (fixes #426, fixes #427). Now computed on out-of-fold predictions via the best level-1 bagged model (`feature_stage="transformed_model"`). Transformed-feature importances are aggregated back to original feature names via `feature_generator.get_feature_links()`; if AG ever returns transformed names absent from both the link map and `feature_cols`, the aggregator raises rather than silently dropping importances.
- **Leaderboard CSV included test scores** because the previous save path passed `ag_test_data` into `model.leaderboard()`. Test data removed; the leaderboard is now diagnostic-only and uses AG's internal validation scores.
- **Score schema was a flat dict of mixed AG-native metrics** (`*_train`, `*_dev`, `*_test`, `*_test_octo`) that did not match the canonical `metric / partition / aggregation / split / value` schema produced by Tako. Scoring now delegates entirely to `octopus.metrics.utils.get_performance_from_predictions` so AG and Tako share one metric router. Dev scores are computed from OOF predictions; test scores from in-memory `predict` / `predict_proba` against the test frame.
- **OOF predictions are now reindexed to the caller's source-frame index** before being concatenated with row_id / target, removing reliance on AG's internal row order. Misalignment surfaces as `RuntimeError` rather than silently mis-paired predictions and labels. 
- **T2E guard** - raise `ValueError` with an actionable message when AG is configured for a time-to-event task, pointing users at the Tako module with CatBoostCoxSurvival / XGBoostCoxSurvival.

## Architecture

The previous monolithic ``octopus/modules/autogluon/core.py`` (~500 lines mixing fit, prediction frame construction, scoring, FI, and sklearn adapter logic) is split into focused submodules:

- ``adapters.py`` - ``SklearnClassifier`` / ``SklearnRegressor`` wrappers; ``__reduce__`` persists the AG store path so in-process pickling round-trips cheaply within a study tree.
- ``predictions.py`` - ``build_predictions`` produces DEV (OOF) and TEST frames in Tako's canonical schema. Hard predictions for classification are derived from the proba frame's argmax (matches AG's own internal ``predict_oof`` logic; halves OOF compute cost). Two helpers ``_aligned_oof_predict`` / ``_aligned_oof_predict_proba`` encapsulate the reindex-plus-isna contract.
- ``feature_importance.py`` - ``compute_fi`` selects the leaderboard-best L1 child satisfying ``_bagged_mode and not _child_oof``, computes transformed-feature OOF FI, and aggregates back to original features. Returns an empty DataFrame (with a warning) when no qualifying L1 child exists - never falls back to test-data FI, never fails the whole module on optional FI. AG private-API surface and reproducibility caveats are documented in the module docstring.
- ``core.py`` - now contains only the ``AutoGluonModule.fit`` orchestration, the AG/Octopus metric map, the sklearn-wrapper builder, and ``_compute_scores``.

## Code quality

- ``fit()`` signature matches ``ModuleExecution.fit`` from ``modules/base.py``; ``scratch_dir`` and ``dependency_results`` are absorbed via ``**kwargs``  Rationale documented in the ``fit`` docstring.
- Replaced raw partition strings with ``DataPartition.TEST`` / ``DataPartition.DEV``.
- Added a ``prediction`` column to multiclass OOF/test frames for downstream-schema consistency.
