### PR TITLE
Fix threadpool assertion in parallelization test

### DIFF
--- a/tests/infrastructure/test_parallelization.py
+++ b/tests/infrastructure/test_parallelization.py
@@ -43,7 +43,7 @@ def test_inner_parallelization_setup_in_workers(tmp_path, outer_splits):
         assert len(threadpool_info) >= 2
 
         for lib in threadpool_info:
-            assert lib["num_threads"] == 1
+            assert lib["num_threads"] == n_cpus_per_worker
 
     ray_parallel.run_parallel_outer(
         outer_split_data=outer_splits,


### PR DESCRIPTION
## Problem

`test_inner_parallelization_setup_in_workers` fails on machines with many CPUs (e.g. 36-CPU EC2 instances) but passes in CI (4-CPU GitHub Actions runners).

The test asserted `lib["num_threads"] == 1` for all detected threadpool libraries inside the Ray outer worker. This only passed by coincidence on CI where `cpus_per_worker = 4 CPUs // 4 outer_splits = 1`.

On a 36-CPU machine: `cpus_per_worker = 36 // 4 = 9`, and since the production code correctly applies `threadpool_limits(limits=cpus_per_worker)`, the libraries report 9 threads — causing the assertion to fail.

## Fix

Replace the hardcoded `== 1` assertion with `== n_cpus_per_worker`, which matches:
- The `threadpool_limits(limits=n_cpus_per_worker)` context in `ray_parallel.py`
- The env var assertions earlier in the same test (which already check for `cpus_per_worker`)

## Verification

- Passes on 36-CPU EC2 instance (previously failing)
- Also verified correct for the 4-CPU CI case (where `cpus_per_worker=1`)

Fixes #438