### PR TITLE
complete AG metrics

### DIFF
--- a/octopus/_optional/autogluon.py
+++ b/octopus/_optional/autogluon.py
@@ -9,16 +9,27 @@ try:
         balanced_accuracy,
         f1,
         log_loss,
+        make_scorer,
         mcc,
         mean_absolute_error,
+        mean_squared_error,
         precision,
         r2,
         recall,
         roc_auc,
+        roc_auc_ovr,
+        roc_auc_ovr_weighted,
         root_mean_squared_error,
     )
     from autogluon.tabular import TabularPredictor
+    from sklearn.metrics import brier_score_loss
 
+    brier_score = make_scorer(
+        "brier_score",
+        brier_score_loss,
+        greater_is_better=False,
+        needs_proba=True,
+    )
 
 except ModuleNotFoundError as ex:
     raise OptionalImportError(
@@ -33,13 +44,17 @@ __all__ = [
     "accuracy",
     "average_precision",
     "balanced_accuracy",
+    "brier_score",
     "f1",
     "log_loss",
     "mcc",
     "mean_absolute_error",
+    "mean_squared_error",
     "precision",
     "r2",
     "recall",
     "roc_auc",
+    "roc_auc_ovr",
+    "roc_auc_ovr_weighted",
     "root_mean_squared_error",
 ]

--- a/octopus/modules/autogluon/core.py
+++ b/octopus/modules/autogluon/core.py
@@ -16,14 +16,18 @@ from octopus._optional.autogluon import (
     accuracy,
     average_precision,
     balanced_accuracy,
+    brier_score,
     f1,
     log_loss,
     mcc,
     mean_absolute_error,
+    mean_squared_error,
     precision,
     r2,
     recall,
     roc_auc,
+    roc_auc_ovr,
+    roc_auc_ovr_weighted,
     root_mean_squared_error,
 )
 from octopus.logger import get_logger
@@ -86,21 +90,27 @@ class SklearnRegressor(BaseEstimator, RegressorMixin):
         raise NotImplementedError("This regressor is already fitted. Only for inference use.")
 
 
-# Mapping of Octopus metrics to AutoGluon metrics
+# Mapping of Octopus metric name -> AutoGluon scorer.
+# Validity per ml_type is enforced upstream by Metrics.get_by_type(); this dict
+# assumes the caller has already chosen a metric supported by their ml_type
+# (e.g. AUCROC is binary-only and will error if used for multiclass).
 metrics_inventory_autogluon = {
-    "AUCROC": roc_auc,
     "ACC": accuracy,
     "ACCBAL": balanced_accuracy,
+    "ACCBAL_MC": balanced_accuracy,
     "AUCPR": average_precision,
+    "AUCROC": roc_auc,
+    "AUCROC_MACRO": roc_auc_ovr,
+    "AUCROC_WEIGHTED": roc_auc_ovr_weighted,
+    "BRIERSCORE": brier_score,
     "F1": f1,
     "LOGLOSS": log_loss,
     "MAE": mean_absolute_error,
     "MCC": mcc,
-    "MSE": root_mean_squared_error,
-    "BRIERSCORE": "brier_score_loss",
+    "MSE": mean_squared_error,
     "PRECISION": precision,
-    "RECALL": recall,
     "R2": r2,
+    "RECALL": recall,
     "RMSE": root_mean_squared_error,
 }
 
@@ -149,6 +159,11 @@ class AutoGluonModule(ModuleExecution["AutoGluon"]):
         if study_context.target_metric is None:
             raise ValueError("target_metric should be set during fit()")
 
+        if study_context.target_metric not in metrics_inventory_autogluon:
+            raise ValueError(
+                f"target_metric={study_context.target_metric!r} is not supported by AutoGluon. "
+                f"Supported metrics: {sorted(metrics_inventory_autogluon)}"
+            )
         scoring_type = metrics_inventory_autogluon[study_context.target_metric]
 
         # Initialize TabularPredictor (store temporarily for fit operations)

--- a/tests/modules/autogluon/test_metrics_coverage.py
+++ b/tests/modules/autogluon/test_metrics_coverage.py
@@ -8,122 +8,27 @@ from octopus.types import MLType
 
 
 class TestAutogluonMetricsCoverage:
-    """Test that all octopus classification and regression metrics are available in autogluon."""
+    """Test that all octopus classification, multiclass, and regression metrics are in AG."""
 
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.autogluon_metrics_inventory = metrics_inventory_autogluon
-
-    def get_octopus_classification_metrics(self):
-        """Get all octopus classification metrics."""
-        all_metrics = Metrics.get_all_metrics()
-        classification_metrics = []
-
-        for metric_name in all_metrics:
-            try:
-                config = Metrics.get_instance(metric_name)
-                if config.supports_ml_type(MLType.BINARY):
-                    classification_metrics.append(metric_name)
-            except Exception:
-                # Skip metrics that can't be configured
-                continue
-
-        return classification_metrics
-
-    def get_octopus_regression_metrics(self):
-        """Get all octopus regression metrics."""
-        all_metrics = Metrics.get_all_metrics()
-        regression_metrics = []
-
-        for metric_name in all_metrics:
-            try:
-                config = Metrics.get_instance(metric_name)
-                if config.supports_ml_type(MLType.REGRESSION):
-                    regression_metrics.append(metric_name)
-            except Exception:
-                # Skip metrics that can't be configured
-                continue
-
-        return regression_metrics
-
-    def test_all_classification_metrics_in_autogluon(self):
-        """Test that all octopus classification metrics are available in autogluon."""
-        octopus_classification_metrics = self.get_octopus_classification_metrics()
-        autogluon_metrics = set(self.autogluon_metrics_inventory.keys())
-
-        missing_metrics = []
-        for metric in octopus_classification_metrics:
-            if metric not in autogluon_metrics:
-                missing_metrics.append(metric)
-
-        assert not missing_metrics, (
-            f"The following octopus classification metrics are missing from autogluon inventory: "
-            f"{missing_metrics}. "
-            f"Octopus classification metrics: {sorted(octopus_classification_metrics)}. "
-            f"Autogluon metrics: {sorted(autogluon_metrics)}"
+    @pytest.mark.parametrize("ml_type", [MLType.BINARY, MLType.MULTICLASS, MLType.REGRESSION])
+    def test_all_metrics_covered(self, ml_type: MLType) -> None:
+        """Every octopus metric for the given ML type must have an AG mapping."""
+        octopus_metrics = set(Metrics.get_by_type(ml_type))
+        ag_metrics = set(metrics_inventory_autogluon.keys())
+        missing = sorted(octopus_metrics - ag_metrics)
+        assert not missing, (
+            f"Octopus {ml_type.value} metrics missing from autogluon inventory: {missing}. "
+            f"Octopus: {sorted(octopus_metrics)}. AG: {sorted(ag_metrics)}"
         )
 
-    def test_all_regression_metrics_in_autogluon(self):
-        """Test that all octopus regression metrics are available in autogluon."""
-        octopus_regression_metrics = self.get_octopus_regression_metrics()
-        autogluon_metrics = set(self.autogluon_metrics_inventory.keys())
-
-        missing_metrics = []
-        for metric in octopus_regression_metrics:
-            if metric not in autogluon_metrics:
-                missing_metrics.append(metric)
-
-        assert not missing_metrics, (
-            f"The following octopus regression metrics are missing from autogluon inventory: "
-            f"{missing_metrics}. "
-            f"Octopus regression metrics: {sorted(octopus_regression_metrics)}. "
-            f"Autogluon metrics: {sorted(autogluon_metrics)}"
-        )
-
-    def test_metrics_coverage_summary(self):
-        """Provide a summary of metrics coverage."""
-        octopus_classification = self.get_octopus_classification_metrics()
-        octopus_regression = self.get_octopus_regression_metrics()
-        autogluon_metrics = set(self.autogluon_metrics_inventory.keys())
-
-        total_octopus_metrics = len(octopus_classification) + len(octopus_regression)
-        covered_metrics = len([m for m in octopus_classification + octopus_regression if m in autogluon_metrics])
-
-        coverage_percentage = (covered_metrics / total_octopus_metrics) * 100 if total_octopus_metrics > 0 else 0
-
-        print("\n=== Metrics Coverage Summary ===")
-        print(f"Octopus Classification Metrics ({len(octopus_classification)}): {sorted(octopus_classification)}")
-        print(f"Octopus Regression Metrics ({len(octopus_regression)}): {sorted(octopus_regression)}")
-        print(f"Autogluon Metrics ({len(autogluon_metrics)}): {sorted(autogluon_metrics)}")
-        print(f"Coverage: {covered_metrics}/{total_octopus_metrics} ({coverage_percentage:.1f}%)")
-
-        # This test should always pass if the above tests pass
-        assert coverage_percentage == 100.0, f"Expected 100% coverage, got {coverage_percentage:.1f}%"
-
-    def test_no_time_to_event_metrics_included(self):
-        """Verify that time-to-event metrics are excluded from the comparison."""
-        all_metrics = Metrics.get_all_metrics()
-        time_to_event_metrics = []
-
-        for metric_name in all_metrics:
-            try:
-                config = Metrics.get_instance(metric_name)
-                if config.supports_ml_type(MLType.TIMETOEVENT):
-                    time_to_event_metrics.append(metric_name)
-            except Exception:
-                continue
-
-        # Verify that time-to-event metrics exist but are not in autogluon inventory
-        if time_to_event_metrics:
-            for metric in time_to_event_metrics:
-                # It's OK if time-to-event metrics are not in autogluon inventory
-                # This test just documents that they exist and are excluded
-                print(f"Time-to-event metric excluded from comparison: {metric}")
-
-        # This test always passes - it's for documentation
-        assert True, "Time-to-event metrics are properly excluded from the comparison"
+    def test_t2e_metrics_excluded(self) -> None:
+        """Time-to-event metrics should NOT be in the AG inventory."""
+        t2e_metrics = set(Metrics.get_by_type(MLType.TIMETOEVENT))
+        ag_metrics = set(metrics_inventory_autogluon.keys())
+        assert t2e_metrics, "Expected at least one T2E metric to exist"
+        overlap = t2e_metrics & ag_metrics
+        assert not overlap, f"T2E metrics should not be in AG inventory: {overlap}"
 
 
 if __name__ == "__main__":
-    # Allow running the test directly
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
MSE metric fix — metrics_inventory_autogluon["MSE"] pointed to root_mean_squared_error (RMSE). Now correctly maps to mean_squared_error.

BRIERSCORE fix — Was a raw string "brier_score_loss" that AG couldn't use as a proper scorer. Now a custom scorer created via make_scorer wrapping sklearn's brier_score_loss with greater_is_better=False and needs_proba=True.

3 multiclass metrics added — ACCBAL_MC, AUCROC_MACRO, AUCROC_WEIGHTED were missing entirely, causing KeyError for multiclass studies using AG.