### PR TITLE
fix: classification target validation and metric computation for non-standard labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor: rename sequence to workflow
 - changed name of output directory
 
+### Changed
+- `Metric.calculate` no longer accepts `**kwargs`. The parameter was always silently discarded by the implementation; explicit kwargs now raise `TypeError`. Custom `Metric` subclasses that override `calculate(self, y_true, y_pred, **kwargs)` continue to work; only callers passing kwargs to the base class are affected.
+
 ## [0.1.0] -
 
 ### Added

--- a/docs/userguide/classification.md
+++ b/docs/userguide/classification.md
@@ -39,9 +39,10 @@ Octopus also auto-converts null-like strings (`"None"`, `"null"`, `"nan"`, `"NA"
 to `NaN` in feature and target columns. The reserved column names `datasplit_group` and
 `row_id` cannot appear in your data.
 
-For binary classification, Octopus automatically sets `positive_class=1` if you
-don't specify it. If your positive class is encoded as a different value (e.g.,
-`0`), set `positive_class` explicitly.
+For binary classification, `positive_class` is auto-inferred as `1` when target
+labels are exactly `{0, 1}`. For any other binary encoding (e.g., `{-1, 1}`,
+`{0, 2}`, string labels mapped to non-`{0, 1}` integers), `positive_class` must
+be specified explicitly.
 
 ```python
 import pandas as pd
@@ -93,7 +94,7 @@ study.fit(data=df)
 | `target_metric` | Metric to optimize | `"AUCROC"` |
 | `sample_id_col` | Column identifying unique subjects (prevents correlated observation leakage) | `None` |
 | `stratification_col` | Column used to keep class ratios balanced across CV splits | `None` |
-| `positive_class` | Integer label of the positive class (binary only). Auto-detected as `1` if omitted. | `None` |
+| `positive_class` | Integer label of the positive class (binary only). Auto-inferred as `1` when labels are `{0, 1}`; required otherwise. | `None` |
 | `n_outer_splits` | Number of outer cross-validation splits | `5` |
 | `single_outer_split` | Run only one split for quick testing (e.g., `0`) | `None` |
 | `n_cpus` | Number of CPUs (`0` = all, `-1` = all but one) | `0` |

--- a/octopus/datasplit.py
+++ b/octopus/datasplit.py
@@ -36,11 +36,24 @@ DATASPLIT_COL = "datasplit_group"
 def validate_class_coverage(
     splits: OuterSplits | InnerSplits,
     target_col: str,
+    *,
+    expected_classes: set[int] | None = None,
 ) -> None:
-    """Verify no split partition contains only a single class.
+    """Verify class coverage across split partitions.
 
-    Raises SingleClassSplitError if any partition has just one unique class,
-    which would cause degenerate model training or undefined metrics.
+    When expected_classes is None, rejects partitions with only a single class
+    (degenerate training). When expected_classes is provided, requires every
+    partition to contain all expected classes (multiclass alignment).
+
+    Args:
+        splits: Outer or inner cross-validation splits.
+        target_col: Name of the target column.
+        expected_classes: If provided, require every partition to contain all
+            these classes. Used for multiclass to prevent models with
+            differing class sets across splits.
+
+    Raises:
+        SingleClassSplitError: If any partition violates coverage requirements.
     """
     for split_id, split in splits.items():
         if isinstance(split, OuterSplit):
@@ -49,7 +62,8 @@ def validate_class_coverage(
             partitions = {"train": split.train, "dev": split.dev}
 
         for part_name, part_df in partitions.items():
-            unique_classes = part_df[target_col].unique()
+            unique_classes = set(part_df[target_col].unique())
+
             if len(unique_classes) <= 1:
                 raise SingleClassSplitError(
                     f"Split {split_id} {part_name} partition contains only class(es) "
@@ -59,6 +73,17 @@ def validate_class_coverage(
                     "or setting `stratification_col` to the target column "
                     "for balanced splits."
                 )
+
+            if expected_classes is not None:
+                missing = expected_classes - unique_classes
+                if missing:
+                    raise SingleClassSplitError(
+                        f"Split {split_id} {part_name} partition is missing classes "
+                        f"{sorted(missing)}. Found: {sorted(unique_classes)}, "
+                        f"expected: {sorted(expected_classes)}. "
+                        "Try: setting `stratification_col` to the target column, "
+                        "increasing dataset size, or reducing `n_inner_splits`."
+                    )
 
 
 @define

--- a/octopus/metrics/config.py
+++ b/octopus/metrics/config.py
@@ -47,13 +47,12 @@ class Metric:
         """Optimization direction for Optuna ('maximize' or 'minimize')."""
         return MetricDirection.MAXIMIZE if self.higher_is_better else MetricDirection.MINIMIZE
 
-    def calculate(self, y_true: OctoArrayLike, y_pred: OctoArrayLike, **kwargs) -> float:
+    def calculate(self, y_true: OctoArrayLike, y_pred: OctoArrayLike) -> float:
         """Calculate metric for classification/regression tasks.
 
         Args:
             y_true: True target values
             y_pred: Predicted values (predictions or probabilities depending on prediction_type)
-            **kwargs: Additional keyword arguments passed to metric function
 
         Returns:
             Metric value as float

--- a/octopus/metrics/utils.py
+++ b/octopus/metrics/utils.py
@@ -14,37 +14,34 @@ def _to_numpy(data: Any) -> np.ndarray:
     return data.to_numpy() if isinstance(data, pd.DataFrame) else np.asarray(data)
 
 
-def _get_probability_columns(pred_df: pd.DataFrame, target_col: str) -> list[int]:
-    """Extract and validate probability columns for multiclass predictions.
+def binarize_target_for_positive_class(
+    target: pd.Series | np.ndarray,
+    positive_class: int | str,
+) -> np.ndarray:
+    """Map a binary target to a {0, 1} indicator for the positive class.
+
+    sklearn's binary metrics (``roc_auc_score``, ``average_precision_score``,
+    ``log_loss``, ``f1_score``, ...) assume ``y_true`` is encoded as ``{0, 1}``
+    with ``1`` denoting the positive class, or require a per-metric ``pos_label``
+    / ``labels`` argument whose name and presence is inconsistent across the API.
+    Binarizing once at the scoring boundary lets every binary metric work
+    uniformly without per-metric special-casing.
+
+    This is only applied at metric/scoring time for binary classification:
+    models still train on the original labels, and multiclass / regression /
+    time-to-event paths do not transform the target.
 
     Args:
-        pred_df: Prediction DataFrame
-        target_col: Target column name (string) to exclude
+        target: Original target values, any binary integer or boolean encoding.
+        positive_class: The label considered positive. Becomes ``1`` in the
+            returned array; all other values become ``0``.
 
     Returns:
-        Sorted list of probability column indices
-
-    Raises:
-        ValueError: If probability columns are not consecutive integers starting from 0
+        Numpy array of dtype int with shape ``(len(target),)`` containing
+        ``1`` where ``target == positive_class`` and ``0`` elsewhere.
     """
-    prob_columns: list[int] = []
-    for col in pred_df.columns:
-        if isinstance(col, int) and col not in [target_col, "prediction"]:
-            prob_columns.append(col)
-
-    if not prob_columns:
-        return []
-
-    prob_columns_sorted = sorted(prob_columns)
-    expected_sequence = list(range(len(prob_columns_sorted)))
-
-    if prob_columns_sorted != expected_sequence:
-        raise ValueError(
-            f"Probability columns must be consecutive integers starting from 0. "
-            f"Found: {prob_columns_sorted}, expected: {expected_sequence}"
-        )
-
-    return prob_columns_sorted
+    result: np.ndarray = (np.asarray(target) == positive_class).astype(int)
+    return result
 
 
 def get_performance_from_model(
@@ -103,12 +100,13 @@ def get_performance_from_model(
             raise ValueError(f"positive_class {positive_class} not found in model classes {model.classes_}") from e
 
         probabilities = _to_numpy(model.predict_proba(input_data))[:, positive_class_idx]
+        target_binary = binarize_target_for_positive_class(target, positive_class)
 
         if metric.prediction_type == PredictionType.PROBABILITIES:
-            return metric.calculate(target, probabilities)
+            return metric.calculate(target_binary, probabilities)
 
         predictions = (probabilities >= threshold).astype(int)
-        return metric.calculate(target, predictions)
+        return metric.calculate(target_binary, predictions)
 
     # Multiclass classification: no positive_class means multiclass context
     if metric.supports_ml_type(MLType.MULTICLASS) and positive_class is None:
@@ -182,18 +180,45 @@ def get_performance_from_predictions(
 
                 # Binary classification: positive_class provided means binary context
                 if positive_class is not None and metric.supports_ml_type(MLType.BINARY):
+                    if positive_class not in pred_df.columns:
+                        raise ValueError(
+                            f"positive_class={positive_class!r} not found in prediction columns "
+                            f"{list(pred_df.columns)!r}. Expected a probability column named after "
+                            f"the positive class."
+                        )
                     probabilities = pred_df[positive_class]
+                    target_binary = binarize_target_for_positive_class(target, positive_class)
 
                     if metric.prediction_type == PredictionType.PROBABILITIES:
-                        perf_value = metric.calculate(target, probabilities)
+                        perf_value = metric.calculate(target_binary, probabilities)
                     else:
                         predictions_binary = (probabilities >= threshold).astype(int)
-                        perf_value = metric.calculate(target, predictions_binary)
+                        perf_value = metric.calculate(target_binary, predictions_binary)
 
                 # Multiclass classification: no positive_class means multiclass context
                 elif metric.supports_ml_type(MLType.MULTICLASS) and positive_class is None:
                     if metric.prediction_type == PredictionType.PROBABILITIES:
-                        prob_columns = _get_probability_columns(pred_df, target_col)
+                        prob_columns = sorted(
+                            col for col in pred_df.columns if isinstance(col, int) and not isinstance(col, bool)
+                        )
+                        target_classes = set(target.unique())
+
+                        if len(prob_columns) < 2:
+                            raise ValueError(
+                                "Expected at least 2 integer-named probability columns "
+                                "for multiclass predictions, found "
+                                f"{len(prob_columns)}. Columns: {list(pred_df.columns)}"
+                            )
+
+                        missing = sorted(target_classes - set(prob_columns))
+                        if missing:
+                            raise ValueError(
+                                "Prediction DataFrame is missing probability columns "
+                                f"for target class labels {missing}. "
+                                f"Target classes: {sorted(target_classes)}, "
+                                f"probability columns: {prob_columns}."
+                            )
+
                         probabilities = pred_df[prob_columns].values
                         perf_value = metric.calculate(target, probabilities)
                     else:

--- a/octopus/modules/tako/core.py
+++ b/octopus/modules/tako/core.py
@@ -189,7 +189,11 @@ class TakoModuleTemplate[T: Tako](ModuleExecution[T]):
         ).get_inner_splits()
 
         if study_context.ml_type in (MLType.BINARY, MLType.MULTICLASS):
-            validate_class_coverage(self.data_splits_, list(study_context.target_assignments.values())[0])
+            target_col = list(study_context.target_assignments.values())[0]
+            expected_classes = (
+                set(data_traindev[target_col].dropna().unique()) if study_context.ml_type == MLType.MULTICLASS else None
+            )
+            validate_class_coverage(self.data_splits_, target_col, expected_classes=expected_classes)
         elif study_context.ml_type == MLType.TIMETOEVENT:
             validate_class_coverage(self.data_splits_, study_context.target_assignments["event"])
 

--- a/octopus/poststudy/analysis/tables.py
+++ b/octopus/poststudy/analysis/tables.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics import auc, confusion_matrix, roc_curve
 
+from octopus.metrics.utils import binarize_target_for_positive_class
 from octopus.poststudy.study_io import StudyInfo, discover_result_types, load_scores, load_selected_features
 from octopus.types import MLType, ResultType
 
@@ -298,9 +299,9 @@ def aucroc_data(predictor: OctoTestEvaluator) -> dict[str, Any]:
     for split_id in predictor.study_info.outersplits:
         split_df = proba_df[proba_df["outersplit"] == split_id]
         probabilities = np.asarray(split_df[positive_class])
-        target = np.asarray(split_df["target"])
+        target_binary = binarize_target_for_positive_class(split_df["target"], positive_class)
 
-        fpr, tpr, _ = roc_curve(target, probabilities, drop_intermediate=True)
+        fpr, tpr, _ = roc_curve(target_binary, probabilities, drop_intermediate=True)
         auc_score = float(auc(fpr, tpr))
         interp_tpr = np.interp(mean_fpr, fpr, tpr)
         interp_tpr[0] = 0.0
@@ -310,8 +311,8 @@ def aucroc_data(predictor: OctoTestEvaluator) -> dict[str, Any]:
 
     # Merged (pooled) ROC
     all_probabilities = np.asarray(proba_df[positive_class])
-    all_targets = np.asarray(proba_df["target"])
-    fpr_merged, tpr_merged, _ = roc_curve(all_targets, all_probabilities, drop_intermediate=True)
+    all_targets_binary = binarize_target_for_positive_class(proba_df["target"], positive_class)
+    fpr_merged, tpr_merged, _ = roc_curve(all_targets_binary, all_probabilities, drop_intermediate=True)
     auc_merged = float(auc(fpr_merged, tpr_merged))
 
     # Averaged ROC
@@ -370,15 +371,22 @@ def confusion_matrix_data(
     summary_rows = {"Mean", "Merged", "Ensemble"}
     per_split_data: dict[int, dict[str, Any]] = {}
 
+    neg_classes = sorted(c for c in predictor.classes_ if c != positive_class)
+    if len(neg_classes) != 1:
+        raise ValueError(
+            f"Binary confusion matrix expected exactly 2 classes including "
+            f"positive_class={positive_class!r}, got classes_={list(predictor.classes_)!r}"
+        )
+    class_names = [str(neg_classes[0]), str(positive_class)]
+
     for outersplit_id in predictor.study_info.outersplits:
         split_df = proba_df[proba_df["outersplit"] == outersplit_id]
         probabilities = np.asarray(split_df[positive_class])
-        target = np.asarray(split_df["target"])
+        target_binary = binarize_target_for_positive_class(split_df["target"], positive_class)
 
         predictions = (probabilities >= threshold).astype(int)
-        cm_abs = confusion_matrix(target, predictions)
-        cm_rel = confusion_matrix(target, predictions, normalize="true")
-        class_names = [str(c) for c in predictor.classes_]
+        cm_abs = confusion_matrix(target_binary, predictions)
+        cm_rel = confusion_matrix(target_binary, predictions, normalize="true")
 
         split_series = all_scores.loc[outersplit_id]
         split_scores = pd.DataFrame({"metric": split_series.index, "score": split_series.values})

--- a/octopus/poststudy/base_predictor.py
+++ b/octopus/poststudy/base_predictor.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from attrs import define, field
 
-from octopus.metrics.utils import get_performance_from_model
+from octopus.metrics.utils import binarize_target_for_positive_class, get_performance_from_model
 from octopus.poststudy.study_io import StudyInfo, load_task_artifacts
 from octopus.types import FIType, MLType, ResultType
 
@@ -291,13 +291,19 @@ class _PredictorBase:
             else:
                 proba = np.asarray(probabilities[list(self.classes_)])
 
+        target_binary: np.ndarray | None = None
+        if ml_type == MLType.BINARY and positive_class is not None:
+            target_binary = binarize_target_for_positive_class(target, positive_class)
+
         for m in metrics:
             metric = Metrics.get_instance(m)
             if metric.prediction_type == PredictionType.PROBABILITIES and proba is not None:
-                scores[m] = metric.calculate(target, proba)
+                scoring_target = target_binary if target_binary is not None else target
+                scores[m] = metric.calculate(scoring_target, proba)
             elif ml_type == MLType.BINARY and positive_class is not None:
                 thresholded = (proba >= threshold).astype(int) if proba is not None else preds
-                scores[m] = metric.calculate(target, thresholded)
+                assert target_binary is not None
+                scores[m] = metric.calculate(target_binary, thresholded)
             elif ml_type == MLType.MULTICLASS and proba is not None:
                 class_labels = list(self.classes_)
                 argmax_indices = np.argmax(proba, axis=1)

--- a/octopus/study/core.py
+++ b/octopus/study/core.py
@@ -30,6 +30,11 @@ logger = get_logger()
 
 _RUNNING_IN_TESTSUITE = "RUNNING_IN_TESTSUITE" in os.environ
 
+_DEFAULT_METRIC_BY_ML_TYPE: dict[MLType, str] = {
+    MLType.BINARY: "AUCROC",
+    MLType.MULTICLASS: "AUCROC_MACRO",
+}
+
 
 @define
 class OctoStudy(ABC):
@@ -87,8 +92,12 @@ class OctoStudy(ABC):
 
     @property
     @abstractmethod
-    def target_metric(self) -> str:
-        """Get target metric. Must be implemented in subclasses."""
+    def target_metric(self) -> str | None:
+        """Get target metric. Must be implemented in subclasses.
+
+        May be None on `OctoClassification` before fit() resolves the default;
+        non-None on all other study types and after fit().
+        """
         ...
 
     @property
@@ -253,7 +262,10 @@ class OctoStudy(ABC):
             splits_to_validate = outer_splits
 
         if ml_type in (MLType.BINARY, MLType.MULTICLASS) and hasattr(self, "target_col"):
-            validate_class_coverage(splits_to_validate, self.target_col)
+            expected_classes = (
+                set(prepared.data[self.target_col].dropna().unique()) if ml_type == MLType.MULTICLASS else None
+            )
+            validate_class_coverage(splits_to_validate, self.target_col, expected_classes=expected_classes)
         elif ml_type == MLType.TIMETOEVENT and hasattr(self, "event_col"):
             validate_class_coverage(splits_to_validate, self.event_col)
 
@@ -308,6 +320,7 @@ class OctoStudy(ABC):
         self, prepared: PreparedData, ml_type: MLType, positive_class: int | None
     ) -> StudyContext:
         """Create a frozen StudyContext from the current study state."""
+        assert self.target_metric is not None, "target_metric must be resolved before context creation"
         return StudyContext(
             ml_type=ml_type,
             target_metric=self.target_metric,
@@ -395,34 +408,53 @@ class OctoClassification(OctoStudy):
     )
     """The type of machine learning model. Can be set explicitly or auto-detected from data (binary vs multiclass)."""
 
-    target_metric: str = field(
-        default="AUCROC",
-        validator=validators.in_(Metrics.get_by_type(MLType.BINARY, MLType.MULTICLASS)),
+    target_metric: str | None = field(
+        default=None,
+        validator=validators.optional(validators.in_(Metrics.get_by_type(MLType.BINARY, MLType.MULTICLASS))),
     )
-    """The primary metric used for model evaluation. Defaults to AUCROC."""
+    """Primary metric for evaluation. When None (default), resolves to AUCROC for binary
+    and AUCROC_MACRO for multiclass at fit() time."""
 
-    positive_class: int | None = field(default=None, validator=validators.optional(validators.instance_of(int)))
-    """The positive class label for binary classification. Defaults to None. Not used for multiclass."""
+    positive_class: int | None = field(
+        default=None,
+        converter=lambda v: int(v) if isinstance(v, bool) else v,
+        validator=validators.optional(validators.instance_of(int)),
+    )
+    """The positive class label for binary classification. Auto-inferred as 1 when target labels are {0, 1}; required for other binary encodings. Not used for multiclass. Bool inputs (True/False) are normalized to int (1/0)."""
 
     def _resolve_ml_config(self, data: pd.DataFrame) -> tuple[MLType, int | None]:
+        """Resolve ml_type, positive_class, and target_metric from data.
+
+        Mutates ``self.target_metric`` when it is None, setting it to the default
+        for the resolved ml_type (AUCROC for binary, AUCROC_MACRO for multiclass).
+        """
         if self.target_col not in data.columns:
             raise ValueError(f"Target column '{self.target_col}' not found in input data.")
         ml_type = self.ml_type
         positive_class = self.positive_class
-        if not ml_type:
+        if ml_type is None:
             unique_values = data[self.target_col].dropna().unique()
-            if len(unique_values) > 2:
-                ml_type, positive_class = MLType.MULTICLASS, None
-            else:
-                ml_type, positive_class = MLType.BINARY, 1
+            ml_type = MLType.MULTICLASS if len(unique_values) > 2 else MLType.BINARY
         if ml_type == MLType.BINARY and positive_class is None:
-            raise ValueError("For binary classification, `positive_class` must be specified.")
+            sorted_unique = sorted(data[self.target_col].dropna().unique())
+            if sorted_unique == [0, 1]:
+                positive_class = 1
+            else:
+                raise ValueError(
+                    f"positive_class must be specified for binary classification "
+                    f"with non-{{0, 1}} labels. Got unique target values {sorted_unique}. "
+                    f"Auto-inference is only supported for labels exactly equal to {{0, 1}}; "
+                    f"pass `positive_class=<label>` explicitly."
+                )
+        if self.target_metric is None:
+            self.target_metric = _DEFAULT_METRIC_BY_ML_TYPE[ml_type]
+        metric = Metrics.get_instance(self.target_metric)
+        if not metric.supports_ml_type(ml_type):
+            raise ValueError(
+                f"target_metric '{self.target_metric}' does not support {ml_type.value}. "
+                f"Compatible metrics: {Metrics.get_by_type(ml_type)}"
+            )
         return ml_type, positive_class
-
-    def _validate_data(self, data: pd.DataFrame, ml_type: MLType, positive_class: int | None) -> None:
-        if self.target_col not in data.columns:
-            raise ValueError(f"Target column '{self.target_col}' not found in input data.")
-        super()._validate_data(data, ml_type, positive_class)
 
     @property
     def target_assignments(self) -> dict[str, str]:

--- a/octopus/study/data_validator.py
+++ b/octopus/study/data_validator.py
@@ -43,8 +43,13 @@ class OctoDataValidator:
     stratification_col: str | None = field(default=None, validator=validators.optional(validators.instance_of(str)))
     """List of columns used for stratification."""
 
-    positive_class: int | None = field(default=None, validator=validators.optional(validators.instance_of(int)))
-    """The positive class label for binary classification. None for non-classification tasks."""
+    positive_class: int | None = field(
+        default=None,
+        converter=lambda v: int(v) if isinstance(v, bool) else v,
+        validator=validators.optional(validators.instance_of(int)),
+    )
+    """The positive class label for binary classification. None for non-classification tasks.
+    Bool inputs are normalized to int."""
 
     def validate(self):
         """Run all validation checks on the OctoData configuration.
@@ -68,7 +73,8 @@ class OctoDataValidator:
             self._validate_feature_target_overlap,
             self._validate_stratification_col,
             self._validate_column_dtypes,
-            self._validate_positive_class,
+            self._validate_target_no_missing,
+            self._validate_classification_target,
         ]
 
         errors = []
@@ -187,6 +193,8 @@ class OctoDataValidator:
         ]
 
         for column in columns_to_check:
+            if column not in self.data.columns:
+                continue
             dtype = self.data[column].dtype
             if not (
                 pd.api.types.is_integer_dtype(dtype)
@@ -246,36 +254,95 @@ class OctoDataValidator:
                 "These column names are used internally by Octopus."
             )
 
-    def _validate_positive_class(self):
-        """Validate positive class for binary classification.
+    def _validate_target_no_missing(self):
+        """Validate target column(s) contain no missing values.
 
-        For classification tasks, validates that:
-        - Target column is integer type
-        - Target has exactly 2 unique values (binary)
-        - positive_class value exists in target column
-
-        Returns:
-            None: Returns early for non-classification ml_types or if positive_class is None.
+        Checks target_col for classification/regression and both duration_col
+        and event_col for time-to-event tasks.
 
         Raises:
-            ValueError: If any validation fails for binary classification.
+            ValueError: If any target column contains NaN/missing values.
         """
-        if self.ml_type != MLType.BINARY:
+        columns_to_check = [
+            col
+            for col in (self.target_col, self.duration_col, self.event_col)
+            if col is not None and col in self.data.columns
+        ]
+        for col in columns_to_check:
+            n_missing = int(self.data[col].isna().sum())
+            if n_missing > 0:
+                raise ValueError(
+                    f"Target column '{col}' contains {n_missing} missing target "
+                    f"value(s). Remove or impute missing target values before fitting."
+                )
+
+    def _validate_classification_target(self):
+        """Validate target column for classification tasks (binary and multiclass).
+
+        Enforces a unified contract:
+        - Target must be integer or boolean dtype (rejects float, object, string-categorical)
+        - For binary: exactly 2 unique values, positive_class set and present
+        - For multiclass: at least 3 unique values
+
+        Returns:
+            None: Returns early for non-classification ml_types.
+
+        Raises:
+            ValueError: If any validation fails.
+        """
+        if self.ml_type not in (MLType.BINARY, MLType.MULTICLASS):
             return
 
-        if self.positive_class is None:
+        if self.target_col is None:
+            raise ValueError(f"target_col must be provided for {self.ml_type.value} classification.")
+
+        if self.target_col not in self.data.columns:
             return
 
         target_data = self.data[self.target_col]
 
-        if not pd.api.types.is_integer_dtype(target_data):
-            raise ValueError(f"Target column must be integer type for binary classification, got {target_data.dtype}")
-
-        unique_values = target_data.dropna().unique()
-        if len(unique_values) != 2:
+        if not (pd.api.types.is_integer_dtype(target_data) or pd.api.types.is_bool_dtype(target_data)):
+            if isinstance(target_data.dtype, pd.CategoricalDtype):
+                raise ValueError(
+                    f"Categorical target columns are not supported for classification. "
+                    f"Convert target to integer labels. Got categories: {list(target_data.cat.categories)}"
+                )
             raise ValueError(
-                f"Binary classification requires exactly 2 unique values, found {len(unique_values)}: {unique_values}"
+                f"Classification target must be integer or boolean dtype, got {target_data.dtype}. "
+                f"Convert target to integer labels."
             )
 
-        if self.positive_class not in unique_values:
-            raise ValueError(f"positive_class {self.positive_class} not found in target. Available: {unique_values}")
+        unique_values = target_data.dropna().unique()
+
+        if len(unique_values) < 2:
+            raise ValueError(
+                f"Target {self.target_col!r} has fewer than 2 unique values "
+                f"after dropping missing data. Found: {list(unique_values)}"
+            )
+
+        if self.ml_type == MLType.BINARY:
+            if len(unique_values) != 2:
+                raise ValueError(
+                    f"Binary classification requires exactly 2 unique target values, "
+                    f"found {len(unique_values)}: {sorted(unique_values)}"
+                )
+            if self.positive_class is None:
+                raise ValueError("positive_class must be specified for binary classification.")
+            if self.positive_class not in unique_values:
+                raise ValueError(
+                    f"positive_class {self.positive_class} not found in target. "
+                    f"Available values: {sorted(unique_values)}"
+                )
+
+        elif self.ml_type == MLType.MULTICLASS:
+            if self.positive_class is not None:
+                raise ValueError(
+                    "positive_class is not used for multiclass classification. "
+                    "Remove positive_class or set ml_type=MLType.BINARY for 2-class problems."
+                )
+            if len(unique_values) < 3:
+                raise ValueError(
+                    f"Multiclass classification requires at least 3 unique target values, "
+                    f"found {len(unique_values)}: {sorted(unique_values)}. "
+                    f"Use ml_type=MLType.BINARY for 2-class problems."
+                )

--- a/tests/metrics/test_utils.py
+++ b/tests/metrics/test_utils.py
@@ -2,15 +2,18 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression, Ridge
 
+from octopus.metrics import Metrics
 from octopus.metrics.utils import (
     get_performance_from_model,
     get_performance_from_predictions,
     get_score_from_model,
     get_score_from_prediction,
 )
+from octopus.types import PredictionType
 
 
 class TestGetPerformanceFromModel:
@@ -111,6 +114,29 @@ class TestGetPerformanceFromPredictions:
         assert "training_0" in performance
         assert "dev" in performance["training_0"]
         assert isinstance(performance["training_0"]["dev"], float)
+
+    def test_binary_raises_when_positive_class_missing_from_columns(self):
+        """positive_class absent from prediction columns raises typed ValueError, not KeyError."""
+        predictions = {
+            "training_0": {
+                "dev": pd.DataFrame(
+                    {
+                        "row": [0, 1, 2],
+                        "prediction": [0, 1, 0],
+                        "target": [0, 1, 0],
+                        0: [0.8, 0.3, 0.9],
+                        1: [0.2, 0.7, 0.1],
+                    }
+                )
+            }
+        }
+        with pytest.raises(ValueError, match=r"positive_class=2 not found in prediction columns"):
+            get_performance_from_predictions(
+                predictions=predictions,
+                target_metric="AUCROC",
+                target_assignments={"default": "target"},
+                positive_class=2,
+            )
 
     def test_multiclass_standard_row_id_col(self):
         """Test multiclass with standard 'row' column."""
@@ -323,3 +349,223 @@ class TestGetScoreFromModel:
 
         assert isinstance(score, float)
         assert score < 0  # minimize: score = -performance
+
+
+class TestMulticlassNonConsecutiveLabels:
+    """Test multiclass with non-consecutive integer class labels."""
+
+    @pytest.mark.parametrize(
+        "labels, metric",
+        [
+            ([1, 3, 5], "ACCBAL_MC"),
+            ([1, 2, 3], "AUCROC_MACRO"),
+        ],
+        ids=["non-consecutive-accbal", "non-zero-based-aucroc"],
+    )
+    def test_model_based(self, labels, metric):
+        """get_performance_from_model handles non-zero-based and non-consecutive labels."""
+        np.random.seed(42)
+        X = pd.DataFrame(np.random.randn(150, 5), columns=[f"f{i}" for i in range(5)])
+        y = np.tile(labels, 150 // len(labels))
+        data = pd.concat([X, pd.DataFrame({"target": y})], axis=1)
+
+        model = RandomForestClassifier(n_estimators=10, random_state=42)
+        model.fit(X, y)
+
+        performance = get_performance_from_model(
+            model=model,
+            data=data,
+            feature_cols=X.columns.tolist(),
+            target_metric=metric,
+            target_assignments={"default": "target"},
+        )
+
+        assert isinstance(performance, float)
+        assert 0 <= performance <= 1
+
+    @pytest.mark.parametrize(
+        "labels, metric",
+        [
+            ([1, 3, 5], "ACCBAL_MC"),
+            ([1, 2, 3], "AUCROC_MACRO"),
+        ],
+        ids=["non-consecutive-accbal", "non-zero-based-aucroc"],
+    )
+    def test_predictions_based(self, labels, metric):
+        """get_performance_from_predictions handles non-zero-based and non-consecutive labels."""
+        c0, c1, c2 = labels
+        predictions = {
+            "training_0": {
+                "dev": pd.DataFrame(
+                    {
+                        "row": [0, 1, 2, 3, 4, 5],
+                        "prediction": [c0, c1, c2, c0, c1, c2],
+                        "target": [c0, c1, c2, c0, c2, c1],
+                        c0: [0.7, 0.1, 0.1, 0.8, 0.1, 0.2],
+                        c1: [0.2, 0.8, 0.1, 0.1, 0.2, 0.6],
+                        c2: [0.1, 0.1, 0.8, 0.1, 0.7, 0.2],
+                    }
+                )
+            }
+        }
+
+        performance = get_performance_from_predictions(
+            predictions=predictions,
+            target_metric=metric,
+            target_assignments={"default": "target"},
+        )
+
+        assert isinstance(performance["training_0"]["dev"], float)
+        assert 0 <= performance["training_0"]["dev"] <= 1
+
+    def test_predictions_missing_probability_columns_raises(self):
+        """Test ValueError when no integer-named probability columns exist."""
+        predictions = {
+            "training_0": {
+                "dev": pd.DataFrame(
+                    {
+                        "row": [0, 1, 2],
+                        "prediction": [1, 2, 3],
+                        "target": [1, 2, 3],
+                        "prob_1": [0.7, 0.1, 0.2],
+                        "prob_2": [0.2, 0.8, 0.1],
+                        "prob_3": [0.1, 0.1, 0.7],
+                    }
+                )
+            }
+        }
+
+        with pytest.raises(ValueError, match="at least 2 integer-named probability columns"):
+            get_performance_from_predictions(
+                predictions=predictions,
+                target_metric="AUCROC_MACRO",
+                target_assignments={"default": "target"},
+            )
+
+    def test_predictions_missing_class_in_prob_columns_raises(self):
+        """Test ValueError when target has a class not in probability columns."""
+        predictions = {
+            "training_0": {
+                "dev": pd.DataFrame(
+                    {
+                        "row": [0, 1, 2],
+                        "prediction": [1, 3, 5],
+                        "target": [1, 3, 5],
+                        1: [0.7, 0.2, 0.1],
+                        3: [0.3, 0.8, 0.2],
+                    }
+                )
+            }
+        }
+
+        with pytest.raises(ValueError, match="missing probability columns"):
+            get_performance_from_predictions(
+                predictions=predictions,
+                target_metric="AUCROC_MACRO",
+                target_assignments={"default": "target"},
+            )
+
+
+class TestBinaryBinarization:
+    """Test binary classification with non-{0,1} labels."""
+
+    @pytest.mark.parametrize(
+        "labels, positive_class, metric",
+        [
+            ([0, 2], 2, "AUCROC"),
+            ([0, 2], 0, "AUCROC"),
+            ([0, 2], 2, "ACCBAL"),
+            ([0, 2], 2, "F1"),
+            ([-1, 1], 1, "AUCROC"),
+            ([-1, 1], 1, "ACCBAL"),
+            ([-1, 1], 1, "F1"),
+        ],
+        ids=[
+            "0_2-pos2-aucroc",
+            "0_2-pos0-aucroc",
+            "0_2-pos2-accbal",
+            "0_2-pos2-f1",
+            "neg1_1-pos1-aucroc",
+            "neg1_1-pos1-accbal",
+            "neg1_1-pos1-f1",
+        ],
+    )
+    def test_model_based(self, labels, positive_class, metric):
+        """get_performance_from_model handles non-{0,1} binary labels."""
+        np.random.seed(42)
+        X = pd.DataFrame(np.random.randn(100, 5), columns=[f"f{i}" for i in range(5)])
+        y = np.tile(labels, 50)
+        data = pd.concat([X, pd.DataFrame({"target": y})], axis=1)
+
+        model = LogisticRegression(random_state=42)
+        model.fit(X, y)
+
+        performance = get_performance_from_model(
+            model=model,
+            data=data,
+            feature_cols=X.columns.tolist(),
+            target_metric=metric,
+            target_assignments={"default": "target"},
+            positive_class=positive_class,
+        )
+
+        pos_idx = list(model.classes_).index(positive_class)
+        proba_pos = model.predict_proba(X)[:, pos_idx]
+        y_binary = (y == positive_class).astype(int)
+        metric_instance = Metrics.get_instance(metric)
+        if metric_instance.prediction_type == PredictionType.PROBABILITIES:
+            baseline = metric_instance.calculate(y_binary, proba_pos)
+        else:
+            preds_binary = (proba_pos >= 0.5).astype(int)
+            baseline = metric_instance.calculate(y_binary, preds_binary)
+        assert performance == pytest.approx(baseline, rel=1e-9)
+
+    @pytest.mark.parametrize(
+        "metric, positive_class, lower_bound, upper_bound",
+        [
+            ("AUCROC", 2, 0.0, 1.0),
+            ("AUCPR", 2, 0.0, 1.0),
+            ("LOGLOSS", 0, 0.0, None),
+            ("LOGLOSS", 2, 0.0, None),
+        ],
+        ids=["aucroc-pos2", "aucpr-pos2", "logloss-pos0", "logloss-pos2"],
+    )
+    def test_predictions_based_binary_labels_0_2(self, metric, positive_class, lower_bound, upper_bound):
+        """get_performance_from_predictions handles binary labels {0, 2} across metrics."""
+        predictions = {
+            "training_0": {
+                "dev": pd.DataFrame(
+                    {
+                        "row": [0, 1, 2, 3, 4],
+                        "prediction": [0, 2, 2, 0, 2],
+                        "target": [0, 2, 2, 0, 0],
+                        0: [0.8, 0.3, 0.2, 0.9, 0.4],
+                        2: [0.2, 0.7, 0.8, 0.1, 0.6],
+                    }
+                )
+            }
+        }
+
+        performance = get_performance_from_predictions(
+            predictions=predictions,
+            target_metric=metric,
+            target_assignments={"default": "target"},
+            positive_class=positive_class,
+        )
+
+        value = performance["training_0"]["dev"]
+        assert isinstance(value, float)
+        assert value > lower_bound
+        if upper_bound is not None:
+            assert value <= upper_bound
+
+        pred_df = predictions["training_0"]["dev"]
+        y_binary = (pred_df["target"] == positive_class).astype(int).to_numpy()
+        proba_pos = pred_df[positive_class].to_numpy()
+        metric_instance = Metrics.get_instance(metric)
+        if metric_instance.prediction_type == PredictionType.PROBABILITIES:
+            baseline = metric_instance.calculate(y_binary, proba_pos)
+        else:
+            preds_binary = (proba_pos >= 0.5).astype(int)
+            baseline = metric_instance.calculate(y_binary, preds_binary)
+        assert value == pytest.approx(baseline, rel=1e-9)

--- a/tests/study/test_core.py
+++ b/tests/study/test_core.py
@@ -117,3 +117,155 @@ def test_ml_type_values():
                 **extra_kwargs,
             )
             assert study.ml_type == expected_ml_type
+
+
+@pytest.mark.parametrize(
+    "target_values, ml_type, positive_class, metric, match",
+    [
+        (np.tile([0, 1, 2], 30), None, None, "AUCROC", "does not support"),
+        (np.tile([0, 1, 2], 30), MLType.MULTICLASS, 1, "ACCBAL_MC", "positive_class is not used for multiclass"),
+        (np.tile([0, 1, 2], 30), None, 1, "ACCBAL_MC", "positive_class is not used for multiclass"),
+        (np.tile([1, 5], 45), None, None, "AUCROC", "non-.0, 1. labels"),
+        (np.tile([-1, 1], 45), None, None, "AUCROC", "non-.0, 1. labels"),
+    ],
+    ids=[
+        "auto-multiclass-binary-metric",
+        "explicit-multiclass-with-positive_class",
+        "auto-multiclass-with-positive_class",
+        "binary-15-no-positive_class",
+        "binary-neg1_1-no-positive_class",
+    ],
+)
+def test_resolve_ml_config_raises(target_values, ml_type, positive_class, metric, match):
+    """_resolve_ml_config rejects incompatible (ml_type, positive_class, metric) combinations."""
+    data = pd.DataFrame(
+        {
+            "sample_id_col": [f"S{i}" for i in range(len(target_values))],
+            "feature1": np.linspace(0, 1, len(target_values)),
+            "target": target_values,
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        kwargs: dict = {
+            "study_name": "test",
+            "target_metric": metric,
+            "feature_cols": ["feature1"],
+            "target_col": "target",
+            "sample_id_col": "sample_id_col",
+            "studies_directory": temp_dir,
+        }
+        if ml_type is not None:
+            kwargs["ml_type"] = ml_type
+        if positive_class is not None:
+            kwargs["positive_class"] = positive_class
+        study = OctoClassification(**kwargs)
+        with pytest.raises(ValueError, match=match):
+            study.fit(data)
+
+
+def test_binary_01_auto_infers_positive_class_1():
+    """Binary classification with {0, 1} labels auto-infers positive_class=1 when omitted."""
+    np.random.seed(42)
+    data = pd.DataFrame(
+        {
+            "sample_id_col": [f"S{i}" for i in range(90)],
+            "feature1": np.random.rand(90),
+            "target": np.tile([0, 1], 45),
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        study = OctoClassification(
+            study_name="test",
+            target_metric="AUCROC",
+            feature_cols=["feature1"],
+            target_col="target",
+            sample_id_col="sample_id_col",
+            studies_directory=temp_dir,
+        )
+        resolved_ml_type, resolved_positive_class = study._resolve_ml_config(data)
+        assert resolved_ml_type == MLType.BINARY
+        assert resolved_positive_class == 1
+
+
+def test_positive_class_bool_normalized_to_int():
+    """OctoClassification(positive_class=True) is normalized to int(1) at construction."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        study = OctoClassification(
+            study_name="test",
+            target_metric="AUCROC",
+            feature_cols=["f1"],
+            target_col="target",
+            sample_id_col="id",
+            studies_directory=temp_dir,
+            positive_class=True,
+        )
+        assert study.positive_class == 1
+        assert not isinstance(study.positive_class, bool)
+
+
+def test_resolve_ml_config_bool_target_auto_infers_positive_class():
+    """Bool target auto-infers positive_class=1 without explicit value."""
+    data = pd.DataFrame(
+        {
+            "sample_id_col": [f"S{i}" for i in range(60)],
+            "feature1": np.random.rand(60),
+            "target": np.tile([True, False], 30),
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        study = OctoClassification(
+            study_name="test",
+            target_metric="AUCROC",
+            feature_cols=["feature1"],
+            target_col="target",
+            sample_id_col="sample_id_col",
+            studies_directory=temp_dir,
+        )
+        resolved_ml_type, resolved_positive_class = study._resolve_ml_config(data)
+        assert resolved_ml_type == MLType.BINARY
+        assert resolved_positive_class == 1
+
+
+def test_default_target_metric_auto_promotes_to_aucroc_macro_for_multiclass():
+    """target_metric=None auto-promotes to AUCROC_MACRO when multiclass is detected."""
+    data = pd.DataFrame(
+        {
+            "sample_id_col": [f"S{i}" for i in range(90)],
+            "feature1": np.random.rand(90),
+            "target": np.tile([0, 1, 2], 30),
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        study = OctoClassification(
+            study_name="test",
+            feature_cols=["feature1"],
+            target_col="target",
+            sample_id_col="sample_id_col",
+            studies_directory=temp_dir,
+        )
+        assert study.target_metric is None
+        ml_type, _ = study._resolve_ml_config(data)
+        assert ml_type == MLType.MULTICLASS
+        assert study.target_metric == "AUCROC_MACRO"
+
+
+def test_default_target_metric_auto_promotes_to_aucroc_for_binary():
+    """target_metric=None auto-resolves to AUCROC when binary is detected."""
+    data = pd.DataFrame(
+        {
+            "sample_id_col": [f"S{i}" for i in range(60)],
+            "feature1": np.random.rand(60),
+            "target": np.tile([0, 1], 30),
+        }
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        study = OctoClassification(
+            study_name="test",
+            feature_cols=["feature1"],
+            target_col="target",
+            sample_id_col="sample_id_col",
+            studies_directory=temp_dir,
+        )
+        ml_type, _ = study._resolve_ml_config(data)
+        assert ml_type == MLType.BINARY
+        assert study.target_metric == "AUCROC"

--- a/tests/study/test_validator.py
+++ b/tests/study/test_validator.py
@@ -211,3 +211,241 @@ def test_validate_error_accumulation(validator_factory, sample_data):
     assert "Multiple validation errors found" in error_message
     assert "Reserved column names found in data" in error_message
     assert "Stratification column cannot be the same as sample_id_col" in error_message
+
+
+class TestClassificationTargetValidation:
+    """Test _validate_classification_target for binary and multiclass."""
+
+    @pytest.mark.parametrize(
+        "target_values, ml_type, positive_class",
+        [
+            (np.tile([0, 1], 25), MLType.BINARY, 1),
+            (np.tile([True, False], 25), MLType.BINARY, 1),
+            (np.tile([True, False], 25), MLType.BINARY, True),
+            (np.tile([1, 3, 5], 20), MLType.MULTICLASS, None),
+            (pd.array(np.tile([0, 1], 25), dtype=pd.Int64Dtype()), MLType.BINARY, 1),
+        ],
+        ids=["int-binary", "bool-binary", "bool-binary-bool-pos", "non-consec-multiclass", "nullable-int-binary"],
+    )
+    def test_accepts_valid_target(self, validator_factory, target_values, ml_type, positive_class):
+        """Valid integer/bool targets are accepted for classification."""
+        n = len(target_values)
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(n)],
+                "feature1": np.linspace(0, 1, n),
+                "target": target_values,
+            }
+        )
+        validator = validator_factory(
+            data=data, feature_cols=["feature1"], ml_type=ml_type, positive_class=positive_class
+        )
+        validator._validate_classification_target()
+
+    @pytest.mark.parametrize(
+        "target_values, ml_type, match",
+        [
+            (np.tile([0.0, 1.0], 25), MLType.BINARY, "integer or boolean dtype"),
+            (np.tile([0.0, 1.0, 2.0], 20), MLType.MULTICLASS, "integer or boolean dtype"),
+            (np.tile(["cat", "dog", "fish"], 20), MLType.MULTICLASS, "integer or boolean dtype"),
+            (pd.Categorical(np.tile(["cat", "dog", "fish"], 20)), MLType.MULTICLASS, "Categorical target"),
+        ],
+        ids=["float-binary", "float-multiclass", "object-multiclass", "categorical-multiclass"],
+    )
+    def test_rejects_invalid_target_dtype(self, validator_factory, target_values, ml_type, match):
+        """Invalid target dtypes are rejected with clear error messages."""
+        n = len(target_values)
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(n)],
+                "feature1": np.linspace(0, 1, n),
+                "target": target_values,
+            }
+        )
+        positive_class = 1 if ml_type == MLType.BINARY else None
+        validator = validator_factory(
+            data=data, feature_cols=["feature1"], ml_type=ml_type, positive_class=positive_class
+        )
+        with pytest.raises(ValueError, match=match):
+            validator._validate_classification_target()
+
+    @pytest.mark.parametrize("ml_type", [MLType.BINARY, MLType.MULTICLASS])
+    def test_rejects_target_with_fewer_than_2_unique_values(self, validator_factory, ml_type):
+        """Target with only 1 unique value is rejected with a clear message."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+                "target": [1] * 50,
+            }
+        )
+        positive_class = 1 if ml_type == MLType.BINARY else None
+        validator = validator_factory(
+            data=data, feature_cols=["feature1"], ml_type=ml_type, positive_class=positive_class
+        )
+        with pytest.raises(ValueError, match="fewer than 2 unique values"):
+            validator._validate_classification_target()
+
+    def test_rejects_multiclass_fewer_than_3_unique(self, validator_factory):
+        """Multiclass with only 2 unique values is rejected."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+                "target": np.tile([0, 1], 25),
+            }
+        )
+        validator = validator_factory(
+            data=data, feature_cols=["feature1"], ml_type=MLType.MULTICLASS, positive_class=None
+        )
+        with pytest.raises(ValueError, match="at least 3 unique target values"):
+            validator._validate_classification_target()
+
+    def test_accepts_boolean_positive_class(self, validator_factory):
+        """Boolean positive_class is normalized to int and accepted."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+                "target": np.tile([0, 1], 25),
+            }
+        )
+        validator = validator_factory(data=data, feature_cols=["feature1"], ml_type=MLType.BINARY, positive_class=True)
+        assert validator.positive_class == 1
+        assert not isinstance(validator.positive_class, bool)
+        validator._validate_classification_target()
+
+    def test_raises_when_target_col_none_for_classification(self):
+        """target_col=None with classification ml_type raises ValueError."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+            }
+        )
+        validator = OctoDataValidator(
+            data=data,
+            feature_cols=["feature1"],
+            target_col=None,
+            sample_id_col="sample_id_col",
+            ml_type=MLType.BINARY,
+            positive_class=1,
+        )
+        with pytest.raises(ValueError, match="target_col must be provided"):
+            validator._validate_classification_target()
+
+    def test_skips_when_target_col_missing_from_data(self, validator_factory):
+        """target_col not in DataFrame columns: skip (already reported by _validate_columns_exist)."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+            }
+        )
+        validator = OctoDataValidator(
+            data=data,
+            feature_cols=["feature1"],
+            target_col="missing_col",
+            sample_id_col="sample_id_col",
+            ml_type=MLType.BINARY,
+            positive_class=1,
+        )
+        validator._validate_classification_target()
+
+    def test_validate_aggregates_missing_target_col_as_valueerror(self):
+        """validate() with missing target_col returns aggregated ValueError, not KeyError."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+            }
+        )
+        validator = OctoDataValidator(
+            data=data,
+            feature_cols=["feature1"],
+            target_col="missing_col",
+            sample_id_col="sample_id_col",
+            ml_type=MLType.BINARY,
+            positive_class=1,
+        )
+        with pytest.raises(ValueError, match="Columns not found"):
+            validator.validate()
+
+
+class TestTargetNoMissingValidation:
+    """Test _validate_target_no_missing across task types."""
+
+    @pytest.mark.parametrize(
+        "ml_type, target_col, extra_cols",
+        [
+            (MLType.BINARY, "target", {}),
+            (MLType.MULTICLASS, "target", {}),
+            (MLType.REGRESSION, "target", {}),
+        ],
+        ids=["binary", "multiclass", "regression"],
+    )
+    def test_rejects_nan_in_target(self, validator_factory, ml_type, target_col, extra_cols):
+        """NaN values in target column are rejected for non-T2E task types."""
+        target = pd.array(np.tile([0, 1, 2], 17)[:50], dtype=pd.Int64Dtype())
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+                target_col: target,
+            }
+        )
+        data.loc[5, target_col] = pd.NA
+        validator = validator_factory(
+            data=data,
+            feature_cols=["feature1"],
+            target_col=target_col,
+            ml_type=ml_type,
+            positive_class=1 if ml_type == MLType.BINARY else None,
+        )
+        with pytest.raises(ValueError, match="missing target value"):
+            validator._validate_target_no_missing()
+
+    def test_rejects_nan_in_t2e_duration(self, validator_factory):
+        """NaN in duration_col is rejected for time-to-event."""
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+                "duration": np.random.rand(50),
+                "event": np.tile([0, 1], 25),
+            }
+        )
+        data.loc[3, "duration"] = np.nan
+        validator = OctoDataValidator(
+            data=data,
+            feature_cols=["feature1"],
+            ml_type=MLType.TIMETOEVENT,
+            duration_col="duration",
+            event_col="event",
+            sample_id_col="sample_id_col",
+        )
+        with pytest.raises(ValueError, match="missing target value"):
+            validator._validate_target_no_missing()
+
+    def test_rejects_nan_in_t2e_event(self, validator_factory):
+        """NaN in event_col is rejected for time-to-event."""
+        event = pd.array(np.tile([0, 1], 25), dtype=pd.Int64Dtype())
+        data = pd.DataFrame(
+            {
+                "sample_id_col": [f"S{i}" for i in range(50)],
+                "feature1": np.random.rand(50),
+                "duration": np.random.rand(50),
+                "event": event,
+            }
+        )
+        data.loc[3, "event"] = pd.NA
+        validator = OctoDataValidator(
+            data=data,
+            feature_cols=["feature1"],
+            ml_type=MLType.TIMETOEVENT,
+            duration_col="duration",
+            event_col="event",
+            sample_id_col="sample_id_col",
+        )
+        with pytest.raises(ValueError, match="missing target value"):
+            validator._validate_target_no_missing()

--- a/tests/test_datasplit.py
+++ b/tests/test_datasplit.py
@@ -488,3 +488,40 @@ def test_validate_class_coverage_passes_when_all_classes_present():
     }
 
     validate_class_coverage(splits, "target")
+
+
+def test_validate_class_coverage_with_expected_classes_missing_raises():
+    """Multiclass split missing a class raises when expected_classes is passed."""
+    splits: OuterSplits = {
+        0: OuterSplit(
+            traindev=pd.DataFrame({"target": [0, 1, 2, 0, 1, 2], DATASPLIT_COL: [0, 0, 0, 1, 1, 1]}),
+            test=pd.DataFrame({"target": [0, 1, 0, 1], DATASPLIT_COL: [2, 2, 3, 3]}),
+        ),
+    }
+
+    with pytest.raises(SingleClassSplitError, match="missing classes"):
+        validate_class_coverage(splits, "target", expected_classes={0, 1, 2})
+
+
+def test_validate_class_coverage_with_expected_classes_all_present_passes():
+    """Multiclass split with all expected classes passes."""
+    splits: OuterSplits = {
+        0: OuterSplit(
+            traindev=pd.DataFrame({"target": [0, 1, 2, 0, 1, 2], DATASPLIT_COL: [0, 0, 0, 1, 1, 1]}),
+            test=pd.DataFrame({"target": [0, 1, 2], DATASPLIT_COL: [2, 2, 2]}),
+        ),
+    }
+
+    validate_class_coverage(splits, "target", expected_classes={0, 1, 2})
+
+
+def test_validate_class_coverage_without_expected_classes_allows_subset():
+    """Without expected_classes, a partition with 2 of 3 classes passes (existing behavior)."""
+    splits: OuterSplits = {
+        0: OuterSplit(
+            traindev=pd.DataFrame({"target": [0, 1, 2, 0, 1, 2], DATASPLIT_COL: [0, 0, 0, 1, 1, 1]}),
+            test=pd.DataFrame({"target": [0, 1, 0, 1], DATASPLIT_COL: [2, 2, 3, 3]}),
+        ),
+    }
+
+    validate_class_coverage(splits, "target")


### PR DESCRIPTION
## Summary

Fixes data-input requirements and metric computation for binary and multiclass classification (GitHub issue #437). Incorporates PR review feedback (parametrized tests, generalized NaN validation, restricted `positive_class` auto-inference, cleanup of redundant code paths).

### Behavioral fixes

- **Multiclass non-consecutive integer labels** (e.g. `[1, 3, 5]`, `[1, 2, 3]`) now work correctly in metric computation.
- **Binary non-`{0, 1}` labels** (e.g. `{-1, 1}`, `{0, 2}`) now work correctly. `y_true` is binarized against `positive_class` before being passed to sklearn metrics, fixing:
  - AUCROC inversion when `positive_class=0`
  - AUCPR raising for label sets that do not contain `1`
  - LOGLOSS inversion
- **Poststudy ROC/confusion matrix** binarizes target for non-`{0, 1}` binary labels before `roc_curve` / `confusion_matrix`.
- **Multiclass split coverage:** outer splits are now required to contain every class present in the full training set, preventing numpy shape mismatches in bag averaging caused by models with different `classes_`.

### `positive_class` semantics

- **Auto-inferred as `1`** when sorted unique target labels are exactly `[0, 1]`.
- **Required explicitly** for any other binary encoding. The error message lists the observed unique values and tells the caller to pass `positive_class=<label>`.
- **Rejected for multiclass:** passing `positive_class` together with multiclass `ml_type` (explicit or auto-detected) now raises, rather than being silently zeroed.
- **Boolean `positive_class` rejected** with an error explaining why: pandas integer-keyed APIs (e.g. `predict_proba` columns indexed by class label) do not treat `True`/`False` as `1`/`0`, which causes `KeyError` during scoring.

### Validation cleanup

- **Unified classification target validation:** rejects float, object, and string-categorical targets with clear error messages. Accepts integer and boolean dtypes. Validates unique-class-count constraints.
- **Generalized NaN target check** moved out of the classification-specific path into a `_validate_target_no_missing` validator that runs for binary, multiclass, regression, and time-to-event (covering both `duration_col` and `event_col`).
- **`target_col=None` in classification** now raises `ValueError` instead of silently producing a downstream `KeyError`.
- **`target_metric` compatibility** with resolved `ml_type` is now checked inside `_resolve_ml_config` (single source of truth), preventing confusing downstream errors when e.g. AUCROC is used with auto-detected multiclass data.
- Removed redundant `OctoClassification._validate_data` override now that the metric check lives in `_resolve_ml_config`.
- Reverted unused `**kwargs` parameter on `Metric.calculate`.

### Tests

- New parametrized tests for `_resolve_ml_config` covering: auto-multiclass + binary-only metric, explicit/auto multiclass with stray `positive_class`, non-`{0, 1}` binary without `positive_class`, and the canonical `{0, 1}` auto-inference happy path.
- Parametrized validator tests covering accepted/rejected target dtypes, NaN in target across all task types (binary, multiclass, regression, T2E-duration, T2E-event), `target_col=None`, and boolean `positive_class`.
- Parametrized metric tests covering multiclass non-consecutive labels and binary non-`{0, 1}` labels across AUCROC, AUCPR, LOGLOSS, ACCBAL, F1.

### Docs

- `docs/userguide/classification.md` updated to describe the narrowed `positive_class` auto-inference rule and required explicit value for non-`{0, 1}` encodings.